### PR TITLE
fix: use atomic write for KeyPool state file

### DIFF
--- a/src/gasclaw/kimigas/key_pool.py
+++ b/src/gasclaw/kimigas/key_pool.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -44,9 +46,31 @@ class KeyPool:
         return {}
 
     def _save_state(self, state: dict[str, Any]) -> None:
+        """Save the key rotation state to disk atomically.
+
+        Uses atomic write (write to temp file, then rename) to avoid
+        race conditions where the file could be corrupted during read.
+        """
         self._state_dir.mkdir(parents=True, exist_ok=True)
         state_file = self._state_dir / "key-rotation.json"
-        state_file.write_text(json.dumps(state, indent=2))
+
+        # Write to temp file in same directory, then rename atomically
+        fd, temp_path = tempfile.mkstemp(
+            dir=self._state_dir,
+            prefix=".key-rotation-",
+            suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, 'w') as f:
+                json.dump(state, f, indent=2)
+            os.replace(temp_path, state_file)
+        except Exception:
+            # Clean up temp file on failure
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+            raise
 
     def get_key(self) -> str:
         """Select the best available key using LRU rotation."""

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -138,3 +138,41 @@ class TestKeyPoolStatus:
         status = pool.status()
         assert status["available"] == 3
         assert status["rate_limited"] == 0
+
+
+class TestKeyPoolAtomicWrite:
+    def test_state_file_written_atomically(self, tmp_path):
+        """State file is written using atomic rename to avoid corruption."""
+        pool = KeyPool(["k1"], state_dir=tmp_path)
+        pool.get_key()
+
+        # The state file should exist, but no temp files should remain
+        state_file = tmp_path / "key-rotation.json"
+        assert state_file.exists()
+
+        # Check no temp files left behind
+        temp_files = list(tmp_path.glob(".key-rotation-*.tmp"))
+        assert len(temp_files) == 0
+
+    def test_corrupted_temp_file_cleaned_up(self, tmp_path, monkeypatch):
+        """Temp file is cleaned up if write fails."""
+        pool = KeyPool(["k1"], state_dir=tmp_path)
+
+        # Make os.fdopen fail to trigger cleanup
+        original_fdopen = __builtins__["open"] if "open" in __builtins__ else open
+
+        def fail_on_fdopen(*args, **kwargs):
+            if args and hasattr(args[0], '__class__') and 'int' in str(type(args[0])):
+                raise OSError("Write failed")
+            return original_fdopen(*args, **kwargs)
+
+        monkeypatch.setattr("os.fdopen", fail_on_fdopen)
+
+        try:
+            pool._save_state({"test": "data"})
+        except OSError:
+            pass
+
+        # Temp file should be cleaned up
+        temp_files = list(tmp_path.glob(".key-rotation-*.tmp"))
+        assert len(temp_files) == 0


### PR DESCRIPTION
## Summary
Fixes #21 - KeyPool state file now uses atomic write to prevent race conditions.

## Changes
- Write to temp file first, then atomic rename
- Clean up temp file on write failure
- Add tests for atomic write behavior

## Test plan
- [x] All 163 unit tests pass
- [x] Added tests for atomic write verification
- [x] Added tests for temp file cleanup on failure