### PR TITLE
feat: add bootstrap rollback mechanism

### DIFF
--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -15,6 +15,10 @@ Bootstrap sequence:
 12. Start Mayor
 13. Send "Gasclaw is up" via Telegram
 14. Enter health monitor loop (foreground)
+
+Rollback on failure:
+- If bootstrap fails at any step, previously started services are stopped
+and a failure notification is sent.
 """
 
 from __future__ import annotations
@@ -25,7 +29,7 @@ from pathlib import Path
 from gasclaw.config import GasclawConfig
 from gasclaw.gastown.agent_config import write_agent_config
 from gasclaw.gastown.installer import gastown_install, setup_kimi_accounts
-from gasclaw.gastown.lifecycle import start_daemon, start_dolt, start_mayor
+from gasclaw.gastown.lifecycle import start_daemon, start_dolt, start_mayor, stop_all
 from gasclaw.health import check_agent_activity, check_health
 from gasclaw.openclaw.doctor import run_doctor
 from gasclaw.openclaw.installer import write_openclaw_config
@@ -41,44 +45,69 @@ def bootstrap(config: GasclawConfig, *, gt_root: Path = Path("/workspace/gt")) -
     Args:
         config: Validated gasclaw configuration.
         gt_root: Where to install Gastown.
+
+    Raises:
+        RuntimeError: If bootstrap fails, after attempting rollback.
     """
-    # 1. Setup Kimi accounts for Gastown agents
-    setup_kimi_accounts(config.gastown_kimi_keys)
+    # Track started services for rollback
+    dolt_started = False
+    services_started = False
 
-    # 2. Write agent config
-    write_agent_config(gt_root)
+    try:
+        # 1. Setup Kimi accounts for Gastown agents
+        setup_kimi_accounts(config.gastown_kimi_keys)
 
-    # 3. Install Gastown
-    gastown_install(gt_root=gt_root, rig_url=config.gt_rig_url)
+        # 2. Write agent config
+        write_agent_config(gt_root)
 
-    # 4. Start Dolt
-    start_dolt()
+        # 3. Install Gastown
+        gastown_install(gt_root=gt_root, rig_url=config.gt_rig_url)
 
-    # 5. Configure OpenClaw
-    openclaw_dir = Path.home() / ".openclaw"
-    write_openclaw_config(
-        openclaw_dir=openclaw_dir,
-        kimi_key=config.openclaw_kimi_key,
-        bot_token=config.telegram_bot_token,
-        owner_id=config.telegram_owner_id,
-    )
+        # 4. Start Dolt
+        start_dolt()
+        dolt_started = True
 
-    # 6. Install skills
-    install_skills(skills_src=_SKILLS_DIR, skills_dst=openclaw_dir / "skills")
+        # 5. Configure OpenClaw
+        openclaw_dir = Path.home() / ".openclaw"
+        write_openclaw_config(
+            openclaw_dir=openclaw_dir,
+            kimi_key=config.openclaw_kimi_key,
+            bot_token=config.telegram_bot_token,
+            owner_id=config.telegram_owner_id,
+        )
 
-    # 6.5. Run openclaw doctor to verify config and fix issues
-    doctor_result = run_doctor(repair=True)
-    if not doctor_result.healthy:
-        notify_telegram(f"openclaw doctor found issues:\n{doctor_result.output[:500]}")
+        # 6. Install skills
+        install_skills(skills_src=_SKILLS_DIR, skills_dst=openclaw_dir / "skills")
 
-    # 7. Start daemon
-    start_daemon()
+        # 6.5. Run openclaw doctor to verify config and fix issues
+        doctor_result = run_doctor(repair=True)
+        if not doctor_result.healthy:
+            notify_telegram(f"openclaw doctor found issues:\n{doctor_result.output[:500]}")
 
-    # 8. Start mayor
-    start_mayor(agent="kimi-claude")
+        # 7. Start daemon
+        start_daemon()
 
-    # 9. Notify
-    notify_telegram("Gasclaw is up and running.")
+        # 8. Start mayor
+        start_mayor(agent="kimi-claude")
+        services_started = True
+
+        # 9. Notify
+        notify_telegram("Gasclaw is up and running.")
+
+    except Exception as e:
+        # Rollback: Stop any services that were started
+        if services_started or dolt_started:
+            notify_telegram(f"Bootstrap failed: {e}. Rolling back...")
+            try:
+                stop_all()
+            except Exception as rollback_error:
+                # Log rollback error but raise original exception
+                notify_telegram(f"Rollback error: {rollback_error}")
+        else:
+            notify_telegram(f"Bootstrap failed: {e}")
+
+        # Re-raise the original exception
+        raise RuntimeError(f"Bootstrap failed: {e}") from e
 
 
 def monitor_loop(

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -99,6 +99,107 @@ class TestBootstrap:
             with pytest.raises(RuntimeError, match="boom"):
                 bootstrap(config, gt_root=tmp_path)
 
+    def test_rollback_on_dolt_failure(self, config, tmp_path):
+        """Rollback stops dolt if it was started before failure."""
+        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
+             patch("gasclaw.bootstrap.write_agent_config"), \
+             patch("gasclaw.bootstrap.gastown_install"), \
+             patch("gasclaw.bootstrap.start_dolt") as m_dolt, \
+             patch("gasclaw.bootstrap.stop_all") as m_stop, \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
+
+            m_dolt.side_effect = RuntimeError("dolt failed")
+
+            with pytest.raises(RuntimeError, match="dolt failed"):
+                bootstrap(config, gt_root=tmp_path)
+
+            # Should not call stop_all since dolt failed to start
+            m_stop.assert_not_called()
+            # Should notify of failure
+            assert any("failed" in str(call).lower() for call in m_notify.call_args_list)
+
+    def test_rollback_on_daemon_failure(self, config, tmp_path):
+        """Rollback stops all services if daemon fails to start."""
+        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
+             patch("gasclaw.bootstrap.write_agent_config"), \
+             patch("gasclaw.bootstrap.gastown_install"), \
+             patch("gasclaw.bootstrap.start_dolt"), \
+             patch("gasclaw.bootstrap.write_openclaw_config"), \
+             patch("gasclaw.bootstrap.install_skills"), \
+             patch("gasclaw.bootstrap.run_doctor") as m_doctor, \
+             patch("gasclaw.bootstrap.start_daemon") as m_daemon, \
+             patch("gasclaw.bootstrap.stop_all") as m_stop, \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
+
+            from gasclaw.openclaw.doctor import DoctorResult
+            m_doctor.return_value = DoctorResult(healthy=True, returncode=0, output="OK")
+            m_daemon.side_effect = RuntimeError("daemon failed")
+
+            with pytest.raises(RuntimeError, match="daemon failed"):
+                bootstrap(config, gt_root=tmp_path)
+
+            # Should call stop_all to rollback
+            m_stop.assert_called_once()
+            # Should notify of failure and rollback
+            notify_calls = [str(call) for call in m_notify.call_args_list]
+            assert any("failed" in c.lower() for c in notify_calls)
+            assert any("rolling back" in c.lower() for c in notify_calls)
+
+    def test_rollback_on_mayor_failure(self, config, tmp_path):
+        """Rollback stops all services if mayor fails to start."""
+        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
+             patch("gasclaw.bootstrap.write_agent_config"), \
+             patch("gasclaw.bootstrap.gastown_install"), \
+             patch("gasclaw.bootstrap.start_dolt"), \
+             patch("gasclaw.bootstrap.write_openclaw_config"), \
+             patch("gasclaw.bootstrap.install_skills"), \
+             patch("gasclaw.bootstrap.run_doctor") as m_doctor, \
+             patch("gasclaw.bootstrap.start_daemon"), \
+             patch("gasclaw.bootstrap.start_mayor") as m_mayor, \
+             patch("gasclaw.bootstrap.stop_all") as m_stop, \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
+
+            from gasclaw.openclaw.doctor import DoctorResult
+            m_doctor.return_value = DoctorResult(healthy=True, returncode=0, output="OK")
+            m_mayor.side_effect = RuntimeError("mayor failed")
+
+            with pytest.raises(RuntimeError, match="mayor failed"):
+                bootstrap(config, gt_root=tmp_path)
+
+            # Should call stop_all to rollback
+            m_stop.assert_called_once()
+            # Should notify of failure and rollback
+            notify_calls = [str(call) for call in m_notify.call_args_list]
+            assert any("failed" in c.lower() for c in notify_calls)
+
+    def test_rollback_error_handled(self, config, tmp_path):
+        """Rollback errors are caught and notified but original exception is raised."""
+        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
+             patch("gasclaw.bootstrap.write_agent_config"), \
+             patch("gasclaw.bootstrap.gastown_install"), \
+             patch("gasclaw.bootstrap.start_dolt"), \
+             patch("gasclaw.bootstrap.write_openclaw_config"), \
+             patch("gasclaw.bootstrap.install_skills"), \
+             patch("gasclaw.bootstrap.run_doctor") as m_doctor, \
+             patch("gasclaw.bootstrap.start_daemon"), \
+             patch("gasclaw.bootstrap.start_mayor") as m_mayor, \
+             patch("gasclaw.bootstrap.stop_all") as m_stop, \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
+
+            from gasclaw.openclaw.doctor import DoctorResult
+            m_doctor.return_value = DoctorResult(healthy=True, returncode=0, output="OK")
+            m_mayor.side_effect = RuntimeError("mayor failed")
+            m_stop.side_effect = RuntimeError("rollback also failed")
+
+            with pytest.raises(RuntimeError, match="mayor failed"):
+                bootstrap(config, gt_root=tmp_path)
+
+            # Should still attempt stop_all
+            m_stop.assert_called_once()
+            # Should notify about rollback error
+            notify_calls = [str(call) for call in m_notify.call_args_list]
+            assert any("rollback error" in c.lower() for c in notify_calls)
+
 
 class TestMonitorLoop:
     def test_runs_health_check(self, config, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #19 - Bootstrap sequence now has rollback mechanism to clean up partial failures.

## Changes

- Track which services have been started during bootstrap (`dolt_started`, `services_started`)
- On any failure during bootstrap:
  - Stop any started services using `stop_all()`
  - Send Telegram notification about failure and rollback
- Handle rollback errors gracefully (log but still raise original exception)
- Update docstring to document rollback behavior
- Add comprehensive tests:
  - `test_rollback_on_dolt_failure` - no rollback if dolt didn't start
  - `test_rollback_on_daemon_failure` - rollback stops services
  - `test_rollback_on_mayor_failure` - rollback stops services
  - `test_rollback_error_handled` - rollback errors don't mask original error

## Test Plan

- [x] All 175 unit tests pass
- [x] New rollback tests pass
- [x] Existing bootstrap tests still pass

```bash
make test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)