### PR TITLE
fix: handle FileNotFoundError in stop_all + add lifecycle tests

### DIFF
--- a/src/gasclaw/gastown/lifecycle.py
+++ b/src/gasclaw/gastown/lifecycle.py
@@ -67,6 +67,10 @@ def start_mayor(*, agent: str = "kimi-claude") -> None:
 
 def stop_all() -> None:
     """Stop all Gastown services (mayor, daemon, dolt)."""
-    subprocess.run(["gt", "mayor", "stop"], check=False)
-    subprocess.run(["gt", "daemon", "stop"], check=False)
-    subprocess.run(["dolt", "sql-server", "--stop"], check=False)
+    try:
+        subprocess.run(["gt", "mayor", "stop"], check=False)
+        subprocess.run(["gt", "daemon", "stop"], check=False)
+        subprocess.run(["dolt", "sql-server", "--stop"], check=False)
+    except FileNotFoundError:
+        # Binaries not installed - services likely not running
+        pass

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -43,6 +43,25 @@ class TestStartDolt:
             assert "exited early" in str(e)
             assert "1" in str(e)
 
+    def test_raises_timeout_if_never_ready(self, monkeypatch):
+        """If dolt never becomes ready, raise TimeoutError."""
+        class MockProc:
+            pid = 1
+            def poll(self):
+                return None  # Still running
+
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: MockProc())
+        # Always return non-zero (not ready)
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
+        )
+        try:
+            start_dolt(data_dir="/tmp/dolt-data", port=3307, timeout=1)
+            assert False, "Expected TimeoutError"
+        except TimeoutError as e:
+            assert "not ready" in str(e).lower() or "timeout" in str(e).lower()
+
 
 class TestStartDaemon:
     def test_runs_gt_daemon(self, monkeypatch):
@@ -79,3 +98,22 @@ class TestStopAll:
         cmd_strs = [" ".join(str(x) for x in cmd) for cmd in calls]
         assert any("mayor" in s and "stop" in s for s in cmd_strs)
         assert any("daemon" in s and "stop" in s for s in cmd_strs)
+
+    def test_handles_stop_failures_gracefully(self, monkeypatch):
+        """stop_all uses check=False so failures don't raise."""
+        def mock_run(*a, **kw):
+            # Simulate failure for all commands
+            return subprocess.CompletedProcess(a[0], 1, stderr=b"not running")
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        # Should not raise even though all commands "fail"
+        stop_all()
+
+    def test_handles_missing_binaries_gracefully(self, monkeypatch):
+        """stop_all handles FileNotFoundError when binaries are missing."""
+        def mock_run(*a, **kw):
+            raise FileNotFoundError("gt not found")
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        # Should not raise even though binaries are missing
+        stop_all()


### PR DESCRIPTION
## Summary

Bug fix and edge case tests for the lifecycle module:

- **Bug fix**: `stop_all()` now gracefully handles `FileNotFoundError` when binaries are not installed (indicating services are not running)
- **New tests**: 
  - Test for `start_dolt` timeout when server never becomes ready
  - Test for `stop_all` handling command failures (non-zero exit)
  - Test for `stop_all` handling missing binaries (FileNotFoundError)

## Test Plan

- [x] All 110 unit tests pass
- [x] `make lint` passes
- [x] Bug fix tested with new test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)