### PR TITLE
test: add edge case tests for multiple modules

### DIFF
--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -153,3 +153,57 @@ class TestMonitorLoop:
             project_dir="/custom/project",
             deadline_seconds=config.activity_deadline,
         )
+
+    def test_notifies_on_non_compliance(self, config, monkeypatch):
+        """monitor_loop sends notification when activity is non-compliant."""
+        check_count = 0
+        notify_calls = []
+
+        def mock_check(**kw):
+            nonlocal check_count
+            check_count += 1
+            if check_count >= 2:
+                raise KeyboardInterrupt
+            from gasclaw.health import HealthReport
+            return HealthReport(
+                dolt="healthy", daemon="healthy", mayor="healthy",
+                openclaw="healthy", agents=["mayor"],
+            )
+
+        activity_return = {"compliant": False, "last_commit_age": 7200}
+        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
+             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify, \
+             patch("time.sleep"):
+            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            monitor_loop(config, interval=1)
+
+        assert len(notify_calls) >= 1
+        assert any("ACTIVITY ALERT" in msg for msg in notify_calls)
+
+    def test_notifies_on_service_down(self, config, monkeypatch):
+        """monitor_loop sends notification when critical service is down."""
+        check_count = 0
+        notify_calls = []
+
+        def mock_check(**kw):
+            nonlocal check_count
+            check_count += 1
+            if check_count >= 2:
+                raise KeyboardInterrupt
+            from gasclaw.health import HealthReport
+            return HealthReport(
+                dolt="unhealthy", daemon="healthy", mayor="healthy",
+                openclaw="healthy", agents=["mayor"],
+            )
+
+        activity_return = {"compliant": True, "last_commit_age": 100}
+        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
+             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify, \
+             patch("time.sleep"):
+            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            monitor_loop(config, interval=1)
+
+        assert len(notify_calls) >= 1
+        assert any("SERVICE DOWN" in msg for msg in notify_calls)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -158,6 +158,13 @@ class TestLoadConfig:
         cfg = load_config()
         assert cfg.activity_deadline == 3600
 
+    def test_activity_deadline_negative_defaults(self, monkeypatch, env_vars):
+        """Negative activity_deadline defaults to 3600."""
+        for k, v in env_vars(ACTIVITY_DEADLINE="-100").items():
+            monkeypatch.setenv(k, v)
+        cfg = load_config()
+        assert cfg.activity_deadline == 3600
+
 
 class TestGasclawConfig:
     def test_dataclass_fields(self):

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -73,6 +73,29 @@ class TestStartDaemon:
         start_daemon()
         assert any("daemon" in str(cmd) for cmd in calls)
 
+    def test_handles_failure(self, monkeypatch):
+        """start_daemon raises RuntimeError if daemon fails to start."""
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("daemon failed")),
+        )
+        try:
+            start_daemon()
+            assert False, "Expected RuntimeError"
+        except RuntimeError as e:
+            assert "daemon" in str(e).lower() or "failed" in str(e).lower()
+
+    def test_handles_missing_binary(self, monkeypatch):
+        """start_daemon raises FileNotFoundError if gt not installed."""
+        def raise_not_found(*a, **kw):
+            raise FileNotFoundError("gt not found")
+        monkeypatch.setattr(subprocess, "run", raise_not_found)
+        try:
+            start_daemon()
+            assert False, "Expected FileNotFoundError"
+        except FileNotFoundError:
+            pass
+
 
 class TestStartMayor:
     def test_runs_gt_mayor_start(self, monkeypatch):
@@ -85,6 +108,29 @@ class TestStartMayor:
         cmd_strs = [" ".join(str(x) for x in cmd) for cmd in calls]
         assert any("mayor" in s and "start" in s for s in cmd_strs)
         assert any("kimi-claude" in s for s in cmd_strs)
+
+    def test_handles_failure(self, monkeypatch):
+        """start_mayor raises RuntimeError if mayor fails to start."""
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("mayor failed")),
+        )
+        try:
+            start_mayor(agent="kimi-claude")
+            assert False, "Expected RuntimeError"
+        except RuntimeError as e:
+            assert "mayor" in str(e).lower() or "failed" in str(e).lower()
+
+    def test_handles_missing_binary(self, monkeypatch):
+        """start_mayor raises FileNotFoundError if gt not installed."""
+        def raise_not_found(*a, **kw):
+            raise FileNotFoundError("gt not found")
+        monkeypatch.setattr(subprocess, "run", raise_not_found)
+        try:
+            start_mayor(agent="kimi-claude")
+            assert False, "Expected FileNotFoundError"
+        except FileNotFoundError:
+            pass
 
 
 class TestStopAll:

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -103,3 +103,38 @@ class TestKeyPoolStatus:
     def test_empty_pool_raises(self):
         with pytest.raises(ValueError, match="at least one"):
             KeyPool([])
+
+    def test_partial_rate_limited_availability(self, tmp_path):
+        """Test with 4 keys where 2 are rate-limited."""
+        pool = KeyPool(["k1", "k2", "k3", "k4"], state_dir=tmp_path)
+        pool.mark_rate_limited("k1")
+        pool.mark_rate_limited("k3")
+        status = pool.status()
+        assert status["total"] == 4
+        assert status["available"] == 2
+        assert status["rate_limited"] == 2
+
+    def test_rate_limiting_unused_key(self, tmp_path):
+        """Marking a key as rate-limited before it's used works."""
+        pool = KeyPool(["k1", "k2"], state_dir=tmp_path)
+        # Mark k1 as rate-limited before ever using it
+        pool.mark_rate_limited("k1")
+        # k2 should be selected since k1 is rate-limited
+        assert pool.get_key() == "k2"
+
+    def test_all_keys_used_then_rotated(self, tmp_path):
+        """After all keys are used, rotation starts over with LRU."""
+        pool = KeyPool(["k1", "k2", "k3"], state_dir=tmp_path)
+        # Use all keys once
+        assert pool.get_key() == "k1"
+        assert pool.get_key() == "k2"
+        assert pool.get_key() == "k3"
+        # Next should be k1 again (LRU)
+        assert pool.get_key() == "k1"
+
+    def test_status_with_no_rate_limited_keys(self, tmp_path):
+        """Status shows all available when no keys are rate-limited."""
+        pool = KeyPool(["k1", "k2", "k3"], state_dir=tmp_path)
+        status = pool.status()
+        assert status["available"] == 3
+        assert status["rate_limited"] == 0


### PR DESCRIPTION
## Summary

Adds edge case tests to improve test coverage across multiple modules:

### Changes

- **test_config.py**: Add `test_activity_deadline_negative_defaults` to verify negative values default to 3600
- **test_gastown_lifecycle.py**: Add failure case tests for `start_daemon` and `start_mayor` (RuntimeError and FileNotFoundError)
- **test_bootstrap.py**: Add `test_notifies_on_non_compliance` and `test_notifies_on_service_down` for monitor_loop notification behavior
- **test_kimigas_key_pool.py**: Add 4 new tests for partial rate limiting, unused key rate limiting, rotation, and status

### Test Count
- Before: 110 tests
- After: 121 tests (+11)

### Test Plan
- [x] `python -m pytest tests/unit -v` passes (121 tests)
- [x] `python -m ruff check src/ tests/` passes
- [x] All new tests follow existing mocking patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)