### PR TITLE
test: add edge case tests for bootstrap, lifecycle, and installer

### DIFF
--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -207,3 +207,59 @@ class TestMonitorLoop:
 
         assert len(notify_calls) >= 1
         assert any("SERVICE DOWN" in msg for msg in notify_calls)
+
+    def test_notifies_when_doctor_unhealthy(self, config, monkeypatch, tmp_path):
+        """bootstrap notifies when doctor reports unhealthy."""
+        notify_calls = []
+
+        from gasclaw.openclaw.doctor import DoctorResult
+        mock_doctor = DoctorResult(healthy=False, returncode=1, output="Config error: missing token")
+
+        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
+             patch("gasclaw.bootstrap.write_agent_config"), \
+             patch("gasclaw.bootstrap.gastown_install"), \
+             patch("gasclaw.bootstrap.start_dolt"), \
+             patch("gasclaw.bootstrap.write_openclaw_config"), \
+             patch("gasclaw.bootstrap.install_skills"), \
+             patch("gasclaw.bootstrap.run_doctor", return_value=mock_doctor), \
+             patch("gasclaw.bootstrap.start_daemon"), \
+             patch("gasclaw.bootstrap.start_mayor"), \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
+            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            bootstrap(config, gt_root=tmp_path)
+
+        # Should have "Gasclaw is up" and doctor warning notifications
+        assert len(notify_calls) >= 1
+        assert any("openclaw doctor" in msg.lower() for msg in notify_calls)
+        assert any("config error" in msg.lower() for msg in notify_calls)
+
+    def test_notifies_on_multiple_services_down(self, config, monkeypatch):
+        """monitor_loop sends notifications for each unhealthy service."""
+        check_count = 0
+        notify_calls = []
+
+        def mock_check(**kw):
+            nonlocal check_count
+            check_count += 1
+            if check_count >= 2:
+                raise KeyboardInterrupt
+            from gasclaw.health import HealthReport
+            return HealthReport(
+                dolt="unhealthy", daemon="unhealthy", mayor="unhealthy",
+                openclaw="healthy", agents=[],
+            )
+
+        activity_return = {"compliant": True, "last_commit_age": 100}
+        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
+             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify, \
+             patch("time.sleep"):
+            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            monitor_loop(config, interval=1)
+
+        # Should have notifications for dolt, daemon, and mayor
+        service_notifications = [msg for msg in notify_calls if "SERVICE DOWN" in msg]
+        assert len(service_notifications) >= 3  # dolt, daemon, mayor
+        assert any("dolt" in msg for msg in service_notifications)
+        assert any("daemon" in msg for msg in service_notifications)
+        assert any("mayor" in msg for msg in service_notifications)

--- a/tests/unit/test_gastown_installer.py
+++ b/tests/unit/test_gastown_installer.py
@@ -33,6 +33,24 @@ class TestSetupKimiAccounts:
         doc = tomlkit.loads((tmp_path / "1" / "config.toml").read_text())
         assert doc["providers"]["kimi-api"]["api_key"] == "sk-key1"
 
+    def test_empty_keys_list_creates_no_accounts(self, tmp_path):
+        """Empty keys list should not create any account directories."""
+        from pathlib import Path
+        setup_kimi_accounts([], accounts_dir=tmp_path)
+        # No subdirectories should be created
+        assert list(tmp_path.iterdir()) == []
+
+    def test_uses_default_accounts_dir_when_none_provided(self, monkeypatch, tmp_path):
+        """setup_kimi_accounts uses ~/.kimi-accounts when accounts_dir is None."""
+        from pathlib import Path
+        # Mock Path.home() to return tmp_path
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        setup_kimi_accounts(["sk-test"], accounts_dir=None)
+
+        # Should create account in ~/.kimi-accounts/1/
+        assert (tmp_path / ".kimi-accounts" / "1" / "config.toml").exists()
+
 
 class TestGastownInstall:
     def test_runs_gt_install(self, monkeypatch, tmp_path):

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -62,6 +62,63 @@ class TestStartDolt:
         except TimeoutError as e:
             assert "not ready" in str(e).lower() or "timeout" in str(e).lower()
 
+    def test_uses_custom_data_dir(self, monkeypatch):
+        """start_dolt passes custom data_dir to dolt command."""
+        popen_calls = []
+        run_calls = []
+
+        class MockProc:
+            pid = 1
+            def poll(self):
+                return None
+
+        def mock_popen(*a, **kw):
+            popen_calls.append(a[0])
+            return MockProc()
+
+        def mock_run(*a, **kw):
+            run_calls.append(a[0])
+            return subprocess.CompletedProcess(a[0], 0)
+
+        monkeypatch.setattr(subprocess, "Popen", mock_popen)
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        start_dolt(data_dir="/custom/dolt/path", port=3307, timeout=1)
+
+        # Check data-dir is in the command
+        cmd_str = " ".join(str(x) for x in popen_calls[0])
+        assert "--data-dir" in cmd_str
+        assert "/custom/dolt/path" in cmd_str
+
+    def test_uses_custom_port(self, monkeypatch):
+        """start_dolt uses custom port for both server and health check."""
+        popen_calls = []
+        run_calls = []
+
+        class MockProc:
+            pid = 1
+            def poll(self):
+                return None
+
+        def mock_popen(*a, **kw):
+            popen_calls.append(a[0])
+            return MockProc()
+
+        def mock_run(*a, **kw):
+            run_calls.append(a[0])
+            return subprocess.CompletedProcess(a[0], 0)
+
+        monkeypatch.setattr(subprocess, "Popen", mock_popen)
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        start_dolt(data_dir="/tmp/dolt", port=9999, timeout=1)
+
+        # Check port appears in both commands
+        popen_str = " ".join(str(x) for x in popen_calls[0])
+        run_str = " ".join(str(x) for x in run_calls[0])
+        assert "9999" in popen_str
+        assert "9999" in run_str
+
 
 class TestStartDaemon:
     def test_runs_gt_daemon(self, monkeypatch):


### PR DESCRIPTION
## Summary
Add 6 new edge case tests to improve coverage for bootstrap, lifecycle, and installer modules.

## Changes
- `test_bootstrap.py`: Add 2 tests for doctor unhealthy notification and multiple services down notification
- `test_gastown_lifecycle.py`: Add 2 tests for start_dolt with custom data_dir and port
- `test_gastown_installer.py`: Add 2 tests for empty keys list and default accounts dir

## Test Plan
- [x] `python -m pytest tests/unit -v` passes (127 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)