### PR TITLE
fix: process tracking, path handling, and exception safety

### DIFF
--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -98,7 +98,10 @@ def monitor_loop(
     try:
         while True:
             report = check_health()
-            activity = check_agent_activity(deadline_seconds=config.activity_deadline)
+            activity = check_agent_activity(
+                project_dir=config.project_dir,
+                deadline_seconds=config.activity_deadline,
+            )
             report.activity = activity
 
             # If not compliant, notify the overseer

--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -52,11 +52,15 @@ def status() -> None:
 
     try:
         config = load_config()
-        activity = check_agent_activity(deadline_seconds=config.activity_deadline)
+        activity = check_agent_activity(
+            project_dir=config.project_dir,
+            deadline_seconds=config.activity_deadline,
+        )
         report.activity = activity
         pool = KeyPool(config.gastown_kimi_keys)
         report.key_pool = pool.status()
-    except (ValueError, Exception):
+    except ValueError:
+        # Config not loaded, skip optional fields
         pass
 
     table = Table(title="Gasclaw Status")

--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -18,6 +18,7 @@ class GasclawConfig:
 
     # Optional with defaults
     gt_rig_url: str = "/project"
+    project_dir: str = "/project"  # Directory for git activity checks
     gt_agent_count: int = 6
     monitor_interval: int = 300  # seconds between health checks
     activity_deadline: int = 3600  # seconds — must see a push/PR within this window
@@ -49,6 +50,7 @@ def load_config() -> GasclawConfig:
         telegram_bot_token=_require_env("TELEGRAM_BOT_TOKEN"),
         telegram_owner_id=_require_env("TELEGRAM_OWNER_ID"),
         gt_rig_url=os.environ.get("GT_RIG_URL", "/project").strip() or "/project",
+        project_dir=os.environ.get("PROJECT_DIR", "/project").strip() or "/project",
         gt_agent_count=int(os.environ.get("GT_AGENT_COUNT", "6")),
         monitor_interval=int(os.environ.get("MONITOR_INTERVAL", "300")),
         activity_deadline=int(os.environ.get("ACTIVITY_DEADLINE", "3600")),

--- a/src/gasclaw/gastown/lifecycle.py
+++ b/src/gasclaw/gastown/lifecycle.py
@@ -18,8 +18,12 @@ def start_dolt(
         data_dir: Directory for Dolt data files.
         port: SQL server port.
         timeout: Max seconds to wait for readiness.
+
+    Raises:
+        RuntimeError: If the dolt process exits early.
+        TimeoutError: If dolt is not ready within the timeout.
     """
-    subprocess.Popen(
+    proc = subprocess.Popen(
         ["dolt", "sql-server", "--port", str(port), "--data-dir", data_dir],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -28,6 +32,10 @@ def start_dolt(
     # Wait for port to be ready
     deadline = time.time() + timeout
     while time.time() < deadline:
+        # Check if process died early
+        if proc.poll() is not None:
+            raise RuntimeError(f"Dolt process exited early with code {proc.returncode}")
+
         result = subprocess.run(
             ["dolt", "sql", "--port", str(port), "-q", "SELECT 1"],
             capture_output=True,

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -86,13 +86,18 @@ def check_health(*, gateway_port: int = 18789) -> HealthReport:
     )
 
 
-def check_agent_activity(*, deadline_seconds: int = 3600) -> dict[str, Any]:
+def check_agent_activity(
+    *,
+    project_dir: str = "/project",
+    deadline_seconds: int = 3600,
+) -> dict[str, Any]:
     """Check if there has been recent git activity (push/PR/commit).
 
     The overseer (OpenClaw) uses this to enforce the activity benchmark:
     code must be pushed or a PR merged within the deadline window.
 
     Args:
+        project_dir: Directory containing the git repository.
         deadline_seconds: Max allowed time since last activity.
 
     Returns:
@@ -100,10 +105,10 @@ def check_agent_activity(*, deadline_seconds: int = 3600) -> dict[str, Any]:
     """
     try:
         result = subprocess.run(
-            ["git", "log", "--oneline", "-1", "--format=%ct", "/project"],
+            ["git", "log", "-1", "--format=%ct"],
             capture_output=True,
             timeout=10,
-            cwd="/project",
+            cwd=project_dir,
         )
         if result.returncode == 0 and result.stdout.strip():
             last_ts = int(result.stdout.decode().strip())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -77,6 +77,7 @@ class TestLoadConfig:
             monkeypatch.setenv(k, v)
         cfg = load_config()
         assert cfg.gt_rig_url == "/project"
+        assert cfg.project_dir == "/project"
         assert cfg.gt_agent_count == 6
         assert cfg.monitor_interval == 300
         assert cfg.activity_deadline == 3600
@@ -85,6 +86,7 @@ class TestLoadConfig:
         """Optional fields can be overridden."""
         for k, v in env_vars(
             GT_RIG_URL="git@github.com:org/repo.git",
+            PROJECT_DIR="/workspace/repo",
             GT_AGENT_COUNT="8",
             MONITOR_INTERVAL="120",
             ACTIVITY_DEADLINE="1800",
@@ -92,6 +94,7 @@ class TestLoadConfig:
             monkeypatch.setenv(k, v)
         cfg = load_config()
         assert cfg.gt_rig_url == "git@github.com:org/repo.git"
+        assert cfg.project_dir == "/workspace/repo"
         assert cfg.gt_agent_count == 8
         assert cfg.monitor_interval == 120
         assert cfg.activity_deadline == 1800

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -10,9 +10,15 @@ from gasclaw.gastown.lifecycle import start_dolt, start_daemon, start_mayor, sto
 class TestStartDolt:
     def test_runs_dolt_sql_server(self, monkeypatch):
         calls = []
+
+        class MockProc:
+            pid = 1
+            def poll(self):
+                return None  # Still running
+
         monkeypatch.setattr(
             subprocess, "Popen",
-            lambda *a, **kw: (calls.append((a, kw)), type("P", (), {"pid": 1, "poll": lambda s: None}))[-1],
+            lambda *a, **kw: (calls.append((a, kw)), MockProc())[-1],
         )
         monkeypatch.setattr(
             subprocess, "run",
@@ -20,6 +26,22 @@ class TestStartDolt:
         )
         start_dolt(data_dir="/tmp/dolt-data", port=3307, timeout=1)
         assert any("dolt" in str(c) for c in calls)
+
+    def test_raises_if_process_exits_early(self, monkeypatch):
+        """If dolt process dies immediately, we should get RuntimeError not TimeoutError."""
+        class DeadProcess:
+            pid = 1
+            returncode = 1
+            def poll(self):
+                return self.returncode  # Process already exited
+
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: DeadProcess())
+        try:
+            start_dolt(data_dir="/tmp/dolt-data", port=3307, timeout=1)
+            assert False, "Expected RuntimeError"
+        except RuntimeError as e:
+            assert "exited early" in str(e)
+            assert "1" in str(e)
 
 
 class TestStartDaemon:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -60,10 +60,10 @@ class TestCheckAgentActivity:
         monkeypatch.setattr(
             subprocess, "run",
             lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout=b"abc1234 2h ago commit msg\n"
+                a[0], 0, stdout=b"1234567890\n"
             ),
         )
-        activity = check_agent_activity(deadline_seconds=3600)
+        activity = check_agent_activity(project_dir="/tmp/test", deadline_seconds=3600)
         assert "last_commit_age" in activity
         assert "compliant" in activity
 
@@ -73,8 +73,17 @@ class TestCheckAgentActivity:
             subprocess, "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b""),
         )
-        activity = check_agent_activity(deadline_seconds=3600)
+        activity = check_agent_activity(project_dir="/tmp/test", deadline_seconds=3600)
         assert activity["compliant"] is False
+
+    def test_uses_project_dir(self, monkeypatch):
+        calls = []
+        def _capture(cmd, **kw):
+            calls.append(kw.get("cwd"))
+            return subprocess.CompletedProcess(cmd, 0, stdout=b"1234567890\n")
+        monkeypatch.setattr(subprocess, "run", _capture)
+        check_agent_activity(project_dir="/custom/path", deadline_seconds=3600)
+        assert calls == ["/custom/path"]
 
 
 class TestHealthReportSummary:


### PR DESCRIPTION
## Summary

This PR fixes three bugs found during codebase audit:

1. **lifecycle.py**: `start_dolt()` now detects if the dolt process exits early (e.g., port in use) instead of waiting the full timeout period. Previously, a failed start would result in a 30-second wait before the TimeoutError was raised.

2. **health.py**: `check_agent_activity()` now accepts a configurable `project_dir` parameter instead of hardcoding `/project` in both the git command and cwd. This makes the function reusable and testable.

3. **cli.py**: Narrowed exception handling in `status()` from broad `(ValueError, Exception)` to just `ValueError`. The broad exception handler was masking unexpected errors.

## Changes

- `src/gasclaw/gastown/lifecycle.py`: Store Popen result, poll for early exit
- `src/gasclaw/health.py`: Add `project_dir` parameter, simplify git command
- `src/gasclaw/config.py`: Add `PROJECT_DIR` env var configuration
- `src/gasclaw/bootstrap.py`: Pass `project_dir` to `check_agent_activity()`
- `src/gasclaw/cli.py`: Narrow exception handling, pass `project_dir`
- Tests updated for all changes

## Test Plan

- [x] `make test` passes (75 tests)
- [x] New test for early process exit detection
- [x] New test for configurable project_dir
- [x] New test for project_dir being passed to git command

🤖 Generated with [Claude Code](https://claude.com/claude-code)