### PR TITLE
test: add edge case tests for openclaw installer

### DIFF
--- a/tests/unit/test_openclaw_installer.py
+++ b/tests/unit/test_openclaw_installer.py
@@ -85,3 +85,83 @@ class TestWriteOpenclawConfig:
         models = cfg["agents"]["defaults"].get("models", {})
         # At least one model entry should reference kimi
         assert any("kimi" in k.lower() or "moonshot" in k.lower() for k in models)
+
+    def test_returns_config_path(self, tmp_path):
+        """Function returns the path to the written config file."""
+        result = write_openclaw_config(
+            openclaw_dir=tmp_path,
+            kimi_key="sk-test",
+            bot_token="123:ABC",
+            owner_id="999",
+        )
+        assert result == tmp_path / "openclaw.json"
+        assert result.exists()
+
+    def test_custom_gateway_port(self, tmp_path):
+        """Custom gateway port is used correctly."""
+        write_openclaw_config(
+            openclaw_dir=tmp_path,
+            kimi_key="sk-test",
+            bot_token="123:ABC",
+            owner_id="999",
+            gateway_port=9999,
+        )
+        cfg = json.loads((tmp_path / "openclaw.json").read_text())
+        assert cfg["gateway"]["port"] == 9999
+
+    def test_auth_token_is_unique_per_call(self, tmp_path):
+        """Each call generates a different auth token."""
+        write_openclaw_config(
+            openclaw_dir=tmp_path,
+            kimi_key="sk-test",
+            bot_token="123:ABC",
+            owner_id="999",
+        )
+        cfg1 = json.loads((tmp_path / "openclaw.json").read_text())
+        token1 = cfg1["gateway"]["auth"]["token"]
+
+        write_openclaw_config(
+            openclaw_dir=tmp_path,
+            kimi_key="sk-test",
+            bot_token="123:ABC",
+            owner_id="999",
+        )
+        cfg2 = json.loads((tmp_path / "openclaw.json").read_text())
+        token2 = cfg2["gateway"]["auth"]["token"]
+
+        assert token1 != token2
+        assert len(token1) == 64
+        assert len(token2) == 64
+
+    def test_creates_nested_directory(self, tmp_path):
+        """Creates nested directories if needed."""
+        deep_path = tmp_path / "a" / "b" / "c" / ".openclaw"
+        write_openclaw_config(
+            openclaw_dir=deep_path,
+            kimi_key="sk-test",
+            bot_token="123:ABC",
+            owner_id="999",
+        )
+        assert (deep_path / "openclaw.json").exists()
+
+    def test_kimi_key_in_env(self, tmp_path):
+        """Kimi key is stored in env section."""
+        write_openclaw_config(
+            openclaw_dir=tmp_path,
+            kimi_key="sk-secret-key",
+            bot_token="123:ABC",
+            owner_id="999",
+        )
+        cfg = json.loads((tmp_path / "openclaw.json").read_text())
+        assert cfg["env"]["MOONSHOT_API_KEY"] == "sk-secret-key"
+
+    def test_owner_id_in_allowlist(self, tmp_path):
+        """Owner ID is in the allowlist."""
+        write_openclaw_config(
+            openclaw_dir=tmp_path,
+            kimi_key="sk-test",
+            bot_token="123:ABC",
+            owner_id="555666777",
+        )
+        cfg = json.loads((tmp_path / "openclaw.json").read_text())
+        assert "555666777" in cfg["channels"]["telegram"]["allowFrom"]


### PR DESCRIPTION
## Summary

Add 6 new edge case tests for openclaw installer to improve coverage.

## Changes

### test_openclaw_installer.py (+6 tests)
- `test_returns_config_path`: Verify function returns correct path
- `test_custom_gateway_port`: Custom gateway port handling
- `test_auth_token_is_unique_per_call`: Auth tokens are unique per invocation
- `test_creates_nested_directory`: Nested directory creation
- `test_kimi_key_in_env`: Kimi key stored in env section
- `test_owner_id_in_allowlist`: Owner ID in telegram allowlist

## Test Plan
- [x] All 197 tests pass
- [x] New tests follow existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)