### PR TITLE
style: fix lint issues in edge case tests

### DIFF
--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -388,7 +388,7 @@ class TestMonitorLoop:
 
         with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
              patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify, \
+             patch("gasclaw.bootstrap.notify_telegram"), \
              patch("time.sleep") as m_sleep:
             monitor_loop(config, interval=None)  # interval=None triggers line 131
 

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -191,7 +191,9 @@ class TestKeyPoolAtomicWrite:
         monkeypatch.setattr("os.unlink", fail_unlink)
 
         # Make os.fdopen fail to trigger cleanup path
-        monkeypatch.setattr("os.fdopen", lambda *a, **kw: (_ for _ in ()).throw(OSError("Write failed")))
+        def fail_fdopen(*a, **kw):
+            raise OSError("Write failed")
+        monkeypatch.setattr("os.fdopen", fail_fdopen)
 
         # Should raise the original OSError, not the unlink error
         with pytest.raises(OSError, match="Write failed"):


### PR DESCRIPTION
## Summary

Fix lint issues introduced in PR #44:

- Remove unused variable `m_notify`
- Break long lambda line into proper function definition

## Test plan

- [x] `ruff check src tests` passes
- [x] `python -m pytest tests/unit -v` passes (214 tests)