### PR TITLE
test: add edge case tests for improved coverage

### DIFF
--- a/tests/unit/test_gastown_agent_config.py
+++ b/tests/unit/test_gastown_agent_config.py
@@ -36,3 +36,28 @@ class TestWriteAgentConfig:
         write_agent_config(tmp_path)
         cfg = json.loads((tmp_path / "settings" / "config.json").read_text())
         assert cfg["default_agent"] == "kimi-claude"
+
+    def test_returns_config_path(self, tmp_path):
+        """Function returns the path to the written config file."""
+        result = write_agent_config(tmp_path)
+        assert result == tmp_path / "settings" / "config.json"
+        assert result.exists()
+
+    def test_overwrites_existing_config(self, tmp_path):
+        """Overwrites existing config file with fresh content."""
+        settings_dir = tmp_path / "settings"
+        settings_dir.mkdir()
+        config_file = settings_dir / "config.json"
+        config_file.write_text('{"old": "content"}')
+
+        write_agent_config(tmp_path)
+
+        cfg = json.loads(config_file.read_text())
+        assert cfg["type"] == "town-settings"
+        assert "old" not in cfg
+
+    def test_creates_nested_directories(self, tmp_path):
+        """Creates nested directories if needed."""
+        deep_path = tmp_path / "a" / "b" / "c" / "gt"
+        write_agent_config(deep_path)
+        assert (deep_path / "settings" / "config.json").exists()

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -176,3 +176,54 @@ class TestKeyPoolAtomicWrite:
         # Temp file should be cleaned up
         temp_files = list(tmp_path.glob(".key-rotation-*.tmp"))
         assert len(temp_files) == 0
+
+
+class TestKeyPoolEdgeCases:
+    def test_creates_state_dir_if_not_exists(self, tmp_path):
+        """State directory is created if it doesn't exist."""
+        nested_dir = tmp_path / "nested" / "state"
+        pool = KeyPool(["k1"], state_dir=nested_dir)
+        pool.get_key()
+        assert nested_dir.exists()
+        assert (nested_dir / "key-rotation.json").exists()
+
+    def test_duplicate_keys_treated_as_separate(self, tmp_path):
+        """Duplicate keys in list are treated as separate entries."""
+        # This tests the behavior when duplicate keys are provided
+        pool = KeyPool(["k1", "k1", "k2"], state_dir=tmp_path)
+        assert pool.total_keys == 3
+
+    def test_empty_string_key_is_valid(self, tmp_path):
+        """Empty string can be a key (edge case)."""
+        pool = KeyPool([""], state_dir=tmp_path)
+        assert pool.get_key() == ""
+
+    def test_key_hash_consistency(self, tmp_path):
+        """Same key produces same hash across instances."""
+        pool1 = KeyPool(["k1"], state_dir=tmp_path)
+        pool2 = KeyPool(["k1"], state_dir=tmp_path)
+        assert pool1._key_hash("k1") == pool2._key_hash("k1")
+
+    def test_mark_nonexistent_key_rate_limited(self, tmp_path):
+        """Marking a key not in pool as rate-limited is handled gracefully."""
+        pool = KeyPool(["k1"], state_dir=tmp_path)
+        # This should not raise an error
+        pool.mark_rate_limited("nonexistent-key")
+        # k1 should still be available
+        assert pool.get_key() == "k1"
+
+    def test_state_file_is_json(self, tmp_path):
+        """State file contains valid JSON with expected structure."""
+        import json
+
+        pool = KeyPool(["k1", "k2"], state_dir=tmp_path)
+        pool.get_key()
+        pool.mark_rate_limited("k2")
+
+        state_file = tmp_path / "key-rotation.json"
+        state = json.loads(state_file.read_text())
+
+        assert "last_used" in state
+        assert "rate_limited" in state
+        assert isinstance(state["last_used"], dict)
+        assert isinstance(state["rate_limited"], dict)

--- a/tests/unit/test_openclaw_skill_manager.py
+++ b/tests/unit/test_openclaw_skill_manager.py
@@ -95,3 +95,43 @@ class TestInstallSkills:
         # Should have new content, not old
         assert "# Health Skill" in (dst / "gastown-health" / "SKILL.md").read_text()
         assert not (dst / "gastown-health" / "old-file.txt").exists()
+
+    def test_empty_source_directory(self, tmp_path):
+        """Empty source directory results in no skills copied."""
+        src = tmp_path / "src-skills"
+        dst = tmp_path / "dst-skills"
+        src.mkdir()
+        install_skills(skills_src=src, skills_dst=dst)
+        assert dst.exists()
+        assert len(list(dst.iterdir())) == 0
+
+    def test_skill_without_scripts_dir(self, tmp_path):
+        """Skills without scripts directory don't cause errors."""
+        src = tmp_path / "src-skills"
+        dst = tmp_path / "dst-skills"
+
+        # Create skill without scripts
+        skill_dir = src / "minimal-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Minimal Skill")
+
+        install_skills(skills_src=src, skills_dst=dst)
+
+        assert (dst / "minimal-skill" / "SKILL.md").exists()
+        assert not (dst / "minimal-skill" / "scripts").exists()
+
+    def test_multiple_skills(self, tmp_path):
+        """Multiple skills are copied correctly."""
+        src = tmp_path / "src-skills"
+        dst = tmp_path / "dst-skills"
+
+        for name in ["skill-a", "skill-b", "skill-c"]:
+            skill_dir = src / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(f"# {name}")
+
+        install_skills(skills_src=src, skills_dst=dst)
+
+        for name in ["skill-a", "skill-b", "skill-c"]:
+            assert (dst / name / "SKILL.md").exists()
+            assert f"# {name}" in (dst / name / "SKILL.md").read_text()

--- a/tests/unit/test_updater_checker.py
+++ b/tests/unit/test_updater_checker.py
@@ -29,3 +29,49 @@ class TestCheckVersions:
         versions = check_versions()
         for v in versions.values():
             assert v == "not installed"
+
+    def test_handles_nonzero_exit(self, monkeypatch):
+        """Non-zero exit code is treated as not installed."""
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 1, stdout=b"", stderr=b"error"
+            ),
+        )
+        versions = check_versions()
+        for v in versions.values():
+            assert v == "not installed"
+
+    def test_handles_timeout(self, monkeypatch):
+        """TimeoutExpired is caught and reported as not installed."""
+        def _timeout(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd=a[0], timeout=10)
+
+        monkeypatch.setattr(subprocess, "run", _timeout)
+        versions = check_versions()
+        for v in versions.values():
+            assert v == "not installed"
+
+    def test_strips_whitespace_from_output(self, monkeypatch):
+        """Version output has whitespace stripped."""
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 0, stdout=b"  1.0.0  \n\r\n"
+            ),
+        )
+        versions = check_versions()
+        for v in versions.values():
+            assert v == "1.0.0"
+
+    def test_includes_kimigas(self, monkeypatch):
+        """Kimigas is included in version checks."""
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 0, stdout=b"0.5.0\n"
+            ),
+        )
+        versions = check_versions()
+        assert "kimigas" in versions
+        assert versions["kimigas"] == "0.5.0"


### PR DESCRIPTION
## Summary

Add 16 new edge case tests to improve test coverage across multiple modules.

## Changes

### test_updater_checker.py (+4 tests)
- `test_handles_nonzero_exit`: Non-zero exit codes treated as "not installed"
- `test_handles_timeout`: TimeoutExpired caught and reported
- `test_strips_whitespace_from_output`: Version output whitespace handling
- `test_includes_kimigas`: Verify kimigas is included in version checks

### test_gastown_agent_config.py (+3 tests)
- `test_returns_config_path`: Function returns correct path
- `test_overwrites_existing_config`: Fresh config on each write
- `test_creates_nested_directories`: Handles deeply nested paths

### test_openclaw_skill_manager.py (+3 tests)
- `test_empty_source_directory`: No errors on empty source
- `test_skill_without_scripts_dir`: Skills without scripts work
- `test_multiple_skills`: Multiple skills copied correctly

### test_kimigas_key_pool.py (+6 tests)
- `test_creates_state_dir_if_not_exists`: Auto-creates state directory
- `test_duplicate_keys_treated_as_separate`: Duplicate key handling
- `test_empty_string_key_is_valid`: Edge case for empty key
- `test_key_hash_consistency`: Hash consistency across instances
- `test_mark_nonexistent_key_rate_limited`: Graceful handling of unknown keys
- `test_state_file_is_json`: Valid JSON structure verification

## Test Plan
- [x] All 191 tests pass
- [x] Ruff linting passes
- [x] New tests follow existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)