### PR TITLE
fix: warn on invalid _parse_positive_int() config values

### DIFF
--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 
 __all__ = ["GasclawConfig", "load_config"]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -39,12 +42,33 @@ def _parse_keys(raw: str) -> list[str]:
     return [k.strip() for k in raw.split(":") if k.strip()]
 
 
-def _parse_positive_int(value: str, default: int) -> int:
-    """Parse a positive integer, returning default if invalid."""
+def _parse_positive_int(value: str, default: int, name: str = "") -> int:
+    """Parse a positive integer, returning default if invalid.
+
+    Args:
+        value: The string value to parse.
+        default: The default to return if parsing fails or value is not positive.
+        name: The name of the config variable (for warning messages).
+
+    Returns:
+        The parsed positive integer, or default if invalid.
+    """
     try:
         result = int(value)
-        return result if result > 0 else default
+        if result <= 0:
+            if name:
+                logger.warning(
+                    "Invalid %s: %r must be positive, using default %d",
+                    name, value, default
+                )
+            return default
+        return result
     except (ValueError, TypeError):
+        if name:
+            logger.warning(
+                "Invalid %s: %r is not a valid integer, using default %d",
+                name, value, default
+            )
         return default
 
 
@@ -62,7 +86,7 @@ def load_config() -> GasclawConfig:
         telegram_owner_id=_require_env("TELEGRAM_OWNER_ID"),
         gt_rig_url=os.environ.get("GT_RIG_URL", "/project").strip() or "/project",
         project_dir=os.environ.get("PROJECT_DIR", "/project").strip() or "/project",
-        gt_agent_count=_parse_positive_int(os.environ.get("GT_AGENT_COUNT", "6"), 6),
-        monitor_interval=_parse_positive_int(os.environ.get("MONITOR_INTERVAL", "300"), 300),
-        activity_deadline=_parse_positive_int(os.environ.get("ACTIVITY_DEADLINE", "3600"), 3600),
+        gt_agent_count=_parse_positive_int(os.environ.get("GT_AGENT_COUNT", "6"), 6, "GT_AGENT_COUNT"),
+        monitor_interval=_parse_positive_int(os.environ.get("MONITOR_INTERVAL", "300"), 300, "MONITOR_INTERVAL"),
+        activity_deadline=_parse_positive_int(os.environ.get("ACTIVITY_DEADLINE", "3600"), 3600, "ACTIVITY_DEADLINE"),
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -177,3 +177,60 @@ class TestGasclawConfig:
         )
         assert cfg.gt_rig_url == "/project"
         assert cfg.gt_agent_count == 6
+
+
+class TestParsePositiveIntWarnings:
+    """Tests that _parse_positive_int logs warnings for invalid values."""
+
+    def test_invalid_value_logs_warning(self, monkeypatch, env_vars, caplog):
+        """Invalid integer value logs a warning."""
+        import logging
+        for k, v in env_vars(GT_AGENT_COUNT="abc").items():
+            monkeypatch.setenv(k, v)
+
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+
+        assert cfg.gt_agent_count == 6  # Default used
+        assert "GT_AGENT_COUNT" in caplog.text
+        assert "abc" in caplog.text
+        assert "not a valid integer" in caplog.text.lower()
+
+    def test_zero_value_logs_warning(self, monkeypatch, env_vars, caplog):
+        """Zero value logs a warning about positive requirement."""
+        import logging
+        for k, v in env_vars(MONITOR_INTERVAL="0").items():
+            monkeypatch.setenv(k, v)
+
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+
+        assert cfg.monitor_interval == 300  # Default used
+        assert "MONITOR_INTERVAL" in caplog.text
+        assert "must be positive" in caplog.text.lower()
+
+    def test_negative_value_logs_warning(self, monkeypatch, env_vars, caplog):
+        """Negative value logs a warning about positive requirement."""
+        import logging
+        for k, v in env_vars(ACTIVITY_DEADLINE="-100").items():
+            monkeypatch.setenv(k, v)
+
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+
+        assert cfg.activity_deadline == 3600  # Default used
+        assert "ACTIVITY_DEADLINE" in caplog.text
+        assert "must be positive" in caplog.text.lower()
+
+    def test_valid_value_no_warning(self, monkeypatch, env_vars, caplog):
+        """Valid value does not log a warning."""
+        import logging
+        for k, v in env_vars(GT_AGENT_COUNT="8").items():
+            monkeypatch.setenv(k, v)
+
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+
+        assert cfg.gt_agent_count == 8
+        # Should not have any warnings about GT_AGENT_COUNT
+        assert "GT_AGENT_COUNT" not in caplog.text


### PR DESCRIPTION
## Summary

Fixes #22 - `_parse_positive_int()` now logs warnings when invalid config values are provided.

## Changes

- Added optional `name` parameter to `_parse_positive_int()` for logging context
- Log warnings when:
  - Value cannot be parsed as an integer (e.g., "abc")
  - Value is zero or negative (e.g., "0", "-5")
- Add `logger` instance for the config module
- Added tests for warning messages:
  - `test_invalid_value_logs_warning`
  - `test_zero_value_logs_warning`
  - `test_negative_value_logs_warning`
  - `test_valid_value_no_warning`

## Test Plan

- [x] All 171 unit tests pass
- [x] New warning tests pass
- [x] Existing behavior preserved (defaults still applied)

```bash
make test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)