### PR TITLE
fix: resolve all ruff lint issues

### DIFF
--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -25,8 +25,8 @@ from pathlib import Path
 from gasclaw.config import GasclawConfig
 from gasclaw.gastown.agent_config import write_agent_config
 from gasclaw.gastown.installer import gastown_install, setup_kimi_accounts
-from gasclaw.gastown.lifecycle import start_dolt, start_daemon, start_mayor
-from gasclaw.health import check_health, check_agent_activity
+from gasclaw.gastown.lifecycle import start_daemon, start_dolt, start_mayor
+from gasclaw.health import check_agent_activity, check_health
 from gasclaw.openclaw.doctor import run_doctor
 from gasclaw.openclaw.installer import write_openclaw_config
 from gasclaw.openclaw.skill_manager import install_skills

--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from gasclaw.bootstrap import bootstrap, monitor_loop
 from gasclaw.config import load_config
 from gasclaw.gastown.lifecycle import stop_all
-from gasclaw.health import check_health, check_agent_activity
+from gasclaw.health import check_agent_activity, check_health
 from gasclaw.kimigas.key_pool import KeyPool
 from gasclaw.updater.applier import apply_updates
 from gasclaw.updater.checker import check_versions
@@ -74,14 +74,14 @@ def status() -> None:
 
     table.add_row("agents", str(len(report.agents)))
     if report.key_pool:
-        table.add_row(
-            "key pool",
-            f"{report.key_pool.get('available', '?')}/{report.key_pool.get('total', '?')} available",
-        )
+        avail = report.key_pool.get("available", "?")
+        total = report.key_pool.get("total", "?")
+        table.add_row("key pool", f"{avail}/{total} available")
     if report.activity:
         compliant = report.activity.get("compliant", False)
         style = "green" if compliant else "red"
-        table.add_row("activity", f"[{style}]{'compliant' if compliant else 'NOT COMPLIANT'}[/{style}]")
+        status = "compliant" if compliant else "NOT COMPLIANT"
+        table.add_row("activity", f"[{style}]{status}[/{style}]")
 
     console.print(table)
 

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -29,6 +29,8 @@ class HealthReport:
 
     def summary(self) -> str:
         """Human-readable summary string."""
+        avail = self.key_pool.get("available", "?")
+        total = self.key_pool.get("total", "?")
         lines = [
             f"Dolt: {self.dolt}",
             f"Daemon: {self.daemon}",
@@ -36,12 +38,13 @@ class HealthReport:
             f"OpenClaw: {self.openclaw}",
             f"OpenClaw Doctor: {self.openclaw_doctor}",
             f"Agents: {len(self.agents)} active ({', '.join(self.agents[:5])})",
-            f"Keys: {self.key_pool.get('available', '?')}/{self.key_pool.get('total', '?')} available",
+            f"Keys: {avail}/{total} available",
         ]
         if self.activity:
             compliant = self.activity.get("compliant", False)
             age = self.activity.get("last_commit_age", "?")
-            lines.append(f"Activity: {'compliant' if compliant else 'NOT COMPLIANT'} (last commit {age}s ago)")
+            status = "compliant" if compliant else "NOT COMPLIANT"
+            lines.append(f"Activity: {status} (last commit {age}s ago)")
         return "\n".join(lines)
 
 

--- a/src/gasclaw/openclaw/skill_manager.py
+++ b/src/gasclaw/openclaw/skill_manager.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import stat
 from pathlib import Path

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import patch
 
 import pytest
 
@@ -69,16 +69,19 @@ class TestBootstrap:
             order.append("doctor")
             return mock_doctor
 
-        with patch("gasclaw.bootstrap.setup_kimi_accounts", side_effect=lambda *a, **kw: order.append("kimi")), \
-             patch("gasclaw.bootstrap.write_agent_config", side_effect=lambda *a, **kw: order.append("agent_config")), \
-             patch("gasclaw.bootstrap.gastown_install", side_effect=lambda *a, **kw: order.append("install")), \
-             patch("gasclaw.bootstrap.start_dolt", side_effect=lambda *a, **kw: order.append("dolt")), \
-             patch("gasclaw.bootstrap.write_openclaw_config", side_effect=lambda *a, **kw: order.append("openclaw")), \
-             patch("gasclaw.bootstrap.install_skills", side_effect=lambda *a, **kw: order.append("skills")), \
+        def se(name):
+            return lambda *a, **kw: order.append(name)
+
+        with patch("gasclaw.bootstrap.setup_kimi_accounts", side_effect=se("kimi")), \
+             patch("gasclaw.bootstrap.write_agent_config", side_effect=se("agent_config")), \
+             patch("gasclaw.bootstrap.gastown_install", side_effect=se("install")), \
+             patch("gasclaw.bootstrap.start_dolt", side_effect=se("dolt")), \
+             patch("gasclaw.bootstrap.write_openclaw_config", side_effect=se("openclaw")), \
+             patch("gasclaw.bootstrap.install_skills", side_effect=se("skills")), \
              patch("gasclaw.bootstrap.run_doctor", side_effect=doctor_side_effect), \
-             patch("gasclaw.bootstrap.start_daemon", side_effect=lambda *a, **kw: order.append("daemon")), \
-             patch("gasclaw.bootstrap.start_mayor", side_effect=lambda *a, **kw: order.append("mayor")), \
-             patch("gasclaw.bootstrap.notify_telegram", side_effect=lambda *a, **kw: order.append("notify")):
+             patch("gasclaw.bootstrap.start_daemon", side_effect=se("daemon")), \
+             patch("gasclaw.bootstrap.start_mayor", side_effect=se("mayor")), \
+             patch("gasclaw.bootstrap.notify_telegram", side_effect=se("notify")):
 
             bootstrap(config, gt_root=tmp_path)
 
@@ -113,8 +116,9 @@ class TestMonitorLoop:
                 activity={"compliant": True, "last_commit_age": 100},
             )
 
+        activity_return = {"compliant": True, "last_commit_age": 100}
         with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
-             patch("gasclaw.bootstrap.check_agent_activity", return_value={"compliant": True, "last_commit_age": 100}), \
+             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
              patch("gasclaw.bootstrap.notify_telegram"), \
              patch("time.sleep"):
             monitor_loop(config, interval=1)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from gasclaw.cli import app
 from gasclaw.config import GasclawConfig
-
 
 runner = CliRunner()
 
@@ -84,8 +82,10 @@ class TestStatusCommand:
                 agents=["mayor", "crew-1"],
             )
 
+        def raise_valueerror():
+            raise ValueError("no config")
         monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
-        monkeypatch.setattr("gasclaw.cli.load_config", lambda: (_ for _ in ()).throw(ValueError("no config")))
+        monkeypatch.setattr("gasclaw.cli.load_config", raise_valueerror)
 
         result = runner.invoke(app, ["status"])
 

--- a/tests/unit/test_gastown_installer.py
+++ b/tests/unit/test_gastown_installer.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import call
 
 import tomlkit
 
-from gasclaw.gastown.installer import setup_kimi_accounts, gastown_install
+from gasclaw.gastown.installer import gastown_install, setup_kimi_accounts
 
 
 class TestSetupKimiAccounts:

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 
-from gasclaw.gastown.lifecycle import start_dolt, start_daemon, start_mayor, stop_all
+from gasclaw.gastown.lifecycle import start_daemon, start_dolt, start_mayor, stop_all
 
 
 class TestStartDolt:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import subprocess
 
-import httpx
-import respx
-
-from gasclaw.health import check_health, check_agent_activity, HealthReport
+from gasclaw.health import HealthReport, check_agent_activity, check_health
 
 
 class TestCheckHealth:

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import time
 
 import pytest
 
-from gasclaw.kimigas.key_pool import KeyPool, RATE_LIMIT_COOLDOWN
+from gasclaw.kimigas.key_pool import RATE_LIMIT_COOLDOWN, KeyPool
 
 
 class TestKeyPoolSingleKey:

--- a/tests/unit/test_kimigas_proxy.py
+++ b/tests/unit/test_kimigas_proxy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from gasclaw.kimigas.proxy import build_claude_env, KIMI_ANTHROPIC_BASE_URL
+from gasclaw.kimigas.proxy import KIMI_ANTHROPIC_BASE_URL, build_claude_env
 
 
 class TestBuildClaudeEnv:

--- a/tests/unit/test_openclaw_doctor.py
+++ b/tests/unit/test_openclaw_doctor.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import subprocess
 
-import pytest
-
-from gasclaw.openclaw.doctor import run_doctor, DoctorResult
+from gasclaw.openclaw.doctor import DoctorResult, run_doctor
 
 
 class TestRunDoctor:
@@ -51,7 +49,9 @@ class TestRunDoctor:
 
         def mock_run(cmd, **kwargs):
             captured_args["cmd"] = cmd
-            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"Repaired", stderr=b"")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=b"Repaired", stderr=b""
+            )
 
         monkeypatch.setattr("gasclaw.openclaw.doctor.subprocess.run", mock_run)
         run_doctor(repair=True)

--- a/tests/unit/test_openclaw_skill_manager.py
+++ b/tests/unit/test_openclaw_skill_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import stat
 
 from gasclaw.openclaw.skill_manager import install_skills
 

--- a/tests/unit/test_updater_applier.py
+++ b/tests/unit/test_updater_applier.py
@@ -14,7 +14,7 @@ class TestApplyUpdates:
             subprocess, "run",
             lambda *a, **kw: calls.append(a[0]) or subprocess.CompletedProcess(a[0], 0),
         )
-        results = apply_updates()
+        apply_updates()
         assert len(calls) > 0
         # Should attempt to update gt, openclaw, kimigas
         cmd_strs = [" ".join(str(x) for x in cmd) for cmd in calls]

--- a/tests/unit/test_updater_checker.py
+++ b/tests/unit/test_updater_checker.py
@@ -12,7 +12,7 @@ class TestCheckVersions:
         monkeypatch.setattr(
             subprocess, "run",
             lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout="1.0.0\n".encode()
+                a[0], 0, stdout=b"1.0.0\n"
             ),
         )
         versions = check_versions()


### PR DESCRIPTION
## Summary

Fixes all 38+ ruff lint issues across the codebase:

- Remove unused imports (F401): `os`, `stat`, `httpx`, `respx`, `pytest`, `json`, `call`, `MagicMock`
- Fix import sorting (I001) across all modules  
- Fix line too long (E501) in cli.py, health.py, and test files
- Fix unused variable (F841) in test_updater_applier.py
- Fix unnecessary encode call (UP012) in test_updater_checker.py

## Test plan
- [x] `python -m ruff check src/ tests/` passes with no errors
- [x] All 90 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)