### PR TITLE
fix: add project_dir config and pass to monitor_loop

### DIFF
--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -104,7 +104,10 @@ def monitor_loop(
     try:
         while True:
             report = check_health()
-            activity = check_agent_activity(deadline_seconds=config.activity_deadline)
+            activity = check_agent_activity(
+                project_dir=config.project_dir,
+                deadline_seconds=config.activity_deadline,
+            )
             report.activity = activity
 
             # If not compliant, notify the overseer

--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -18,6 +18,7 @@ class GasclawConfig:
 
     # Optional with defaults
     gt_rig_url: str = "/project"
+    project_dir: str = "/project"  # Directory for git activity checks
     gt_agent_count: int = 6
     monitor_interval: int = 300  # seconds between health checks
     activity_deadline: int = 3600  # seconds — must see a push/PR within this window
@@ -49,6 +50,7 @@ def load_config() -> GasclawConfig:
         telegram_bot_token=_require_env("TELEGRAM_BOT_TOKEN"),
         telegram_owner_id=_require_env("TELEGRAM_OWNER_ID"),
         gt_rig_url=os.environ.get("GT_RIG_URL", "/project").strip() or "/project",
+        project_dir=os.environ.get("PROJECT_DIR", "/project").strip() or "/project",
         gt_agent_count=int(os.environ.get("GT_AGENT_COUNT", "6")),
         monitor_interval=int(os.environ.get("MONITOR_INTERVAL", "300")),
         activity_deadline=int(os.environ.get("ACTIVITY_DEADLINE", "3600")),

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -120,3 +120,32 @@ class TestMonitorLoop:
             monitor_loop(config, interval=1)
 
         assert check_count >= 1
+
+    def test_passes_project_dir_to_activity_check(self, config, monkeypatch):
+        """monitor_loop should pass config.project_dir to check_agent_activity."""
+        config.project_dir = "/custom/project"
+        call_count = 0
+
+        def mock_check_health(**kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise KeyboardInterrupt
+            from gasclaw.health import HealthReport
+            return HealthReport(
+                dolt="healthy", daemon="healthy", mayor="healthy",
+                openclaw="healthy", agents=["mayor"],
+                activity={"compliant": True, "last_commit_age": 100},
+            )
+
+        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check_health), \
+             patch("gasclaw.bootstrap.check_agent_activity") as m_activity, \
+             patch("gasclaw.bootstrap.notify_telegram"), \
+             patch("time.sleep"):
+            m_activity.return_value = {"compliant": True, "last_commit_age": 100}
+            monitor_loop(config, interval=1)
+
+        m_activity.assert_called_with(
+            project_dir="/custom/project",
+            deadline_seconds=config.activity_deadline,
+        )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -77,6 +77,7 @@ class TestLoadConfig:
             monkeypatch.setenv(k, v)
         cfg = load_config()
         assert cfg.gt_rig_url == "/project"
+        assert cfg.project_dir == "/project"
         assert cfg.gt_agent_count == 6
         assert cfg.monitor_interval == 300
         assert cfg.activity_deadline == 3600
@@ -85,6 +86,7 @@ class TestLoadConfig:
         """Optional fields can be overridden."""
         for k, v in env_vars(
             GT_RIG_URL="git@github.com:org/repo.git",
+            PROJECT_DIR="/workspace/repo",
             GT_AGENT_COUNT="8",
             MONITOR_INTERVAL="120",
             ACTIVITY_DEADLINE="1800",
@@ -92,6 +94,7 @@ class TestLoadConfig:
             monkeypatch.setenv(k, v)
         cfg = load_config()
         assert cfg.gt_rig_url == "git@github.com:org/repo.git"
+        assert cfg.project_dir == "/workspace/repo"
         assert cfg.gt_agent_count == 8
         assert cfg.monitor_interval == 120
         assert cfg.activity_deadline == 1800


### PR DESCRIPTION
## Summary

Adds the missing `project_dir` configuration option that `check_agent_activity` expects, and passes it from `monitor_loop`.

## Changes

- `config.py`: Add `project_dir` field to `GasclawConfig` with env var `PROJECT_DIR`
- `bootstrap.py`: Pass `config.project_dir` to `check_agent_activity()`
- Tests for default value, custom value, and passing to activity check

## Test Plan

- [x] `python -m pytest tests/unit` passes (82 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)