### PR TITLE
test: add edge case tests for 100% coverage

### DIFF
--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -366,3 +366,31 @@ class TestMonitorLoop:
         assert any("dolt" in msg for msg in service_notifications)
         assert any("daemon" in msg for msg in service_notifications)
         assert any("mayor" in msg for msg in service_notifications)
+
+    def test_uses_config_interval_when_none_provided(self, config, monkeypatch):
+        """monitor_loop uses config.monitor_interval when interval=None."""
+        check_count = 0
+
+        def mock_check(**kw):
+            nonlocal check_count
+            check_count += 1
+            if check_count >= 2:
+                raise KeyboardInterrupt
+            from gasclaw.health import HealthReport
+            return HealthReport(
+                dolt="healthy", daemon="healthy", mayor="healthy",
+                openclaw="healthy", agents=["mayor"],
+                activity={"compliant": True, "last_commit_age": 100},
+            )
+
+        activity_return = {"compliant": True, "last_commit_age": 100}
+        config.monitor_interval = 42  # Custom interval
+
+        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
+             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
+             patch("gasclaw.bootstrap.notify_telegram") as m_notify, \
+             patch("time.sleep") as m_sleep:
+            monitor_loop(config, interval=None)  # interval=None triggers line 131
+
+        # Verify sleep was called with the config interval
+        m_sleep.assert_called_with(42)

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -177,6 +177,29 @@ class TestKeyPoolAtomicWrite:
         temp_files = list(tmp_path.glob(".key-rotation-*.tmp"))
         assert len(temp_files) == 0
 
+    def test_oserror_on_unlink_is_ignored(self, tmp_path, monkeypatch):
+        """OSError during temp file cleanup is ignored (line 71-72 coverage)."""
+        pool = KeyPool(["k1"], state_dir=tmp_path)
+
+        # Track if unlink was called
+        unlink_calls = []
+
+        def fail_unlink(*args, **kwargs):
+            unlink_calls.append(args)
+            raise OSError("Cannot unlink")
+
+        monkeypatch.setattr("os.unlink", fail_unlink)
+
+        # Make os.fdopen fail to trigger cleanup path
+        monkeypatch.setattr("os.fdopen", lambda *a, **kw: (_ for _ in ()).throw(OSError("Write failed")))
+
+        # Should raise the original OSError, not the unlink error
+        with pytest.raises(OSError, match="Write failed"):
+            pool._save_state({"test": "data"})
+
+        # Unlink should have been attempted
+        assert len(unlink_calls) >= 1
+
 
 class TestKeyPoolEdgeCases:
     def test_creates_state_dir_if_not_exists(self, tmp_path):


### PR DESCRIPTION
## Summary

Adds edge case tests to achieve 100% code coverage:

1. `test_uses_config_interval_when_none_provided`: Tests that `monitor_loop` uses `config.monitor_interval` when `interval=None` is passed (covers line 131 in bootstrap.py)

2. `test_oserror_on_unlink_is_ignored`: Tests that `KeyPool._save_state()` handles OSError during temp file cleanup gracefully (covers lines 71-72 in key_pool.py)

## Test plan

- [x] `python -m pytest tests/unit -v` passes (214 tests)
- [x] Coverage now at 100% for bootstrap.py and key_pool.py