### PR TITLE
feat: add --version flag and version subcommand

### DIFF
--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -8,6 +8,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from gasclaw import __version__
 from gasclaw.bootstrap import bootstrap, monitor_loop
 from gasclaw.config import load_config
 from gasclaw.gastown.lifecycle import stop_all
@@ -16,8 +17,29 @@ from gasclaw.kimigas.key_pool import KeyPool
 from gasclaw.updater.applier import apply_updates
 from gasclaw.updater.checker import check_versions
 
+
+def version_callback(value: bool) -> None:
+    """Print version and exit."""
+    if value:
+        console.print(f"gasclaw {__version__}")
+        raise typer.Exit()
+
+
 app = typer.Typer(help="Gasclaw — Gastown + OpenClaw + KimiGas in one container.")
 console = Console()
+
+
+@app.callback()
+def main(
+    version: bool | None = typer.Option(
+        None, "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+) -> None:
+    """Gasclaw CLI."""
+    pass
 
 
 @app.command()
@@ -99,3 +121,9 @@ def update() -> None:
     for name, result in results.items():
         style = "green" if result == "updated" else "yellow"
         console.print(f"  {name}: [{style}]{result}[/{style}]")
+
+
+@app.command()
+def version() -> None:
+    """Show gasclaw version."""
+    console.print(f"gasclaw {__version__}")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -143,6 +143,22 @@ class TestUpdateCommand:
         assert "Applying updates" in result.output
 
 
+class TestVersionCommand:
+    def test_version_flag_shows_version(self):
+        """--version flag displays version and exits."""
+        from gasclaw import __version__
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
+
+    def test_version_command_shows_version(self):
+        """version subcommand displays version."""
+        from gasclaw import __version__
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
+
+
 class TestCLIEdgeCases:
     def test_help_flag_shows_help(self):
         """Running with --help shows help text."""


### PR DESCRIPTION
## Summary
Add `--version` flag and `version` subcommand to display gasclaw version.

Closes #27

## Changes
- Add `version` command that prints gasclaw version
- Add `--version` flag (eager callback) that prints version and exits
- Uses `__version__` from `gasclaw/__init__.py`

## Test Plan
- [x] `gasclaw --version` prints version and exits with code 0
- [x] `gasclaw version` prints version and exits with code 0
- [x] All 155 unit tests pass
- [x] Lint passes