### PR TITLE
test: add config edge case tests and validation

### DIFF
--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -39,6 +39,15 @@ def _parse_keys(raw: str) -> list[str]:
     return [k.strip() for k in raw.split(":") if k.strip()]
 
 
+def _parse_positive_int(value: str, default: int) -> int:
+    """Parse a positive integer, returning default if invalid."""
+    try:
+        result = int(value)
+        return result if result > 0 else default
+    except (ValueError, TypeError):
+        return default
+
+
 def load_config() -> GasclawConfig:
     """Load and validate configuration from environment variables."""
     raw_keys = _require_env("GASTOWN_KIMI_KEYS")
@@ -53,7 +62,7 @@ def load_config() -> GasclawConfig:
         telegram_owner_id=_require_env("TELEGRAM_OWNER_ID"),
         gt_rig_url=os.environ.get("GT_RIG_URL", "/project").strip() or "/project",
         project_dir=os.environ.get("PROJECT_DIR", "/project").strip() or "/project",
-        gt_agent_count=int(os.environ.get("GT_AGENT_COUNT", "6")),
-        monitor_interval=int(os.environ.get("MONITOR_INTERVAL", "300")),
-        activity_deadline=int(os.environ.get("ACTIVITY_DEADLINE", "3600")),
+        gt_agent_count=_parse_positive_int(os.environ.get("GT_AGENT_COUNT", "6"), 6),
+        monitor_interval=_parse_positive_int(os.environ.get("MONITOR_INTERVAL", "300"), 300),
+        activity_deadline=_parse_positive_int(os.environ.get("ACTIVITY_DEADLINE", "3600"), 3600),
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -107,6 +107,58 @@ class TestLoadConfig:
         assert cfg.openclaw_kimi_key not in cfg.gastown_kimi_keys
 
 
+    def test_whitespace_only_env_vars_treated_as_missing(self, monkeypatch, env_vars):
+        """Whitespace-only env vars should be treated as missing."""
+        for k, v in env_vars().items():
+            monkeypatch.setenv(k, v)
+        monkeypatch.setenv("GASTOWN_KIMI_KEYS", "   ")
+        with pytest.raises(ValueError, match="GASTOWN_KIMI_KEYS"):
+            load_config()
+
+    def test_only_colons_in_keys_raises(self, monkeypatch, env_vars):
+        """Keys containing only colons should raise ValueError."""
+        for k, v in env_vars().items():
+            monkeypatch.setenv(k, v)
+        monkeypatch.setenv("GASTOWN_KIMI_KEYS", ":::")
+        with pytest.raises(ValueError, match="GASTOWN_KIMI_KEYS"):
+            load_config()
+
+    def test_gt_agent_count_zero_defaults_to_six(self, monkeypatch, env_vars):
+        """Zero gt_agent_count defaults to 6."""
+        for k, v in env_vars(GT_AGENT_COUNT="0").items():
+            monkeypatch.setenv(k, v)
+        cfg = load_config()
+        assert cfg.gt_agent_count == 6
+
+    def test_gt_agent_count_negative_defaults_to_six(self, monkeypatch, env_vars):
+        """Negative gt_agent_count defaults to 6."""
+        for k, v in env_vars(GT_AGENT_COUNT="-1").items():
+            monkeypatch.setenv(k, v)
+        cfg = load_config()
+        assert cfg.gt_agent_count == 6
+
+    def test_monitor_interval_zero_defaults(self, monkeypatch, env_vars):
+        """Zero monitor_interval defaults to 300."""
+        for k, v in env_vars(MONITOR_INTERVAL="0").items():
+            monkeypatch.setenv(k, v)
+        cfg = load_config()
+        assert cfg.monitor_interval == 300
+
+    def test_monitor_interval_negative_defaults(self, monkeypatch, env_vars):
+        """Negative monitor_interval defaults to 300."""
+        for k, v in env_vars(MONITOR_INTERVAL="-10").items():
+            monkeypatch.setenv(k, v)
+        cfg = load_config()
+        assert cfg.monitor_interval == 300
+
+    def test_activity_deadline_zero_defaults(self, monkeypatch, env_vars):
+        """Zero activity_deadline defaults to 3600."""
+        for k, v in env_vars(ACTIVITY_DEADLINE="0").items():
+            monkeypatch.setenv(k, v)
+        cfg = load_config()
+        assert cfg.activity_deadline == 3600
+
+
 class TestGasclawConfig:
     def test_dataclass_fields(self):
         """GasclawConfig has all expected fields."""


### PR DESCRIPTION
## Summary

Add edge case tests and validation for configuration loading:

- **Validation**: Zero/negative values for `gt_agent_count`, `monitor_interval`, and `activity_deadline` now default to safe values (6, 300, 3600 respectively) instead of being accepted as-is
- **Edge case tests**: Added tests for whitespace-only env vars, keys containing only colons, and invalid integer values

## Test Plan

- [x] All 97 unit tests pass
- [x] `make lint` passes
- [x] New tests cover edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)