### PR TITLE
fix: notify_telegram returns bool and logs failures

### DIFF
--- a/src/gasclaw/updater/notifier.py
+++ b/src/gasclaw/updater/notifier.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["notify_telegram"]
 
@@ -14,13 +17,16 @@ def notify_telegram(
     *,
     gateway_port: int = 18789,
     auth_token: str = "",
-) -> None:
+) -> bool:
     """Send a notification message via OpenClaw gateway.
 
     Args:
         message: The message text to send.
         gateway_port: OpenClaw gateway port.
         auth_token: Gateway auth token.
+
+    Returns:
+        True if notification was sent successfully, False otherwise.
     """
     url = f"http://localhost:{gateway_port}/api/message"
     headers = {"Content-Type": "application/json"}
@@ -34,5 +40,10 @@ def notify_telegram(
             headers=headers,
             timeout=10.0,
         )
-    except (httpx.ConnectError, httpx.TimeoutException):
-        pass  # Gateway not available — silently skip
+        return True
+    except httpx.ConnectError as e:
+        logger.warning("Failed to send notification: gateway not available (%s)", e)
+        return False
+    except httpx.TimeoutException as e:
+        logger.warning("Failed to send notification: gateway timeout (%s)", e)
+        return False

--- a/tests/unit/test_updater_notifier.py
+++ b/tests/unit/test_updater_notifier.py
@@ -31,5 +31,33 @@ class TestNotifyTelegram:
         respx.post("http://localhost:18789/api/message").mock(
             side_effect=httpx.ConnectError("down")
         )
-        # Should not raise — just log
-        notify_telegram("Test", gateway_port=18789, auth_token="tok")
+        # Should not raise — return False
+        result = notify_telegram("Test", gateway_port=18789, auth_token="tok")
+        assert result is False
+
+    @respx.mock
+    def test_returns_true_on_success(self):
+        """Function returns True when notification succeeds."""
+        respx.post("http://localhost:18789/api/message").mock(
+            return_value=httpx.Response(200)
+        )
+        result = notify_telegram("Test", gateway_port=18789, auth_token="tok")
+        assert result is True
+
+    @respx.mock
+    def test_returns_false_on_connect_error(self):
+        """Function returns False on connection error."""
+        respx.post("http://localhost:18789/api/message").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        result = notify_telegram("Test", gateway_port=18789)
+        assert result is False
+
+    @respx.mock
+    def test_returns_false_on_timeout(self):
+        """Function returns False on timeout."""
+        respx.post("http://localhost:18789/api/message").mock(
+            side_effect=httpx.TimeoutException("Request timed out")
+        )
+        result = notify_telegram("Test", gateway_port=18789)
+        assert result is False


### PR DESCRIPTION
## Summary
Fixes #18 - notify_telegram() now returns bool and logs failures instead of silently swallowing exceptions.

## Changes
- Return `True` on success, `False` on failure
- Log failed notifications at WARNING level with error details  
- Distinguish between `ConnectError` and `TimeoutException`

## Test plan
- [x] All 158 unit tests pass
- [x] Added tests for return value verification
- [x] Tests verify both ConnectError and TimeoutException handling