### PR TITLE
test: add edge case tests for skill manager and proxy

### DIFF
--- a/tests/unit/test_kimigas_proxy.py
+++ b/tests/unit/test_kimigas_proxy.py
@@ -29,3 +29,20 @@ class TestBuildClaudeEnv:
     def test_base_url_is_kimi(self):
         env = build_claude_env("sk-test")
         assert "kimi.com" in env["ANTHROPIC_BASE_URL"]
+
+    def test_empty_string_config_dir_uses_default(self):
+        """Empty string config_dir falls back to default."""
+        env = build_claude_env("sk-test", config_dir="")
+        # Empty string is falsy, so default is used
+        assert ".claude-kimigas" in env["CLAUDE_CONFIG_DIR"]
+
+    def test_handles_special_chars_in_key(self):
+        """API keys with special characters are handled correctly."""
+        special_key = "sk-key-with-dash_and_underscore.123"
+        env = build_claude_env(special_key)
+        assert env["ANTHROPIC_API_KEY"] == special_key
+
+    def test_config_dir_with_trailing_slash(self):
+        """Config dir with trailing slash is preserved."""
+        env = build_claude_env("sk-test", config_dir="/tmp/claude/")
+        assert env["CLAUDE_CONFIG_DIR"] == "/tmp/claude/"

--- a/tests/unit/test_openclaw_skill_manager.py
+++ b/tests/unit/test_openclaw_skill_manager.py
@@ -46,3 +46,52 @@ class TestInstallSkills:
         self._make_source_skills(src)
         install_skills(skills_src=src, skills_dst=dst)
         assert dst.is_dir()
+
+    def test_skips_non_skill_files_in_source(self, tmp_path):
+        """Non-directory items in source (like README.md) are skipped."""
+        src = tmp_path / "src-skills"
+        dst = tmp_path / "dst-skills"
+        self._make_source_skills(src)
+        # Create a file in the source that should be ignored
+        (src / "README.md").write_text("# Skills")
+        (src / ".DS_Store").write_text("")
+        install_skills(skills_src=src, skills_dst=dst)
+        # Only the skill directory should be copied
+        assert (dst / "gastown-health").exists()
+        assert not (dst / "README.md").exists()
+        assert not (dst / ".DS_Store").exists()
+
+    def test_handles_nested_directories(self, tmp_path):
+        """Skill directories with nested subdirectories are copied."""
+        src = tmp_path / "src-skills"
+        dst = tmp_path / "dst-skills"
+
+        # Create skill with nested directory
+        skill_dir = src / "complex-skill"
+        nested_dir = skill_dir / "data" / "templates"
+        nested_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Complex Skill")
+        (nested_dir / "template.j2").write_text("template content")
+
+        install_skills(skills_src=src, skills_dst=dst)
+
+        assert (dst / "complex-skill" / "data" / "templates" / "template.j2").exists()
+        assert (dst / "complex-skill" / "data" / "templates" / "template.j2").read_text() == "template content"
+
+    def test_overwrites_existing_skills(self, tmp_path):
+        """Installing over existing skills replaces them."""
+        src = tmp_path / "src-skills"
+        dst = tmp_path / "dst-skills"
+        self._make_source_skills(src)
+
+        # Pre-create an old version of the skill
+        old_skill = dst / "gastown-health"
+        old_skill.mkdir(parents=True)
+        (old_skill / "SKILL.md").write_text("# Old Version")
+        (old_skill / "old-file.txt").write_text("should be removed")
+
+        install_skills(skills_src=src, skills_dst=dst)
+
+        # Should have new content, not old
+        assert "# Health Skill" in (dst / "gastown-health" / "SKILL.md").read_text()
+        assert not (dst / "gastown-health" / "old-file.txt").exists()


### PR DESCRIPTION
## Summary
Add edge case tests for skill_manager and proxy modules.

## Changes
- `test_openclaw_skill_manager.py`: Add 3 tests for edge cases
  - Skips non-skill files in source directory
  - Handles nested directories in skills
  - Overwrites existing skills correctly

- `test_kimigas_proxy.py`: Add 3 tests for edge cases
  - Empty string config_dir falls back to default
  - Handles special characters in API keys
  - Config dir with trailing slash

## Test Plan
- [x] `python -m pytest tests/unit -v` passes (133 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)