### PR TITLE
feat: add multi-platform Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Go 1.24
-RUN curl -fsSL https://go.dev/dl/go1.24.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+# Go 1.24 (multi-platform: amd64 or arm64)
+ARG TARGETARCH
+RUN curl -fsSL https://go.dev/dl/go1.24.1.linux-${TARGETARCH}.tar.gz | tar -C /usr/local -xzf -
 ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
 
 # Dolt

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ docker compose up -d
 # 4. Chat with your bot on Telegram
 ```
 
+## Platform Support
+
+Gasclaw runs on Linux and macOS (including Apple Silicon) via Docker:
+
+- **Linux (amd64/arm64)**: Native Docker support
+- **macOS Intel (amd64)**: Docker Desktop
+- **macOS Apple Silicon (arm64)**: Docker Desktop with native ARM64 support
+
+The Docker image is multi-platform and automatically selects the correct architecture:
+
+```bash
+# Build for your current platform
+docker compose up -d
+
+# Build for specific platform
+docker compose build --build-arg TARGETARCH=arm64
+```
+
 ## Environment Variables
 
 | Variable | Required | Description |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   gasclaw:
-    build: .
+    build:
+      context: .
+      # Multi-platform support: linux/amd64, linux/arm64 (Apple Silicon)
+      platforms:
+        - linux/amd64
+        - linux/arm64
     container_name: gasclaw
     ports:
       - "18789:18789"


### PR DESCRIPTION
## Summary

Fixes #24 - Add macOS support with multi-platform Docker builds and Apple Silicon compatibility.

## Changes

- Update Dockerfile to use `TARGETARCH` build arg for Go downloads
  - Supports both `linux/amd64` and `linux/arm64`
  - Automatically selects correct architecture during build
- Update docker-compose.yml with multi-platform configuration
  - Add `platforms` section for both architectures
- Add Platform Support section to README
  - Document Linux, macOS Intel, and macOS Apple Silicon support
  - Include build instructions for specific platforms

## Test Plan

- [x] All 175 unit tests pass
- [x] Dockerfile syntax validated
- [x] docker-compose.yml syntax validated

## Notes

Multi-platform builds require Docker Buildx. On macOS with Apple Silicon, Docker Desktop handles the platform selection automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)