### PR TITLE
fix: start_dolt cleans up subprocess on failure

### DIFF
--- a/src/gasclaw/gastown/lifecycle.py
+++ b/src/gasclaw/gastown/lifecycle.py
@@ -31,21 +31,31 @@ def start_dolt(
         stderr=subprocess.DEVNULL,
     )
 
-    # Wait for port to be ready
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        # Check if process died early
-        if proc.poll() is not None:
-            raise RuntimeError(f"Dolt process exited early with code {proc.returncode}")
+    try:
+        # Wait for port to be ready
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            # Check if process died early
+            if proc.poll() is not None:
+                raise RuntimeError(f"Dolt process exited early with code {proc.returncode}")
 
-        result = subprocess.run(
-            ["dolt", "sql", "--port", str(port), "-q", "SELECT 1"],
-            capture_output=True,
-        )
-        if result.returncode == 0:
-            return
-        time.sleep(1)
-    raise TimeoutError(f"Dolt not ready after {timeout}s on port {port}")
+            result = subprocess.run(
+                ["dolt", "sql", "--port", str(port), "-q", "SELECT 1"],
+                capture_output=True,
+            )
+            if result.returncode == 0:
+                return
+            time.sleep(1)
+        raise TimeoutError(f"Dolt not ready after {timeout}s on port {port}")
+    except Exception:
+        # Clean up subprocess on any failure
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        raise
 
 
 def start_daemon() -> None:

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -34,6 +34,10 @@ class TestStartDolt:
             returncode = 1
             def poll(self):
                 return self.returncode  # Process already exited
+            def terminate(self):
+                pass
+            def wait(self, timeout=None):
+                return 0
 
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: DeadProcess())
         try:
@@ -49,6 +53,10 @@ class TestStartDolt:
             pid = 1
             def poll(self):
                 return None  # Still running
+            def terminate(self):
+                pass
+            def wait(self, timeout=None):
+                return 0
 
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: MockProc())
         # Always return non-zero (not ready)
@@ -118,6 +126,89 @@ class TestStartDolt:
         run_str = " ".join(str(x) for x in run_calls[0])
         assert "9999" in popen_str
         assert "9999" in run_str
+
+    def test_terminates_on_early_exit(self, monkeypatch):
+        """Subprocess is terminated when dolt exits early."""
+        terminate_called = []
+        wait_called = []
+
+        class DeadProcess:
+            pid = 1
+            returncode = 1
+            def poll(self):
+                return self.returncode
+            def terminate(self):
+                terminate_called.append(True)
+            def wait(self, timeout=None):
+                wait_called.append(timeout)
+                return 0
+
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: DeadProcess())
+        try:
+            start_dolt(data_dir="/tmp/dolt", port=3307, timeout=1)
+        except RuntimeError:
+            pass
+
+        assert len(terminate_called) == 1
+        assert len(wait_called) == 1
+
+    def test_terminates_on_timeout(self, monkeypatch):
+        """Subprocess is terminated when timeout occurs."""
+        terminate_called = []
+
+        class SlowProc:
+            pid = 1
+            def poll(self):
+                return None  # Never exits
+            def terminate(self):
+                terminate_called.append(True)
+            def wait(self, timeout=None):
+                return 0
+
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: SlowProc())
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
+        )
+
+        try:
+            start_dolt(data_dir="/tmp/dolt", port=3307, timeout=1)
+        except TimeoutError:
+            pass
+
+        assert len(terminate_called) == 1
+
+    def test_force_kill_on_terminate_timeout(self, monkeypatch):
+        """Process is killed if graceful terminate doesn't work."""
+        terminate_called = []
+        kill_called = []
+
+        class StubbornProc:
+            pid = 1
+            def poll(self):
+                return None
+            def terminate(self):
+                terminate_called.append(True)
+            def kill(self):
+                kill_called.append(True)
+            def wait(self, timeout=None):
+                if timeout == 5:
+                    raise subprocess.TimeoutExpired(cmd=["dolt"], timeout=5)
+                return 0
+
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: StubbornProc())
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
+        )
+
+        try:
+            start_dolt(data_dir="/tmp/dolt", port=3307, timeout=1)
+        except TimeoutError:
+            pass
+
+        assert len(terminate_called) == 1
+        assert len(kill_called) == 1
 
 
 class TestStartDaemon:


### PR DESCRIPTION
## Summary
Fixes #20 - start_dolt() now cleans up subprocess on failure instead of leaking it.

## Changes
- Wrap subprocess operations in try/except block
- Terminate subprocess on any failure (early exit or timeout)
- Attempt graceful termination (5s), fall back to kill if needed
- Re-raise original exception after cleanup

## Test plan
- [x] All 161 unit tests pass
- [x] Added tests for subprocess cleanup on early exit
- [x] Added tests for subprocess cleanup on timeout
- [x] Added tests for force kill when graceful terminate fails