### PR TITLE
docs: add troubleshooting section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,71 @@ skills/my-skill/
 ```
 
 Skills are automatically installed to `~/.openclaw/skills/` on startup.
+
+## Troubleshooting
+
+### Bootstrap fails with "dolt process exited early"
+
+**Cause:** Dolt SQL server failed to start, often due to port conflicts or data directory issues.
+
+**Solutions:**
+- Check if port 3307 is already in use: `lsof -i :3307`
+- Clear Dolt data directory: `rm -rf /workspace/gt/.dolt-data`
+- Check Dolt logs for specific errors
+
+### "not a git repository" error in health checks
+
+**Cause:** The `project_dir` path doesn't exist or isn't a git repository.
+
+**Solutions:**
+- Verify `PROJECT_DIR` environment variable points to an existing directory
+- Ensure the directory contains a `.git` subdirectory
+- Run `git init` if needed to initialize a git repository
+
+### Keys exhausted / rate limit errors
+
+**Cause:** All Kimi API keys in the pool are rate-limited.
+
+**Solutions:**
+- Wait 5 minutes for rate-limited keys to cool down
+- Add more keys to `GASTOWN_KIMI_KEYS`
+- Check Kimi dashboard for usage limits
+
+### "Activity compliance" alerts
+
+**Cause:** No git commits or PRs within `ACTIVITY_DEADLINE` seconds (default 1 hour).
+
+**Solutions:**
+- Ensure agents are running: check `gt status`
+- Verify `project_dir` is correct and is a git repo
+- Check agent logs for errors
+- Consider increasing `ACTIVITY_DEADLINE` for low-activity periods
+
+### Services show as "unhealthy"
+
+**Cause:** One or more services (dolt, daemon, mayor) are not responding.
+
+**Solutions:**
+- Check service status: `gasclaw status`
+- View service logs: `gt daemon logs`, `gt mayor logs`
+- Restart services: `gasclaw stop && gasclaw start`
+- Check system resources (memory, disk space)
+
+### Bootstrap rollback messages
+
+If you see "Bootstrap failed: ... Rolling back...", the bootstrap sequence encountered an error and attempted to clean up partial state. Check the specific error message and:
+
+- Review environment variables are set correctly
+- Ensure all binaries (`gt`, `dolt`, `openclaw`) are in PATH
+- Check for port conflicts (3307 for Dolt, 18789 for OpenClaw gateway)
+- Verify network connectivity for external API calls
+
+### Telegram bot not responding
+
+**Cause:** Bot token invalid, network issues, or OpenClaw gateway not running.
+
+**Solutions:**
+- Verify `TELEGRAM_BOT_TOKEN` is correct
+- Check `TELEGRAM_OWNER_ID` matches your Telegram user ID
+- Ensure OpenClaw gateway is running: `curl http://localhost:18789/health`
+- Check firewall rules allow outbound connections to Telegram API


### PR DESCRIPTION
## Summary

Fixes #25 - Add troubleshooting section to README for common issues.

## Changes

Add troubleshooting guide covering:
- Dolt startup failures (port conflicts, data directory)
- Git repository errors (missing .git, invalid project_dir)
- Rate limiting / key exhaustion
- Activity compliance alerts
- Service health issues
- Bootstrap rollback messages
- Telegram bot connectivity

## Test Plan

- [x] All 175 unit tests pass
- [x] README renders correctly with markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)