### PR TITLE
style: apply ruff format to all source files

### DIFF
--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -32,7 +32,8 @@ console = Console()
 @app.callback()
 def main(
     version: bool | None = typer.Option(
-        None, "--version",
+        None,
+        "--version",
         callback=version_callback,
         is_eager=True,
         help="Show version and exit.",

--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -58,16 +58,14 @@ def _parse_positive_int(value: str, default: int, name: str = "") -> int:
         if result <= 0:
             if name:
                 logger.warning(
-                    "Invalid %s: %r must be positive, using default %d",
-                    name, value, default
+                    "Invalid %s: %r must be positive, using default %d", name, value, default
                 )
             return default
         return result
     except (ValueError, TypeError):
         if name:
             logger.warning(
-                "Invalid %s: %r is not a valid integer, using default %d",
-                name, value, default
+                "Invalid %s: %r is not a valid integer, using default %d", name, value, default
             )
         return default
 

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -85,10 +85,7 @@ def _list_agents() -> list[str]:
             timeout=10,
         )
         if result.returncode == 0:
-            return [
-                line.strip() for line in result.stdout.decode().splitlines()
-                if line.strip()
-            ]
+            return [line.strip() for line in result.stdout.decode().splitlines() if line.strip()]
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
     return []

--- a/src/gasclaw/kimigas/key_pool.py
+++ b/src/gasclaw/kimigas/key_pool.py
@@ -56,12 +56,10 @@ class KeyPool:
 
         # Write to temp file in same directory, then rename atomically
         fd, temp_path = tempfile.mkstemp(
-            dir=self._state_dir,
-            prefix=".key-rotation-",
-            suffix=".tmp"
+            dir=self._state_dir, prefix=".key-rotation-", suffix=".tmp"
         )
         try:
-            with os.fdopen(fd, 'w') as f:
+            with os.fdopen(fd, "w") as f:
                 json.dump(state, f, indent=2)
             os.replace(temp_path, state_file)
         except Exception:
@@ -83,7 +81,8 @@ class KeyPool:
 
         rate_limited: dict[str, float] = state.get("rate_limited", {})
         available = [
-            k for k in self._keys
+            k
+            for k in self._keys
             if now - rate_limited.get(self._key_hash(k), 0) > RATE_LIMIT_COOLDOWN
         ]
 
@@ -121,7 +120,8 @@ class KeyPool:
         rate_limited: dict[str, float] = state.get("rate_limited", {})
 
         rl_count = sum(
-            1 for k in self._keys
+            1
+            for k in self._keys
             if now - rate_limited.get(self._key_hash(k), 0) <= RATE_LIMIT_COOLDOWN
         )
 

--- a/src/gasclaw/openclaw/installer.py
+++ b/src/gasclaw/openclaw/installer.py
@@ -12,6 +12,7 @@ def _generate_auth_token() -> str:
     """Generate a random 64-char hex token."""
     return hashlib.sha256(os.urandom(32)).hexdigest()
 
+
 __all__ = ["write_openclaw_config"]
 
 

--- a/tests/integration/test_bootstrap_integration.py
+++ b/tests/integration/test_bootstrap_integration.py
@@ -36,16 +36,17 @@ def config():
 @pytest.fixture
 def mock_subprocess_success(monkeypatch):
     """Mock all subprocess calls to succeed."""
+
     def mock_run(*args, **kwargs):
         return subprocess.CompletedProcess(args[0], 0, stdout=b"ok", stderr=b"")
-    
+
     def mock_popen(*args, **kwargs):
         mock_proc = MagicMock()
         mock_proc.pid = 1234
         mock_proc.poll.return_value = None
         mock_proc.returncode = 0
         return mock_proc
-    
+
     monkeypatch.setattr(subprocess, "run", mock_run)
     monkeypatch.setattr(subprocess, "Popen", mock_popen)
 
@@ -57,7 +58,7 @@ class TestBootstrapIntegration:
         """Test complete bootstrap with respx mocking HTTP calls."""
         gt_root = tmp_path / "gt"
         gt_root.mkdir()
-        
+
         # Track all the calls to verify integration
         calls = {
             "kimi_accounts": False,
@@ -71,9 +72,9 @@ class TestBootstrapIntegration:
             "mayor_start": False,
             "telegram_notify": False,
         }
-        
+
         mock_doctor = DoctorResult(healthy=True, returncode=0, output="All checks passed")
-        
+
         with patch("gasclaw.bootstrap.setup_kimi_accounts") as m_kimi:
             m_kimi.side_effect = lambda keys: calls.update({"kimi_accounts": True})
             with patch("gasclaw.bootstrap.write_agent_config") as m_agent:
@@ -85,39 +86,45 @@ class TestBootstrapIntegration:
                         with patch("gasclaw.bootstrap.write_openclaw_config") as m_oc:
                             m_oc.side_effect = lambda **kw: calls.update({"openclaw_config": True})
                             with patch("gasclaw.bootstrap.install_skills") as m_skills:
-                                m_skills.side_effect = (
-                                    lambda **kw: calls.update({"skills_install": True})
+                                m_skills.side_effect = lambda **kw: calls.update(
+                                    {"skills_install": True}
                                 )
                                 with patch(
                                     "gasclaw.bootstrap.run_doctor", return_value=mock_doctor
                                 ) as m_doctor:
+
                                     def doctor_side_effect(**kw):
                                         calls.update({"doctor": True})
                                         return mock_doctor
+
                                     m_doctor.side_effect = doctor_side_effect
                                     with patch("gasclaw.bootstrap.start_daemon") as m_daemon:
-                                        m_daemon.side_effect = (
-                                            lambda: calls.update({"daemon_start": True})
+                                        m_daemon.side_effect = lambda: calls.update(
+                                            {"daemon_start": True}
                                         )
                                         with patch("gasclaw.bootstrap.start_mayor") as m_mayor:
-                                            m_mayor.side_effect = (
-                                                lambda **kw: calls.update({"mayor_start": True})
+                                            m_mayor.side_effect = lambda **kw: calls.update(
+                                                {"mayor_start": True}
                                             )
                                             with respx.mock:
                                                 # Mock Telegram gateway
-                                                respx.post("http://localhost:18789/api/message").mock(
+                                                respx.post(
+                                                    "http://localhost:18789/api/message"
+                                                ).mock(
                                                     return_value=Response(200, json={"ok": True})
                                                 )
                                                 with patch(
                                                     "gasclaw.bootstrap.notify_telegram"
                                                 ) as m_notify:
+
                                                     def notify_side_effect(msg):
                                                         calls.update({"telegram_notify": True})
+
                                                     m_notify.side_effect = notify_side_effect
-                                                    
+
                                                     # Run bootstrap
                                                     bootstrap(config, gt_root=gt_root)
-        
+
         # Verify all subsystems were called
         assert all(calls.values()), f"Not all subsystems called: {calls}"
 
@@ -125,27 +132,26 @@ class TestBootstrapIntegration:
         """Test bootstrap handles doctor issues gracefully."""
         gt_root = tmp_path / "gt"
         gt_root.mkdir()
-        
+
         # Doctor reports issues but bootstrap continues
         mock_doctor = DoctorResult(
-            healthy=False, 
-            returncode=1, 
-            output="Config issue: missing skill"
+            healthy=False, returncode=1, output="Config issue: missing skill"
         )
-        
-        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
-             patch("gasclaw.bootstrap.write_agent_config"), \
-             patch("gasclaw.bootstrap.gastown_install"), \
-             patch("gasclaw.bootstrap.start_dolt"), \
-             patch("gasclaw.bootstrap.write_openclaw_config"), \
-             patch("gasclaw.bootstrap.install_skills"), \
-             patch("gasclaw.bootstrap.run_doctor", return_value=mock_doctor) as m_doctor, \
-             patch("gasclaw.bootstrap.start_daemon") as m_daemon, \
-             patch("gasclaw.bootstrap.start_mayor") as m_mayor, \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
-            
+
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts"),
+            patch("gasclaw.bootstrap.write_agent_config"),
+            patch("gasclaw.bootstrap.gastown_install"),
+            patch("gasclaw.bootstrap.start_dolt"),
+            patch("gasclaw.bootstrap.write_openclaw_config"),
+            patch("gasclaw.bootstrap.install_skills"),
+            patch("gasclaw.bootstrap.run_doctor", return_value=mock_doctor) as m_doctor,
+            patch("gasclaw.bootstrap.start_daemon") as m_daemon,
+            patch("gasclaw.bootstrap.start_mayor") as m_mayor,
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+        ):
             bootstrap(config, gt_root=gt_root)
-            
+
             # Doctor should be called with repair=True
             m_doctor.assert_called_once_with(repair=True)
             # Should notify about issues
@@ -158,31 +164,35 @@ class TestBootstrapIntegration:
         """Test that services start in correct dependency order."""
         gt_root = tmp_path / "gt"
         gt_root.mkdir()
-        
+
         call_order = []
         mock_doctor = DoctorResult(healthy=True, returncode=0, output="OK")
-        
+
         def track_call(name):
             def wrapper(*args, **kwargs):
                 call_order.append(name)
+
             return wrapper
-        
-        with patch("gasclaw.bootstrap.setup_kimi_accounts", side_effect=track_call("kimi")), \
-             patch("gasclaw.bootstrap.write_agent_config",
-                   side_effect=track_call("agent_config")), \
-             patch("gasclaw.bootstrap.gastown_install", side_effect=track_call("install")), \
-             patch("gasclaw.bootstrap.start_dolt", side_effect=track_call("dolt")), \
-             patch("gasclaw.bootstrap.write_openclaw_config",
-                   side_effect=track_call("openclaw_config")), \
-             patch("gasclaw.bootstrap.install_skills", side_effect=track_call("skills")), \
-             patch("gasclaw.bootstrap.run_doctor",
-                   side_effect=lambda **kw: (track_call("doctor")(kw), mock_doctor)[1]), \
-             patch("gasclaw.bootstrap.start_daemon", side_effect=track_call("daemon")), \
-             patch("gasclaw.bootstrap.start_mayor", side_effect=track_call("mayor")), \
-             patch("gasclaw.bootstrap.notify_telegram", side_effect=track_call("notify")):
-            
+
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts", side_effect=track_call("kimi")),
+            patch("gasclaw.bootstrap.write_agent_config", side_effect=track_call("agent_config")),
+            patch("gasclaw.bootstrap.gastown_install", side_effect=track_call("install")),
+            patch("gasclaw.bootstrap.start_dolt", side_effect=track_call("dolt")),
+            patch(
+                "gasclaw.bootstrap.write_openclaw_config", side_effect=track_call("openclaw_config")
+            ),
+            patch("gasclaw.bootstrap.install_skills", side_effect=track_call("skills")),
+            patch(
+                "gasclaw.bootstrap.run_doctor",
+                side_effect=lambda **kw: (track_call("doctor")(kw), mock_doctor)[1],
+            ),
+            patch("gasclaw.bootstrap.start_daemon", side_effect=track_call("daemon")),
+            patch("gasclaw.bootstrap.start_mayor", side_effect=track_call("mayor")),
+            patch("gasclaw.bootstrap.notify_telegram", side_effect=track_call("notify")),
+        ):
             bootstrap(config, gt_root=gt_root)
-        
+
         # Verify critical ordering constraints
         assert call_order.index("kimi") < call_order.index("install")
         assert call_order.index("install") < call_order.index("dolt")
@@ -200,31 +210,32 @@ class TestMonitorLoopIntegration:
         """Test monitor loop runs health checks in a cycle."""
         health_calls = []
         activity_calls = []
-        
+
         def mock_check_health(**kw):
             health_calls.append(1)
             if len(health_calls) >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
                 dolt="healthy",
-                daemon="healthy", 
+                daemon="healthy",
                 mayor="healthy",
                 openclaw="healthy",
                 agents=["mayor"],
             )
-        
+
         def mock_check_activity(**kw):
             activity_calls.append(kw)
             return {"compliant": True, "last_commit_age": 300}
-        
+
         monkeypatch.setattr("gasclaw.bootstrap.check_health", mock_check_health)
         monkeypatch.setattr("gasclaw.bootstrap.check_agent_activity", mock_check_activity)
         monkeypatch.setattr("gasclaw.bootstrap.notify_telegram", lambda msg: None)
         monkeypatch.setattr("time.sleep", lambda x: None)
-        
+
         monitor_loop(config, interval=1)
-        
+
         assert len(health_calls) >= 1
         assert len(activity_calls) >= 1
 
@@ -232,12 +243,13 @@ class TestMonitorLoopIntegration:
         """Test monitor loop notifies when a service is unhealthy."""
         notifications = []
         call_count = [0]
-        
+
         def mock_check_health(**kw):
             call_count[0] += 1
             if call_count[0] >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
                 dolt="healthy",
                 daemon="unhealthy",  # Service down
@@ -245,20 +257,19 @@ class TestMonitorLoopIntegration:
                 openclaw="healthy",
                 agents=[],
             )
-        
+
         monkeypatch.setattr("gasclaw.bootstrap.check_health", mock_check_health)
         monkeypatch.setattr(
             "gasclaw.bootstrap.check_agent_activity",
-            lambda **kw: {"compliant": True, "last_commit_age": 300}
+            lambda **kw: {"compliant": True, "last_commit_age": 300},
         )
         monkeypatch.setattr(
-            "gasclaw.bootstrap.notify_telegram",
-            lambda msg: notifications.append(msg)
+            "gasclaw.bootstrap.notify_telegram", lambda msg: notifications.append(msg)
         )
         monkeypatch.setattr("time.sleep", lambda x: None)
-        
+
         monitor_loop(config, interval=1)
-        
+
         # Should have notified about unhealthy daemon
         assert any(
             "daemon" in msg.lower() or "service down" in msg.lower() for msg in notifications
@@ -268,33 +279,33 @@ class TestMonitorLoopIntegration:
         """Test monitor loop notifies when activity deadline is violated."""
         notifications = []
         call_count = [0]
-        
+
         def mock_check_health(**kw):
             call_count[0] += 1
             if call_count[0] >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
                 dolt="healthy",
                 daemon="healthy",
-                mayor="healthy", 
+                mayor="healthy",
                 openclaw="healthy",
                 agents=["mayor"],
             )
-        
+
         monkeypatch.setattr("gasclaw.bootstrap.check_health", mock_check_health)
         monkeypatch.setattr(
             "gasclaw.bootstrap.check_agent_activity",
-            lambda **kw: {"compliant": False, "last_commit_age": 5000}  # Not compliant
+            lambda **kw: {"compliant": False, "last_commit_age": 5000},  # Not compliant
         )
         monkeypatch.setattr(
-            "gasclaw.bootstrap.notify_telegram",
-            lambda msg: notifications.append(msg)
+            "gasclaw.bootstrap.notify_telegram", lambda msg: notifications.append(msg)
         )
         monkeypatch.setattr("time.sleep", lambda x: None)
-        
+
         monitor_loop(config, interval=1)
-        
+
         # Should have notified about activity violation
         assert any("activity" in msg.lower() or "alert" in msg.lower() for msg in notifications)
 
@@ -305,14 +316,15 @@ class TestMonitorLoopIntegration:
         respx.post("http://localhost:18789/api/message").mock(
             return_value=Response(200, json={"ok": True})
         )
-        
+
         call_count = [0]
-        
+
         def mock_check_health(**kw):
             call_count[0] += 1
             if call_count[0] >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
                 dolt="healthy",
                 daemon="healthy",
@@ -320,14 +332,14 @@ class TestMonitorLoopIntegration:
                 openclaw="healthy",
                 agents=["mayor"],
             )
-        
+
         monkeypatch.setattr("gasclaw.bootstrap.check_health", mock_check_health)
         monkeypatch.setattr(
             "gasclaw.bootstrap.check_agent_activity",
-            lambda **kw: {"compliant": True, "last_commit_age": 300}
+            lambda **kw: {"compliant": True, "last_commit_age": 300},
         )
         monkeypatch.setattr("time.sleep", lambda x: None)
-        
+
         # Use actual notify_telegram which makes HTTP calls
         monitor_loop(config, interval=1)
 
@@ -335,22 +347,35 @@ class TestMonitorLoopIntegration:
         """Test monitor loop respects configured interval."""
         sleep_calls = []
         call_count = [0]
-        
+
         def mock_sleep(seconds):
             sleep_calls.append(seconds)
             call_count[0] += 1
             if call_count[0] >= 2:
                 raise KeyboardInterrupt
-        
-        monkeypatch.setattr("gasclaw.bootstrap.check_health", lambda **kw: 
-            type("R", (), {"dolt": "healthy", "daemon": "healthy", "mayor": "healthy",
-                          "openclaw": "healthy", "agents": []})())
-        monkeypatch.setattr("gasclaw.bootstrap.check_agent_activity", 
-                           lambda **kw: {"compliant": True, "last_commit_age": 300})
+
+        monkeypatch.setattr(
+            "gasclaw.bootstrap.check_health",
+            lambda **kw: type(
+                "R",
+                (),
+                {
+                    "dolt": "healthy",
+                    "daemon": "healthy",
+                    "mayor": "healthy",
+                    "openclaw": "healthy",
+                    "agents": [],
+                },
+            )(),
+        )
+        monkeypatch.setattr(
+            "gasclaw.bootstrap.check_agent_activity",
+            lambda **kw: {"compliant": True, "last_commit_age": 300},
+        )
         monkeypatch.setattr("gasclaw.bootstrap.notify_telegram", lambda msg: None)
         monkeypatch.setattr("time.sleep", mock_sleep)
-        
+
         custom_interval = 120
         monitor_loop(config, interval=custom_interval)
-        
+
         assert all(s == custom_interval for s in sleep_calls)

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -40,20 +40,20 @@ class TestStartCommandIntegration:
         """Test start command runs full bootstrap and monitor workflow."""
         bootstrap_called = []
         monitor_called = []
-        
+
         def mock_bootstrap(cfg, gt_root):
             bootstrap_called.append((cfg, gt_root))
-        
+
         def mock_monitor(cfg):
             monitor_called.append(cfg)
             raise KeyboardInterrupt  # Exit after one iteration
-        
+
         monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
         monkeypatch.setattr("gasclaw.cli.bootstrap", mock_bootstrap)
         monkeypatch.setattr("gasclaw.cli.monitor_loop", mock_monitor)
-        
+
         result = runner.invoke(app, ["start", "--gt-root", str(tmp_path)])
-        
+
         # KeyboardInterrupt causes exit code 130 (128 + SIGINT)
         assert result.exit_code in (0, 130)
         assert len(bootstrap_called) == 1
@@ -66,11 +66,11 @@ class TestStartCommandIntegration:
         """Test start command handles config loading errors."""
         monkeypatch.setattr(
             "gasclaw.cli.load_config",
-            lambda: (_ for _ in ()).throw(ValueError("Missing required env: TEST_KEY"))
+            lambda: (_ for _ in ()).throw(ValueError("Missing required env: TEST_KEY")),
         )
-        
+
         result = runner.invoke(app, ["start"])
-        
+
         assert result.exit_code == 1
         assert "Config error" in result.output
 
@@ -79,11 +79,11 @@ class TestStartCommandIntegration:
         monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
         monkeypatch.setattr(
             "gasclaw.cli.bootstrap",
-            lambda cfg, gt_root: (_ for _ in ()).throw(RuntimeError("Bootstrap failed"))
+            lambda cfg, gt_root: (_ for _ in ()).throw(RuntimeError("Bootstrap failed")),
         )
-        
+
         result = runner.invoke(app, ["start", "--gt-root", str(tmp_path)])
-        
+
         assert result.exit_code != 0
         assert "Bootstrap failed" in result.output or result.exit_code == 1
 
@@ -95,9 +95,9 @@ class TestStopCommandIntegration:
         """Test stop command stops all services."""
         stop_calls = []
         monkeypatch.setattr("gasclaw.cli.stop_all", lambda: stop_calls.append(1))
-        
+
         result = runner.invoke(app, ["stop"])
-        
+
         assert result.exit_code == 0
         assert len(stop_calls) == 1
         assert "Stopping all services" in result.output
@@ -105,13 +105,14 @@ class TestStopCommandIntegration:
 
     def test_stop_handles_errors_gracefully(self, monkeypatch):
         """Test stop command handles service stop errors."""
+
         def failing_stop():
             raise RuntimeError("Service stop failed")
-        
+
         monkeypatch.setattr("gasclaw.cli.stop_all", failing_stop)
-        
+
         result = runner.invoke(app, ["stop"])
-        
+
         # Should propagate error
         assert result.exit_code != 0
 
@@ -122,7 +123,7 @@ class TestStatusCommandIntegration:
     def test_status_shows_all_services_healthy(self, monkeypatch):
         """Test status command with all services healthy."""
         from gasclaw.health import HealthReport
-        
+
         def mock_check_health(**kw):
             return HealthReport(
                 dolt="healthy",
@@ -134,15 +135,14 @@ class TestStatusCommandIntegration:
                 key_pool={"total": 5, "available": 5},
                 activity={"compliant": True, "last_commit_age": 300},
             )
-        
+
         monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
         monkeypatch.setattr(
-            "gasclaw.cli.load_config",
-            lambda: (_ for _ in ()).throw(ValueError("no config"))
+            "gasclaw.cli.load_config", lambda: (_ for _ in ()).throw(ValueError("no config"))
         )
-        
+
         result = runner.invoke(app, ["status"])
-        
+
         assert result.exit_code == 0
         assert "Gasclaw Status" in result.output
         assert "healthy" in result.output
@@ -151,7 +151,7 @@ class TestStatusCommandIntegration:
     def test_status_shows_unhealthy_services(self, monkeypatch):
         """Test status command shows unhealthy services in red."""
         from gasclaw.health import HealthReport
-        
+
         def mock_check_health(**kw):
             return HealthReport(
                 dolt="unhealthy",
@@ -160,22 +160,21 @@ class TestStatusCommandIntegration:
                 openclaw="healthy",
                 agents=[],
             )
-        
+
         monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
         monkeypatch.setattr(
-            "gasclaw.cli.load_config",
-            lambda: (_ for _ in ()).throw(ValueError("no config"))
+            "gasclaw.cli.load_config", lambda: (_ for _ in ()).throw(ValueError("no config"))
         )
-        
+
         result = runner.invoke(app, ["status"])
-        
+
         assert result.exit_code == 0
         assert "unhealthy" in result.output
 
     def test_status_with_full_config(self, config, monkeypatch):
         """Test status command with config loaded shows all info."""
         from gasclaw.health import HealthReport
-        
+
         def mock_check_health(**kw):
             return HealthReport(
                 dolt="healthy",
@@ -184,20 +183,20 @@ class TestStatusCommandIntegration:
                 openclaw="healthy",
                 agents=["mayor"],
             )
-        
+
         monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
         monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
         monkeypatch.setattr(
             "gasclaw.cli.check_agent_activity",
-            lambda **kw: {"compliant": True, "last_commit_age": 600}
+            lambda **kw: {"compliant": True, "last_commit_age": 600},
         )
         monkeypatch.setattr(
             "gasclaw.cli.KeyPool",
-            MagicMock(return_value=MagicMock(status=lambda: {"total": 3, "available": 2}))
+            MagicMock(return_value=MagicMock(status=lambda: {"total": 3, "available": 2})),
         )
-        
+
         result = runner.invoke(app, ["status"])
-        
+
         assert result.exit_code == 0
         assert "Gasclaw Status" in result.output
         # Should show activity status
@@ -208,7 +207,7 @@ class TestStatusCommandIntegration:
     def test_status_with_activity_violation(self, config, monkeypatch):
         """Test status command shows activity violations."""
         from gasclaw.health import HealthReport
-        
+
         def mock_check_health(**kw):
             return HealthReport(
                 dolt="healthy",
@@ -217,20 +216,20 @@ class TestStatusCommandIntegration:
                 openclaw="healthy",
                 agents=["mayor"],
             )
-        
+
         monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
         monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
         monkeypatch.setattr(
             "gasclaw.cli.check_agent_activity",
-            lambda **kw: {"compliant": False, "last_commit_age": 5000}
+            lambda **kw: {"compliant": False, "last_commit_age": 5000},
         )
         monkeypatch.setattr(
             "gasclaw.cli.KeyPool",
-            MagicMock(return_value=MagicMock(status=lambda: {"total": 3, "available": 3}))
+            MagicMock(return_value=MagicMock(status=lambda: {"total": 3, "available": 3})),
         )
-        
+
         result = runner.invoke(app, ["status"])
-        
+
         assert result.exit_code == 0
         # Should show non-compliant status
         assert "not compliant" in result.output.lower() or "non-compliant" in result.output.lower()
@@ -243,15 +242,15 @@ class TestUpdateCommandIntegration:
         """Test update command checks versions and applies updates."""
         monkeypatch.setattr(
             "gasclaw.cli.check_versions",
-            lambda: {"gt": "1.0.0", "claude": "2.0.0", "openclaw": "0.5.0"}
+            lambda: {"gt": "1.0.0", "claude": "2.0.0", "openclaw": "0.5.0"},
         )
         monkeypatch.setattr(
             "gasclaw.cli.apply_updates",
-            lambda: {"gt": "updated", "claude": "up-to-date", "openclaw": "updated"}
+            lambda: {"gt": "updated", "claude": "up-to-date", "openclaw": "updated"},
         )
-        
+
         result = runner.invoke(app, ["update"])
-        
+
         assert result.exit_code == 0
         assert "Checking versions" in result.output
         assert "gt:" in result.output
@@ -262,16 +261,15 @@ class TestUpdateCommandIntegration:
     def test_update_with_failed_updates(self, monkeypatch):
         """Test update command handles failed updates."""
         monkeypatch.setattr(
-            "gasclaw.cli.check_versions",
-            lambda: {"gt": "1.0.0", "claude": "not installed"}
+            "gasclaw.cli.check_versions", lambda: {"gt": "1.0.0", "claude": "not installed"}
         )
         monkeypatch.setattr(
             "gasclaw.cli.apply_updates",
-            lambda: {"gt": "updated", "claude": "failed: network error"}
+            lambda: {"gt": "updated", "claude": "failed: network error"},
         )
-        
+
         result = runner.invoke(app, ["update"])
-        
+
         assert result.exit_code == 0
         # Should show both successful and failed updates
         assert "updated" in result.output
@@ -281,9 +279,9 @@ class TestUpdateCommandIntegration:
         """Test update command handles empty version results."""
         monkeypatch.setattr("gasclaw.cli.check_versions", lambda: {})
         monkeypatch.setattr("gasclaw.cli.apply_updates", lambda: {})
-        
+
         result = runner.invoke(app, ["update"])
-        
+
         assert result.exit_code == 0
         assert "Checking versions" in result.output
         assert "Applying updates" in result.output
@@ -296,12 +294,10 @@ class TestCLIWithHTTPMocking:
     def test_status_with_gateway_http_check(self, monkeypatch):
         """Test status command with HTTP gateway health check."""
         from gasclaw.health import HealthReport
-        
+
         # Mock the gateway health endpoint
-        respx.get("http://localhost:18789/health").mock(
-            return_value=Response(200, text="healthy")
-        )
-        
+        respx.get("http://localhost:18789/health").mock(return_value=Response(200, text="healthy"))
+
         def mock_check_health(**kw):
             # Simulate the actual health check that would use HTTP
             return HealthReport(
@@ -311,15 +307,14 @@ class TestCLIWithHTTPMocking:
                 openclaw="healthy",  # Would be determined by HTTP check
                 agents=["mayor"],
             )
-        
+
         monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
         monkeypatch.setattr(
-            "gasclaw.cli.load_config",
-            lambda: (_ for _ in ()).throw(ValueError("no config"))
+            "gasclaw.cli.load_config", lambda: (_ for _ in ()).throw(ValueError("no config"))
         )
-        
+
         result = runner.invoke(app, ["status"])
-        
+
         assert result.exit_code == 0
         assert "healthy" in result.output
 
@@ -332,34 +327,33 @@ class TestCLIErrorHandling:
         monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
         monkeypatch.setattr("gasclaw.cli.bootstrap", lambda cfg, gt_root: None)
         monkeypatch.setattr(
-            "gasclaw.cli.monitor_loop",
-            lambda cfg: (_ for _ in ()).throw(KeyboardInterrupt)
+            "gasclaw.cli.monitor_loop", lambda cfg: (_ for _ in ()).throw(KeyboardInterrupt)
         )
-        
+
         result = runner.invoke(app, ["start", "--gt-root", str(tmp_path)])
-        
+
         # KeyboardInterrupt should be handled gracefully
         assert result.exit_code == 0
 
     def test_start_with_custom_gt_root(self, config, monkeypatch, tmp_path):
         """Test start command with custom gt-root option."""
         captured_gt_root = []
-        
+
         def mock_bootstrap(cfg, gt_root):
             captured_gt_root.append(gt_root)
-        
+
         def mock_monitor(cfg):
             raise KeyboardInterrupt
-        
+
         monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
         monkeypatch.setattr("gasclaw.cli.bootstrap", mock_bootstrap)
         monkeypatch.setattr("gasclaw.cli.monitor_loop", mock_monitor)
-        
+
         custom_path = tmp_path / "custom" / "gt"
         custom_path.mkdir(parents=True)
-        
+
         result = runner.invoke(app, ["start", "--gt-root", str(custom_path)])
-        
+
         assert result.exit_code == 0
         assert len(captured_gt_root) == 1
         assert captured_gt_root[0] == custom_path

--- a/tests/integration/test_health_integration.py
+++ b/tests/integration/test_health_integration.py
@@ -17,17 +17,18 @@ class TestHealthCheckIntegration:
 
     def test_full_health_report_with_all_services_healthy(self, monkeypatch):
         """Test complete health report when all services are healthy."""
+
         def mock_subprocess_run(cmd, **kwargs):
             # Return success for all service checks
             return subprocess.CompletedProcess(cmd, 0, stdout=b"running", stderr=b"")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
+
         with patch("gasclaw.health.run_doctor") as mock_doctor:
             mock_doctor.return_value = MagicMock(healthy=True, returncode=0, output="OK")
-            
+
             report = check_health(gateway_port=18789)
-        
+
         assert isinstance(report, HealthReport)
         assert report.dolt == "healthy"
         assert report.daemon == "healthy"
@@ -37,9 +38,10 @@ class TestHealthCheckIntegration:
 
     def test_health_report_with_mixed_service_status(self, monkeypatch):
         """Test health report with some services up, some down."""
+
         def mock_subprocess_run(cmd, **kwargs):
             cmd_str = " ".join(str(c) for c in cmd)
-            
+
             if "dolt" in cmd_str:
                 return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")  # Healthy
             elif "daemon" in cmd_str:
@@ -50,16 +52,16 @@ class TestHealthCheckIntegration:
                 return subprocess.CompletedProcess(cmd, 0, stdout=b"healthy")  # Healthy
             elif "gt status" in cmd_str:
                 return subprocess.CompletedProcess(cmd, 0, stdout=b"mayor\n")
-            
+
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
+
         with patch("gasclaw.health.run_doctor") as mock_doctor:
             mock_doctor.return_value = MagicMock(healthy=True, returncode=0, output="OK")
-            
+
             report = check_health(gateway_port=18789)
-        
+
         assert report.dolt == "healthy"
         assert report.daemon == "unhealthy"
         assert report.mayor == "healthy"
@@ -69,53 +71,51 @@ class TestHealthCheckIntegration:
     def test_health_report_with_doctor_failure(self, monkeypatch):
         """Test health report when openclaw doctor fails."""
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok")
+            subprocess, "run", lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok")
         )
-        
+
         with patch("gasclaw.health.run_doctor") as mock_doctor:
             mock_doctor.return_value = MagicMock(
-                healthy=False, 
-                returncode=1, 
-                output="Missing config"
+                healthy=False, returncode=1, output="Missing config"
             )
-            
+
             report = check_health(gateway_port=18789)
-        
+
         assert report.openclaw_doctor == "unhealthy"
 
     def test_health_report_with_gateway_timeout(self, monkeypatch):
         """Test health report when gateway check times out."""
+
         def mock_subprocess_run(cmd, **kwargs):
             if "curl" in str(cmd):
                 raise subprocess.TimeoutExpired(cmd, 10)
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
+
         with patch("gasclaw.health.run_doctor") as mock_doctor:
             mock_doctor.return_value = MagicMock(healthy=True, returncode=0, output="OK")
-            
+
             report = check_health(gateway_port=18789)
-        
+
         assert report.openclaw == "unhealthy"
 
     def test_health_report_lists_multiple_agents(self, monkeypatch):
         """Test health report correctly lists multiple running agents."""
         agents_output = b"mayor\ndeacon\nwitness\ncrew-1\ncrew-2\ncrew-3\n"
-        
+
         def mock_subprocess_run(cmd, **kwargs):
             if "gt status --agents" in " ".join(str(c) for c in cmd):
                 return subprocess.CompletedProcess(cmd, 0, stdout=agents_output)
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
+
         with patch("gasclaw.health.run_doctor") as mock_doctor:
             mock_doctor.return_value = MagicMock(healthy=True, returncode=0, output="OK")
-            
+
             report = check_health(gateway_port=18789)
-        
+
         assert len(report.agents) == 6
         assert "mayor" in report.agents
         assert "deacon" in report.agents
@@ -123,34 +123,36 @@ class TestHealthCheckIntegration:
 
     def test_health_report_with_no_agents(self, monkeypatch):
         """Test health report handles no running agents."""
+
         def mock_subprocess_run(cmd, **kwargs):
             if "gt status --agents" in " ".join(str(c) for c in cmd):
                 return subprocess.CompletedProcess(cmd, 0, stdout=b"")
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
+
         with patch("gasclaw.health.run_doctor") as mock_doctor:
             mock_doctor.return_value = MagicMock(healthy=True, returncode=0, output="OK")
-            
+
             report = check_health(gateway_port=18789)
-        
+
         assert report.agents == []
 
     def test_health_report_with_missing_commands(self, monkeypatch):
         """Test health report handles missing commands gracefully."""
+
         def mock_subprocess_run(cmd, **kwargs):
             if "dolt" in str(cmd):
                 raise FileNotFoundError("dolt not found")
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
+
         with patch("gasclaw.health.run_doctor") as mock_doctor:
             mock_doctor.return_value = MagicMock(healthy=True, returncode=0, output="OK")
-            
+
             report = check_health(gateway_port=18789)
-        
+
         assert report.dolt == "unhealthy"
 
 
@@ -160,114 +162,99 @@ class TestAgentActivityIntegration:
     def test_activity_check_with_recent_commit(self, monkeypatch):
         """Test activity check with recent git commit."""
         import time
-        
+
         # Recent timestamp (5 minutes ago)
         recent_ts = int(time.time()) - 300
-        
+
         def mock_subprocess_run(cmd, **kwargs):
             if "git log" in " ".join(str(c) for c in cmd):
                 return subprocess.CompletedProcess(cmd, 0, stdout=str(recent_ts).encode())
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
-        activity = check_agent_activity(
-            project_dir="/test/project",
-            deadline_seconds=3600
-        )
-        
+
+        activity = check_agent_activity(project_dir="/test/project", deadline_seconds=3600)
+
         assert activity["compliant"] is True
         assert activity["last_commit_age"] == 300
 
     def test_activity_check_with_old_commit(self, monkeypatch):
         """Test activity check with old git commit (non-compliant)."""
         import time
-        
+
         # Old timestamp (2 hours ago)
         old_ts = int(time.time()) - 7200
-        
+
         def mock_subprocess_run(cmd, **kwargs):
             if "git log" in " ".join(str(c) for c in cmd):
                 return subprocess.CompletedProcess(cmd, 0, stdout=str(old_ts).encode())
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
-        activity = check_agent_activity(
-            project_dir="/test/project",
-            deadline_seconds=3600
-        )
-        
+
+        activity = check_agent_activity(project_dir="/test/project", deadline_seconds=3600)
+
         assert activity["compliant"] is False
         assert activity["last_commit_age"] == 7200
 
     def test_activity_check_with_no_commits(self, monkeypatch):
         """Test activity check with no git history."""
+
         def mock_subprocess_run(cmd, **kwargs):
             if "git log" in " ".join(str(c) for c in cmd):
                 return subprocess.CompletedProcess(cmd, 0, stdout=b"")  # No output
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
-        activity = check_agent_activity(
-            project_dir="/test/project",
-            deadline_seconds=3600
-        )
-        
+
+        activity = check_agent_activity(project_dir="/test/project", deadline_seconds=3600)
+
         assert activity["compliant"] is False
         assert activity["last_commit_age"] is None
 
     def test_activity_check_uses_project_dir(self, monkeypatch):
         """Test activity check uses correct project directory."""
         captured_cwd = []
-        
+
         def mock_subprocess_run(cmd, **kwargs):
             captured_cwd.append(kwargs.get("cwd"))
             if "git log" in " ".join(str(c) for c in cmd):
                 return subprocess.CompletedProcess(cmd, 0, stdout=b"1234567890")
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
-        check_agent_activity(
-            project_dir="/custom/project/path",
-            deadline_seconds=3600
-        )
-        
+
+        check_agent_activity(project_dir="/custom/project/path", deadline_seconds=3600)
+
         assert captured_cwd == ["/custom/project/path"]
 
     def test_activity_check_with_git_error(self, monkeypatch):
         """Test activity check handles git errors gracefully."""
+
         def mock_subprocess_run(cmd, **kwargs):
             if "git log" in " ".join(str(c) for c in cmd):
                 return subprocess.CompletedProcess(cmd, 128, stderr=b"fatal: not a git repository")
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
-        activity = check_agent_activity(
-            project_dir="/not/a/repo",
-            deadline_seconds=3600
-        )
-        
+
+        activity = check_agent_activity(project_dir="/not/a/repo", deadline_seconds=3600)
+
         assert activity["compliant"] is False
         assert activity["last_commit_age"] is None
 
     def test_activity_check_with_invalid_timestamp(self, monkeypatch):
         """Test activity check handles invalid timestamp output."""
+
         def mock_subprocess_run(cmd, **kwargs):
             if "git log" in " ".join(str(c) for c in cmd):
                 return subprocess.CompletedProcess(cmd, 0, stdout=b"not-a-timestamp")
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
-        
+
         monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-        
-        activity = check_agent_activity(
-            project_dir="/test/project",
-            deadline_seconds=3600
-        )
-        
+
+        activity = check_agent_activity(project_dir="/test/project", deadline_seconds=3600)
+
         assert activity["compliant"] is False
         assert activity["last_commit_age"] is None
 
@@ -287,9 +274,9 @@ class TestHealthReportSummary:
             key_pool={"total": 5, "available": 4, "rate_limited": 1},
             activity={"compliant": True, "last_commit_age": 600},
         )
-        
+
         summary = report.summary()
-        
+
         assert "Dolt: healthy" in summary
         assert "Daemon: healthy" in summary
         assert "Mayor: healthy" in summary
@@ -310,9 +297,9 @@ class TestHealthReportSummary:
             key_pool={"total": 3, "available": 0, "rate_limited": 3},
             activity={"compliant": False, "last_commit_age": 5000},
         )
-        
+
         summary = report.summary()
-        
+
         assert "Dolt: unhealthy" in summary
         assert "Mayor: unhealthy" in summary
         assert "0 active" in summary
@@ -330,9 +317,9 @@ class TestHealthReportSummary:
             key_pool={},
             activity={},
         )
-        
+
         summary = report.summary()
-        
+
         assert "?/? available" in summary or "available" in summary
 
     def test_summary_with_many_agents(self):
@@ -346,8 +333,8 @@ class TestHealthReportSummary:
             key_pool={"total": 10, "available": 10},
             activity={"compliant": True, "last_commit_age": 100},
         )
-        
+
         summary = report.summary()
-        
+
         # Should show agent count
         assert "20 active" in summary or "agents" in summary.lower()

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -24,28 +24,32 @@ def config():
 class TestBootstrap:
     def test_calls_all_subsystems(self, config, monkeypatch, tmp_path):
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
         )
         monkeypatch.setattr(
-            subprocess, "Popen",
+            subprocess,
+            "Popen",
             lambda *a, **kw: type("P", (), {"pid": 1, "poll": lambda s: None})(),
         )
 
         from gasclaw.openclaw.doctor import DoctorResult
+
         mock_doctor = DoctorResult(healthy=True, returncode=0, output="OK")
 
-        with patch("gasclaw.bootstrap.setup_kimi_accounts") as m_kimi, \
-             patch("gasclaw.bootstrap.write_agent_config") as m_agent, \
-             patch("gasclaw.bootstrap.gastown_install") as m_install, \
-             patch("gasclaw.bootstrap.start_dolt") as m_dolt, \
-             patch("gasclaw.bootstrap.write_openclaw_config") as m_oc, \
-             patch("gasclaw.bootstrap.install_skills") as m_skills, \
-             patch("gasclaw.bootstrap.run_doctor", return_value=mock_doctor) as m_doctor, \
-             patch("gasclaw.bootstrap.start_daemon") as m_daemon, \
-             patch("gasclaw.bootstrap.start_mayor") as m_mayor, \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
-
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts") as m_kimi,
+            patch("gasclaw.bootstrap.write_agent_config") as m_agent,
+            patch("gasclaw.bootstrap.gastown_install") as m_install,
+            patch("gasclaw.bootstrap.start_dolt") as m_dolt,
+            patch("gasclaw.bootstrap.write_openclaw_config") as m_oc,
+            patch("gasclaw.bootstrap.install_skills") as m_skills,
+            patch("gasclaw.bootstrap.run_doctor", return_value=mock_doctor) as m_doctor,
+            patch("gasclaw.bootstrap.start_daemon") as m_daemon,
+            patch("gasclaw.bootstrap.start_mayor") as m_mayor,
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+        ):
             bootstrap(config, gt_root=tmp_path)
 
             m_kimi.assert_called_once()
@@ -63,6 +67,7 @@ class TestBootstrap:
         order = []
 
         from gasclaw.openclaw.doctor import DoctorResult
+
         mock_doctor = DoctorResult(healthy=True, returncode=0, output="OK")
 
         def doctor_side_effect(**kw):
@@ -72,17 +77,18 @@ class TestBootstrap:
         def se(name):
             return lambda *a, **kw: order.append(name)
 
-        with patch("gasclaw.bootstrap.setup_kimi_accounts", side_effect=se("kimi")), \
-             patch("gasclaw.bootstrap.write_agent_config", side_effect=se("agent_config")), \
-             patch("gasclaw.bootstrap.gastown_install", side_effect=se("install")), \
-             patch("gasclaw.bootstrap.start_dolt", side_effect=se("dolt")), \
-             patch("gasclaw.bootstrap.write_openclaw_config", side_effect=se("openclaw")), \
-             patch("gasclaw.bootstrap.install_skills", side_effect=se("skills")), \
-             patch("gasclaw.bootstrap.run_doctor", side_effect=doctor_side_effect), \
-             patch("gasclaw.bootstrap.start_daemon", side_effect=se("daemon")), \
-             patch("gasclaw.bootstrap.start_mayor", side_effect=se("mayor")), \
-             patch("gasclaw.bootstrap.notify_telegram", side_effect=se("notify")):
-
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts", side_effect=se("kimi")),
+            patch("gasclaw.bootstrap.write_agent_config", side_effect=se("agent_config")),
+            patch("gasclaw.bootstrap.gastown_install", side_effect=se("install")),
+            patch("gasclaw.bootstrap.start_dolt", side_effect=se("dolt")),
+            patch("gasclaw.bootstrap.write_openclaw_config", side_effect=se("openclaw")),
+            patch("gasclaw.bootstrap.install_skills", side_effect=se("skills")),
+            patch("gasclaw.bootstrap.run_doctor", side_effect=doctor_side_effect),
+            patch("gasclaw.bootstrap.start_daemon", side_effect=se("daemon")),
+            patch("gasclaw.bootstrap.start_mayor", side_effect=se("mayor")),
+            patch("gasclaw.bootstrap.notify_telegram", side_effect=se("notify")),
+        ):
             bootstrap(config, gt_root=tmp_path)
 
         # Verify critical ordering
@@ -101,13 +107,14 @@ class TestBootstrap:
 
     def test_rollback_on_dolt_failure(self, config, tmp_path):
         """Rollback stops dolt if it was started before failure."""
-        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
-             patch("gasclaw.bootstrap.write_agent_config"), \
-             patch("gasclaw.bootstrap.gastown_install"), \
-             patch("gasclaw.bootstrap.start_dolt") as m_dolt, \
-             patch("gasclaw.bootstrap.stop_all") as m_stop, \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
-
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts"),
+            patch("gasclaw.bootstrap.write_agent_config"),
+            patch("gasclaw.bootstrap.gastown_install"),
+            patch("gasclaw.bootstrap.start_dolt") as m_dolt,
+            patch("gasclaw.bootstrap.stop_all") as m_stop,
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+        ):
             m_dolt.side_effect = RuntimeError("dolt failed")
 
             with pytest.raises(RuntimeError, match="dolt failed"):
@@ -120,18 +127,20 @@ class TestBootstrap:
 
     def test_rollback_on_daemon_failure(self, config, tmp_path):
         """Rollback stops all services if daemon fails to start."""
-        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
-             patch("gasclaw.bootstrap.write_agent_config"), \
-             patch("gasclaw.bootstrap.gastown_install"), \
-             patch("gasclaw.bootstrap.start_dolt"), \
-             patch("gasclaw.bootstrap.write_openclaw_config"), \
-             patch("gasclaw.bootstrap.install_skills"), \
-             patch("gasclaw.bootstrap.run_doctor") as m_doctor, \
-             patch("gasclaw.bootstrap.start_daemon") as m_daemon, \
-             patch("gasclaw.bootstrap.stop_all") as m_stop, \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
-
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts"),
+            patch("gasclaw.bootstrap.write_agent_config"),
+            patch("gasclaw.bootstrap.gastown_install"),
+            patch("gasclaw.bootstrap.start_dolt"),
+            patch("gasclaw.bootstrap.write_openclaw_config"),
+            patch("gasclaw.bootstrap.install_skills"),
+            patch("gasclaw.bootstrap.run_doctor") as m_doctor,
+            patch("gasclaw.bootstrap.start_daemon") as m_daemon,
+            patch("gasclaw.bootstrap.stop_all") as m_stop,
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+        ):
             from gasclaw.openclaw.doctor import DoctorResult
+
             m_doctor.return_value = DoctorResult(healthy=True, returncode=0, output="OK")
             m_daemon.side_effect = RuntimeError("daemon failed")
 
@@ -147,19 +156,21 @@ class TestBootstrap:
 
     def test_rollback_on_mayor_failure(self, config, tmp_path):
         """Rollback stops all services if mayor fails to start."""
-        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
-             patch("gasclaw.bootstrap.write_agent_config"), \
-             patch("gasclaw.bootstrap.gastown_install"), \
-             patch("gasclaw.bootstrap.start_dolt"), \
-             patch("gasclaw.bootstrap.write_openclaw_config"), \
-             patch("gasclaw.bootstrap.install_skills"), \
-             patch("gasclaw.bootstrap.run_doctor") as m_doctor, \
-             patch("gasclaw.bootstrap.start_daemon"), \
-             patch("gasclaw.bootstrap.start_mayor") as m_mayor, \
-             patch("gasclaw.bootstrap.stop_all") as m_stop, \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
-
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts"),
+            patch("gasclaw.bootstrap.write_agent_config"),
+            patch("gasclaw.bootstrap.gastown_install"),
+            patch("gasclaw.bootstrap.start_dolt"),
+            patch("gasclaw.bootstrap.write_openclaw_config"),
+            patch("gasclaw.bootstrap.install_skills"),
+            patch("gasclaw.bootstrap.run_doctor") as m_doctor,
+            patch("gasclaw.bootstrap.start_daemon"),
+            patch("gasclaw.bootstrap.start_mayor") as m_mayor,
+            patch("gasclaw.bootstrap.stop_all") as m_stop,
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+        ):
             from gasclaw.openclaw.doctor import DoctorResult
+
             m_doctor.return_value = DoctorResult(healthy=True, returncode=0, output="OK")
             m_mayor.side_effect = RuntimeError("mayor failed")
 
@@ -174,19 +185,21 @@ class TestBootstrap:
 
     def test_rollback_error_handled(self, config, tmp_path):
         """Rollback errors are caught and notified but original exception is raised."""
-        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
-             patch("gasclaw.bootstrap.write_agent_config"), \
-             patch("gasclaw.bootstrap.gastown_install"), \
-             patch("gasclaw.bootstrap.start_dolt"), \
-             patch("gasclaw.bootstrap.write_openclaw_config"), \
-             patch("gasclaw.bootstrap.install_skills"), \
-             patch("gasclaw.bootstrap.run_doctor") as m_doctor, \
-             patch("gasclaw.bootstrap.start_daemon"), \
-             patch("gasclaw.bootstrap.start_mayor") as m_mayor, \
-             patch("gasclaw.bootstrap.stop_all") as m_stop, \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
-
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts"),
+            patch("gasclaw.bootstrap.write_agent_config"),
+            patch("gasclaw.bootstrap.gastown_install"),
+            patch("gasclaw.bootstrap.start_dolt"),
+            patch("gasclaw.bootstrap.write_openclaw_config"),
+            patch("gasclaw.bootstrap.install_skills"),
+            patch("gasclaw.bootstrap.run_doctor") as m_doctor,
+            patch("gasclaw.bootstrap.start_daemon"),
+            patch("gasclaw.bootstrap.start_mayor") as m_mayor,
+            patch("gasclaw.bootstrap.stop_all") as m_stop,
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+        ):
             from gasclaw.openclaw.doctor import DoctorResult
+
             m_doctor.return_value = DoctorResult(healthy=True, returncode=0, output="OK")
             m_mayor.side_effect = RuntimeError("mayor failed")
             m_stop.side_effect = RuntimeError("rollback also failed")
@@ -211,17 +224,23 @@ class TestMonitorLoop:
             if check_count >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
-                dolt="healthy", daemon="healthy", mayor="healthy",
-                openclaw="healthy", agents=["mayor"],
+                dolt="healthy",
+                daemon="healthy",
+                mayor="healthy",
+                openclaw="healthy",
+                agents=["mayor"],
                 activity={"compliant": True, "last_commit_age": 100},
             )
 
         activity_return = {"compliant": True, "last_commit_age": 100}
-        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
-             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
-             patch("gasclaw.bootstrap.notify_telegram"), \
-             patch("time.sleep"):
+        with (
+            patch("gasclaw.bootstrap.check_health", side_effect=mock_check),
+            patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return),
+            patch("gasclaw.bootstrap.notify_telegram"),
+            patch("time.sleep"),
+        ):
             monitor_loop(config, interval=1)
 
         assert check_count >= 1
@@ -237,16 +256,22 @@ class TestMonitorLoop:
             if call_count >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
-                dolt="healthy", daemon="healthy", mayor="healthy",
-                openclaw="healthy", agents=["mayor"],
+                dolt="healthy",
+                daemon="healthy",
+                mayor="healthy",
+                openclaw="healthy",
+                agents=["mayor"],
                 activity={"compliant": True, "last_commit_age": 100},
             )
 
-        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check_health), \
-             patch("gasclaw.bootstrap.check_agent_activity") as m_activity, \
-             patch("gasclaw.bootstrap.notify_telegram"), \
-             patch("time.sleep"):
+        with (
+            patch("gasclaw.bootstrap.check_health", side_effect=mock_check_health),
+            patch("gasclaw.bootstrap.check_agent_activity") as m_activity,
+            patch("gasclaw.bootstrap.notify_telegram"),
+            patch("time.sleep"),
+        ):
             m_activity.return_value = {"compliant": True, "last_commit_age": 100}
             monitor_loop(config, interval=1)
 
@@ -266,16 +291,22 @@ class TestMonitorLoop:
             if check_count >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
-                dolt="healthy", daemon="healthy", mayor="healthy",
-                openclaw="healthy", agents=["mayor"],
+                dolt="healthy",
+                daemon="healthy",
+                mayor="healthy",
+                openclaw="healthy",
+                agents=["mayor"],
             )
 
         activity_return = {"compliant": False, "last_commit_age": 7200}
-        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
-             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify, \
-             patch("time.sleep"):
+        with (
+            patch("gasclaw.bootstrap.check_health", side_effect=mock_check),
+            patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return),
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+            patch("time.sleep"),
+        ):
             m_notify.side_effect = lambda msg: notify_calls.append(msg)
             monitor_loop(config, interval=1)
 
@@ -293,16 +324,22 @@ class TestMonitorLoop:
             if check_count >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
-                dolt="unhealthy", daemon="healthy", mayor="healthy",
-                openclaw="healthy", agents=["mayor"],
+                dolt="unhealthy",
+                daemon="healthy",
+                mayor="healthy",
+                openclaw="healthy",
+                agents=["mayor"],
             )
 
         activity_return = {"compliant": True, "last_commit_age": 100}
-        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
-             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify, \
-             patch("time.sleep"):
+        with (
+            patch("gasclaw.bootstrap.check_health", side_effect=mock_check),
+            patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return),
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+            patch("time.sleep"),
+        ):
             m_notify.side_effect = lambda msg: notify_calls.append(msg)
             monitor_loop(config, interval=1)
 
@@ -314,20 +351,23 @@ class TestMonitorLoop:
         notify_calls = []
 
         from gasclaw.openclaw.doctor import DoctorResult
+
         mock_doctor = DoctorResult(
             healthy=False, returncode=1, output="Config error: missing token"
         )
 
-        with patch("gasclaw.bootstrap.setup_kimi_accounts"), \
-             patch("gasclaw.bootstrap.write_agent_config"), \
-             patch("gasclaw.bootstrap.gastown_install"), \
-             patch("gasclaw.bootstrap.start_dolt"), \
-             patch("gasclaw.bootstrap.write_openclaw_config"), \
-             patch("gasclaw.bootstrap.install_skills"), \
-             patch("gasclaw.bootstrap.run_doctor", return_value=mock_doctor), \
-             patch("gasclaw.bootstrap.start_daemon"), \
-             patch("gasclaw.bootstrap.start_mayor"), \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify:
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts"),
+            patch("gasclaw.bootstrap.write_agent_config"),
+            patch("gasclaw.bootstrap.gastown_install"),
+            patch("gasclaw.bootstrap.start_dolt"),
+            patch("gasclaw.bootstrap.write_openclaw_config"),
+            patch("gasclaw.bootstrap.install_skills"),
+            patch("gasclaw.bootstrap.run_doctor", return_value=mock_doctor),
+            patch("gasclaw.bootstrap.start_daemon"),
+            patch("gasclaw.bootstrap.start_mayor"),
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+        ):
             m_notify.side_effect = lambda msg: notify_calls.append(msg)
             bootstrap(config, gt_root=tmp_path)
 
@@ -347,16 +387,22 @@ class TestMonitorLoop:
             if check_count >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
-                dolt="unhealthy", daemon="unhealthy", mayor="unhealthy",
-                openclaw="healthy", agents=[],
+                dolt="unhealthy",
+                daemon="unhealthy",
+                mayor="unhealthy",
+                openclaw="healthy",
+                agents=[],
             )
 
         activity_return = {"compliant": True, "last_commit_age": 100}
-        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
-             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
-             patch("gasclaw.bootstrap.notify_telegram") as m_notify, \
-             patch("time.sleep"):
+        with (
+            patch("gasclaw.bootstrap.check_health", side_effect=mock_check),
+            patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return),
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+            patch("time.sleep"),
+        ):
             m_notify.side_effect = lambda msg: notify_calls.append(msg)
             monitor_loop(config, interval=1)
 
@@ -377,19 +423,25 @@ class TestMonitorLoop:
             if check_count >= 2:
                 raise KeyboardInterrupt
             from gasclaw.health import HealthReport
+
             return HealthReport(
-                dolt="healthy", daemon="healthy", mayor="healthy",
-                openclaw="healthy", agents=["mayor"],
+                dolt="healthy",
+                daemon="healthy",
+                mayor="healthy",
+                openclaw="healthy",
+                agents=["mayor"],
                 activity={"compliant": True, "last_commit_age": 100},
             )
 
         activity_return = {"compliant": True, "last_commit_age": 100}
         config.monitor_interval = 42  # Custom interval
 
-        with patch("gasclaw.bootstrap.check_health", side_effect=mock_check), \
-             patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return), \
-             patch("gasclaw.bootstrap.notify_telegram"), \
-             patch("time.sleep") as m_sleep:
+        with (
+            patch("gasclaw.bootstrap.check_health", side_effect=mock_check),
+            patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return),
+            patch("gasclaw.bootstrap.notify_telegram"),
+            patch("time.sleep") as m_sleep,
+        ):
             monitor_loop(config, interval=None)  # interval=None triggers line 131
 
         # Verify sleep was called with the config interval

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -84,6 +84,7 @@ class TestStatusCommand:
 
         def raise_valueerror():
             raise ValueError("no config")
+
         monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
         monkeypatch.setattr("gasclaw.cli.load_config", raise_valueerror)
 
@@ -110,11 +111,11 @@ class TestStatusCommand:
         monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
         monkeypatch.setattr(
             "gasclaw.cli.check_agent_activity",
-            lambda **kw: {"compliant": True, "last_commit_age": 300}
+            lambda **kw: {"compliant": True, "last_commit_age": 300},
         )
         monkeypatch.setattr(
             "gasclaw.cli.KeyPool",
-            MagicMock(return_value=MagicMock(status=lambda: {"total": 2, "available": 2}))
+            MagicMock(return_value=MagicMock(status=lambda: {"total": 2, "available": 2})),
         )
 
         result = runner.invoke(app, ["status"])
@@ -127,12 +128,10 @@ class TestUpdateCommand:
     def test_shows_versions_and_updates(self, monkeypatch):
         """update command checks versions and applies updates."""
         monkeypatch.setattr(
-            "gasclaw.cli.check_versions",
-            lambda: {"gt": "1.0.0", "claude": "2.0.0"}
+            "gasclaw.cli.check_versions", lambda: {"gt": "1.0.0", "claude": "2.0.0"}
         )
         monkeypatch.setattr(
-            "gasclaw.cli.apply_updates",
-            lambda: {"gt": "updated", "claude": "up-to-date"}
+            "gasclaw.cli.apply_updates", lambda: {"gt": "updated", "claude": "up-to-date"}
         )
 
         result = runner.invoke(app, ["update"])
@@ -147,6 +146,7 @@ class TestVersionCommand:
     def test_version_flag_shows_version(self):
         """--version flag displays version and exits."""
         from gasclaw import __version__
+
         result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
         assert __version__ in result.output
@@ -154,6 +154,7 @@ class TestVersionCommand:
     def test_version_command_shows_version(self):
         """version subcommand displays version."""
         from gasclaw import __version__
+
         result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
         assert __version__ in result.output
@@ -199,8 +200,7 @@ class TestCLIEdgeCases:
 
         monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
         monkeypatch.setattr(
-            "gasclaw.cli.load_config",
-            lambda: (_ for _ in ()).throw(ValueError("no config"))
+            "gasclaw.cli.load_config", lambda: (_ for _ in ()).throw(ValueError("no config"))
         )
 
         result = runner.invoke(app, ["status"])
@@ -227,11 +227,11 @@ class TestCLIEdgeCases:
         monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
         monkeypatch.setattr(
             "gasclaw.cli.check_agent_activity",
-            lambda **kw: {"compliant": False, "last_commit_age": 5000}
+            lambda **kw: {"compliant": False, "last_commit_age": 5000},
         )
         monkeypatch.setattr(
             "gasclaw.cli.KeyPool",
-            MagicMock(return_value=MagicMock(status=lambda: {"total": 2, "available": 1}))
+            MagicMock(return_value=MagicMock(status=lambda: {"total": 2, "available": 1})),
         )
 
         result = runner.invoke(app, ["status"])

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -106,7 +106,6 @@ class TestLoadConfig:
         cfg = load_config()
         assert cfg.openclaw_kimi_key not in cfg.gastown_kimi_keys
 
-
     def test_whitespace_only_env_vars_treated_as_missing(self, monkeypatch, env_vars):
         """Whitespace-only env vars should be treated as missing."""
         for k, v in env_vars().items():
@@ -185,6 +184,7 @@ class TestParsePositiveIntWarnings:
     def test_invalid_value_logs_warning(self, monkeypatch, env_vars, caplog):
         """Invalid integer value logs a warning."""
         import logging
+
         for k, v in env_vars(GT_AGENT_COUNT="abc").items():
             monkeypatch.setenv(k, v)
 
@@ -199,6 +199,7 @@ class TestParsePositiveIntWarnings:
     def test_zero_value_logs_warning(self, monkeypatch, env_vars, caplog):
         """Zero value logs a warning about positive requirement."""
         import logging
+
         for k, v in env_vars(MONITOR_INTERVAL="0").items():
             monkeypatch.setenv(k, v)
 
@@ -212,6 +213,7 @@ class TestParsePositiveIntWarnings:
     def test_negative_value_logs_warning(self, monkeypatch, env_vars, caplog):
         """Negative value logs a warning about positive requirement."""
         import logging
+
         for k, v in env_vars(ACTIVITY_DEADLINE="-100").items():
             monkeypatch.setenv(k, v)
 
@@ -225,6 +227,7 @@ class TestParsePositiveIntWarnings:
     def test_valid_value_no_warning(self, monkeypatch, env_vars, caplog):
         """Valid value does not log a warning."""
         import logging
+
         for k, v in env_vars(GT_AGENT_COUNT="8").items():
             monkeypatch.setenv(k, v)
 
@@ -242,6 +245,7 @@ class TestConfigEdgeCases:
     def test_float_value_defaults_to_int(self, monkeypatch, env_vars, caplog):
         """Float value for integer config uses default."""
         import logging
+
         for k, v in env_vars(GT_AGENT_COUNT="3.14").items():
             monkeypatch.setenv(k, v)
 
@@ -269,6 +273,7 @@ class TestConfigEdgeCases:
     def test_whitespace_in_integer_value(self, monkeypatch, env_vars, caplog):
         """Whitespace around integer values is handled."""
         import logging
+
         for k, v in env_vars(GT_AGENT_COUNT="  42  ").items():
             monkeypatch.setenv(k, v)
 
@@ -282,6 +287,7 @@ class TestConfigEdgeCases:
     def test_scientific_notation_defaults(self, monkeypatch, env_vars, caplog):
         """Scientific notation for integer config uses default."""
         import logging
+
         for k, v in env_vars(MONITOR_INTERVAL="1e3").items():
             monkeypatch.setenv(k, v)
 
@@ -295,6 +301,7 @@ class TestConfigEdgeCases:
     def test_hexadecimal_notation_defaults(self, monkeypatch, env_vars, caplog):
         """Hexadecimal notation for integer config uses default."""
         import logging
+
         for k, v in env_vars(ACTIVITY_DEADLINE="0x100").items():
             monkeypatch.setenv(k, v)
 

--- a/tests/unit/test_gastown_installer.py
+++ b/tests/unit/test_gastown_installer.py
@@ -42,6 +42,7 @@ class TestSetupKimiAccounts:
     def test_uses_default_accounts_dir_when_none_provided(self, monkeypatch, tmp_path):
         """setup_kimi_accounts uses ~/.kimi-accounts when accounts_dir is None."""
         from pathlib import Path
+
         # Mock Path.home() to return tmp_path
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -55,7 +56,8 @@ class TestGastownInstall:
     def test_runs_gt_install(self, monkeypatch, tmp_path):
         calls = []
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: calls.append((a, kw)) or subprocess.CompletedProcess(a[0], 0),
         )
         gastown_install(gt_root=tmp_path, rig_url="/project")
@@ -65,7 +67,8 @@ class TestGastownInstall:
     def test_runs_gt_rig_add(self, monkeypatch, tmp_path):
         calls = []
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: calls.append((a, kw)) or subprocess.CompletedProcess(a[0], 0),
         )
         gastown_install(gt_root=tmp_path, rig_url="/project")
@@ -74,6 +77,7 @@ class TestGastownInstall:
 
     def test_gt_install_failure_raises(self, monkeypatch, tmp_path):
         """gt install failure raises CalledProcessError."""
+
         def mock_run(*a, **kw):
             cmd = a[0] if a else []
             if "install" in str(cmd):
@@ -90,6 +94,7 @@ class TestGastownInstall:
 
     def test_gt_rig_add_failure_raises(self, monkeypatch, tmp_path):
         """gt rig add failure raises CalledProcessError."""
+
         def mock_run(*a, **kw):
             cmd = a[0] if a else []
             if "rig" in str(cmd) and "add" in str(cmd):
@@ -106,6 +111,7 @@ class TestGastownInstall:
 
     def test_missing_gt_binary_raises(self, monkeypatch, tmp_path):
         """Missing gt binary raises FileNotFoundError."""
+
         def raise_not_found(*a, **kw):
             raise FileNotFoundError("gt not found")
 
@@ -118,6 +124,7 @@ class TestGastownInstall:
 
     def test_gt_install_timeout_raises(self, monkeypatch, tmp_path):
         """gt install timeout raises TimeoutExpired."""
+
         def raise_timeout(*a, **kw):
             raise subprocess.TimeoutExpired(cmd=a[0] if a else ["gt"], timeout=60)
 

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -13,15 +13,18 @@ class TestStartDolt:
 
         class MockProc:
             pid = 1
+
             def poll(self):
                 return None  # Still running
 
         monkeypatch.setattr(
-            subprocess, "Popen",
+            subprocess,
+            "Popen",
             lambda *a, **kw: (calls.append((a, kw)), MockProc())[-1],
         )
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b""),
         )
         start_dolt(data_dir="/tmp/dolt-data", port=3307, timeout=1)
@@ -29,13 +32,17 @@ class TestStartDolt:
 
     def test_raises_if_process_exits_early(self, monkeypatch):
         """If dolt process dies immediately, we should get RuntimeError not TimeoutError."""
+
         class DeadProcess:
             pid = 1
             returncode = 1
+
             def poll(self):
                 return self.returncode  # Process already exited
+
             def terminate(self):
                 pass
+
             def wait(self, timeout=None):
                 return 0
 
@@ -49,19 +56,24 @@ class TestStartDolt:
 
     def test_raises_timeout_if_never_ready(self, monkeypatch):
         """If dolt never becomes ready, raise TimeoutError."""
+
         class MockProc:
             pid = 1
+
             def poll(self):
                 return None  # Still running
+
             def terminate(self):
                 pass
+
             def wait(self, timeout=None):
                 return 0
 
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: MockProc())
         # Always return non-zero (not ready)
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
         )
         try:
@@ -77,6 +89,7 @@ class TestStartDolt:
 
         class MockProc:
             pid = 1
+
             def poll(self):
                 return None
 
@@ -105,6 +118,7 @@ class TestStartDolt:
 
         class MockProc:
             pid = 1
+
             def poll(self):
                 return None
 
@@ -135,10 +149,13 @@ class TestStartDolt:
         class DeadProcess:
             pid = 1
             returncode = 1
+
             def poll(self):
                 return self.returncode
+
             def terminate(self):
                 terminate_called.append(True)
+
             def wait(self, timeout=None):
                 wait_called.append(timeout)
                 return 0
@@ -158,16 +175,20 @@ class TestStartDolt:
 
         class SlowProc:
             pid = 1
+
             def poll(self):
                 return None  # Never exits
+
             def terminate(self):
                 terminate_called.append(True)
+
             def wait(self, timeout=None):
                 return 0
 
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: SlowProc())
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
         )
 
@@ -185,12 +206,16 @@ class TestStartDolt:
 
         class StubbornProc:
             pid = 1
+
             def poll(self):
                 return None
+
             def terminate(self):
                 terminate_called.append(True)
+
             def kill(self):
                 kill_called.append(True)
+
             def wait(self, timeout=None):
                 if timeout == 5:
                     raise subprocess.TimeoutExpired(cmd=["dolt"], timeout=5)
@@ -198,7 +223,8 @@ class TestStartDolt:
 
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: StubbornProc())
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
         )
 
@@ -215,7 +241,8 @@ class TestStartDaemon:
     def test_runs_gt_daemon(self, monkeypatch):
         calls = []
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: calls.append(a[0]) or subprocess.CompletedProcess(a[0], 0),
         )
         start_daemon()
@@ -224,7 +251,8 @@ class TestStartDaemon:
     def test_handles_failure(self, monkeypatch):
         """start_daemon raises RuntimeError if daemon fails to start."""
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("daemon failed")),
         )
         try:
@@ -235,8 +263,10 @@ class TestStartDaemon:
 
     def test_handles_missing_binary(self, monkeypatch):
         """start_daemon raises FileNotFoundError if gt not installed."""
+
         def raise_not_found(*a, **kw):
             raise FileNotFoundError("gt not found")
+
         monkeypatch.setattr(subprocess, "run", raise_not_found)
         try:
             start_daemon()
@@ -249,7 +279,8 @@ class TestStartMayor:
     def test_runs_gt_mayor_start(self, monkeypatch):
         calls = []
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: calls.append(a[0]) or subprocess.CompletedProcess(a[0], 0),
         )
         start_mayor(agent="kimi-claude")
@@ -260,7 +291,8 @@ class TestStartMayor:
     def test_handles_failure(self, monkeypatch):
         """start_mayor raises RuntimeError if mayor fails to start."""
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("mayor failed")),
         )
         try:
@@ -271,8 +303,10 @@ class TestStartMayor:
 
     def test_handles_missing_binary(self, monkeypatch):
         """start_mayor raises FileNotFoundError if gt not installed."""
+
         def raise_not_found(*a, **kw):
             raise FileNotFoundError("gt not found")
+
         monkeypatch.setattr(subprocess, "run", raise_not_found)
         try:
             start_mayor(agent="kimi-claude")
@@ -285,7 +319,8 @@ class TestStopAll:
     def test_stops_mayor_daemon_dolt(self, monkeypatch):
         calls = []
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: calls.append(a[0]) or subprocess.CompletedProcess(a[0], 0),
         )
         stop_all()
@@ -295,6 +330,7 @@ class TestStopAll:
 
     def test_handles_stop_failures_gracefully(self, monkeypatch):
         """stop_all uses check=False so failures don't raise."""
+
         def mock_run(*a, **kw):
             # Simulate failure for all commands
             return subprocess.CompletedProcess(a[0], 1, stderr=b"not running")
@@ -305,6 +341,7 @@ class TestStopAll:
 
     def test_handles_missing_binaries_gracefully(self, monkeypatch):
         """stop_all handles FileNotFoundError when binaries are missing."""
+
         def mock_run(*a, **kw):
             raise FileNotFoundError("gt not found")
 
@@ -357,7 +394,8 @@ class TestStopAll:
         calls = []
 
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: calls.append(a[0]) or subprocess.CompletedProcess(a[0], 0),
         )
         stop_all()

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -14,7 +14,8 @@ class TestCheckHealth:
     def test_report_structure(self, monkeypatch, respx_mock: respx.MockRouter):
         respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
         )
         report = check_health(gateway_port=18789)
@@ -29,7 +30,8 @@ class TestCheckHealth:
     def test_all_healthy(self, monkeypatch, respx_mock: respx.MockRouter):
         respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"running"),
         )
         report = check_health(gateway_port=18789)
@@ -45,6 +47,7 @@ class TestCheckHealth:
             if "dolt" in str(cmd):
                 return subprocess.CompletedProcess(cmd, 1, stderr=b"refused")
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
+
         monkeypatch.setattr(subprocess, "run", _mock_run)
         report = check_health(gateway_port=18789)
         assert report.dolt == "unhealthy"
@@ -52,7 +55,8 @@ class TestCheckHealth:
     def test_agents_listed(self, monkeypatch, respx_mock: respx.MockRouter):
         respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(
                 a[0], 0, stdout=b"mayor\ndeacon\nwitness\ncrew-1\ncrew-2\n"
             ),
@@ -105,7 +109,8 @@ class TestCheckAgentActivityValidation:
         # Mock git log to return current timestamp
         now_ts = int(time.time())
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=f"{now_ts}\n".encode()),
         )
         activity = check_agent_activity(project_dir=str(git_dir), deadline_seconds=3600)
@@ -137,7 +142,9 @@ class TestCheckOpenclawGateway:
         """Returns unhealthy when connection fails."""
         from gasclaw.health import _check_openclaw_gateway
 
-        respx_mock.get("http://localhost:8080/health").mock(side_effect=httpx.ConnectError("refused"))
+        respx_mock.get("http://localhost:8080/health").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
         result = _check_openclaw_gateway(8080)
         assert result == "unhealthy"
 
@@ -145,7 +152,9 @@ class TestCheckOpenclawGateway:
         """Returns unhealthy when request times out."""
         from gasclaw.health import _check_openclaw_gateway
 
-        respx_mock.get("http://localhost:8080/health").mock(side_effect=httpx.TimeoutException("timeout"))
+        respx_mock.get("http://localhost:8080/health").mock(
+            side_effect=httpx.TimeoutException("timeout")
+        )
         result = _check_openclaw_gateway(8080)
         assert result == "unhealthy"
 
@@ -183,7 +192,8 @@ class TestCheckServiceErrorHandling:
         git_dot_git.mkdir()
 
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"git error"),
         )
         activity = check_agent_activity(project_dir=str(git_dir), deadline_seconds=3600)
@@ -199,7 +209,8 @@ class TestCheckServiceErrorHandling:
         git_dot_git.mkdir()
 
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"not-a-number\n"),
         )
         activity = check_agent_activity(project_dir=str(git_dir), deadline_seconds=3600)
@@ -214,6 +225,7 @@ class TestCheckServiceErrorHandling:
 
         def raise_not_found(*a, **kw):
             raise FileNotFoundError("git not found")
+
         monkeypatch.setattr(subprocess, "run", raise_not_found)
         activity = check_agent_activity(project_dir=str(git_dir), deadline_seconds=3600)
         assert activity["compliant"] is False
@@ -228,6 +240,7 @@ class TestCheckServiceErrorHandling:
 
         def raise_timeout(*a, **kw):
             raise subprocess.TimeoutExpired(cmd=a[0], timeout=10)
+
         monkeypatch.setattr(subprocess, "run", raise_timeout)
         activity = check_agent_activity(project_dir=str(git_dir), deadline_seconds=3600)
         assert activity["compliant"] is False
@@ -372,6 +385,7 @@ class TestHealthCheckEdgeCases:
 
         def raise_timeout(*a, **kw):
             raise subprocess.TimeoutExpired(cmd=a[0], timeout=10)
+
         monkeypatch.setattr(subprocess, "run", raise_timeout)
         report = check_health(gateway_port=18789)
         # Should return report with unhealthy status, not raise
@@ -388,6 +402,7 @@ class TestHealthCheckEdgeCases:
             if "status" in str(cmd) and "--agents" in str(cmd):
                 raise FileNotFoundError("gt not found")
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
+
         monkeypatch.setattr(subprocess, "run", mock_run)
         report = check_health(gateway_port=18789)
         assert report.agents == []
@@ -400,6 +415,7 @@ class TestHealthCheckEdgeCases:
             if "status" in str(cmd) and "--agents" in str(cmd):
                 raise subprocess.TimeoutExpired(cmd=["gt"], timeout=10)
             return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
+
         monkeypatch.setattr(subprocess, "run", mock_run)
         report = check_health(gateway_port=18789)
         assert report.agents == []
@@ -416,10 +432,9 @@ class TestHealthCheckEdgeCases:
         # Use current timestamp so age is approximately 0
         now_ts = int(time.time())
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout=f"{now_ts}\n".encode()
-            ),
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=f"{now_ts}\n".encode()),
         )
         activity = check_agent_activity(project_dir=str(git_dir), deadline_seconds=0)
         # Age should be 0 (or close to it), so 0 <= 0 is True
@@ -437,7 +452,8 @@ class TestHealthCheckEdgeCases:
 
         old_timestamp = int(time.time()) - 86400  # 1 day ago
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(
                 a[0], 0, stdout=f"{old_timestamp}\n".encode()
             ),
@@ -449,35 +465,34 @@ class TestHealthCheckEdgeCases:
         """check_health uses custom gateway port for openclaw check."""
         respx_mock.get("http://localhost:99999/health").mock(return_value=httpx.Response(200))
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
         )
         report = check_health(gateway_port=99999)
         assert report.openclaw == "healthy"
 
-    def test_openclaw_gateway_connection_error(
-        self, monkeypatch, respx_mock: respx.MockRouter
-    ):
+    def test_openclaw_gateway_connection_error(self, monkeypatch, respx_mock: respx.MockRouter):
         """check_health returns unhealthy when openclaw gateway connection fails."""
         respx_mock.get("http://localhost:18789/health").mock(
             side_effect=httpx.ConnectError("Connection refused")
         )
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
         )
         report = check_health(gateway_port=18789)
         assert report.openclaw == "unhealthy"
 
-    def test_openclaw_gateway_timeout(
-        self, monkeypatch, respx_mock: respx.MockRouter
-    ):
+    def test_openclaw_gateway_timeout(self, monkeypatch, respx_mock: respx.MockRouter):
         """check_health returns unhealthy when openclaw gateway times out."""
         respx_mock.get("http://localhost:18789/health").mock(
             side_effect=httpx.TimeoutException("Request timed out")
         )
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
         )
         report = check_health(gateway_port=18789)
@@ -487,7 +502,8 @@ class TestHealthCheckEdgeCases:
         """check_health returns unhealthy when openclaw gateway returns non-200."""
         respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(503))
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
         )
         report = check_health(gateway_port=18789)

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -162,7 +162,7 @@ class TestKeyPoolAtomicWrite:
         original_fdopen = __builtins__["open"] if "open" in __builtins__ else open
 
         def fail_on_fdopen(*args, **kwargs):
-            if args and hasattr(args[0], '__class__') and 'int' in str(type(args[0])):
+            if args and hasattr(args[0], "__class__") and "int" in str(type(args[0])):
                 raise OSError("Write failed")
             return original_fdopen(*args, **kwargs)
 
@@ -193,6 +193,7 @@ class TestKeyPoolAtomicWrite:
         # Make os.fdopen fail to trigger cleanup path
         def fail_fdopen(*a, **kw):
             raise OSError("Write failed")
+
         monkeypatch.setattr("os.fdopen", fail_fdopen)
 
         # Should raise the original OSError, not the unlink error

--- a/tests/unit/test_openclaw_doctor.py
+++ b/tests/unit/test_openclaw_doctor.py
@@ -23,7 +23,8 @@ class TestRunDoctor:
         monkeypatch.setattr(
             "gasclaw.openclaw.doctor.subprocess.run",
             lambda *a, **kw: subprocess.CompletedProcess(
-                args=a[0], returncode=1,
+                args=a[0],
+                returncode=1,
                 stdout=b"Config issues found\nMissing gateway auth\n",
                 stderr=b"",
             ),

--- a/tests/unit/test_updater_applier.py
+++ b/tests/unit/test_updater_applier.py
@@ -11,7 +11,8 @@ class TestApplyUpdates:
     def test_runs_update_commands(self, monkeypatch):
         calls = []
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: calls.append(a[0]) or subprocess.CompletedProcess(a[0], 0),
         )
         apply_updates()
@@ -22,7 +23,8 @@ class TestApplyUpdates:
 
     def test_handles_failures(self, monkeypatch):
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"fail"),
         )
         results = apply_updates()
@@ -30,6 +32,7 @@ class TestApplyUpdates:
 
     def test_handles_timeout(self, monkeypatch):
         """TimeoutExpired is caught and reported."""
+
         def raise_timeout(*a, **kw):
             raise subprocess.TimeoutExpired(cmd=a[0], timeout=120)
 
@@ -39,6 +42,7 @@ class TestApplyUpdates:
 
     def test_handles_missing_binary(self, monkeypatch):
         """FileNotFoundError is caught and reported."""
+
         def raise_not_found(*a, **kw):
             raise FileNotFoundError("gt not found")
 
@@ -50,7 +54,8 @@ class TestApplyUpdates:
         """Long stderr is truncated to 200 chars."""
         long_error = b"x" * 500
         monkeypatch.setattr(
-            subprocess, "run",
+            subprocess,
+            "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=long_error),
         )
         results = apply_updates()

--- a/tests/unit/test_updater_checker.py
+++ b/tests/unit/test_updater_checker.py
@@ -10,10 +10,9 @@ from gasclaw.updater.checker import check_versions
 class TestCheckVersions:
     def test_returns_version_dict(self, monkeypatch):
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout=b"1.0.0\n"
-            ),
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"1.0.0\n"),
         )
         versions = check_versions()
         assert "gt" in versions
@@ -33,10 +32,9 @@ class TestCheckVersions:
     def test_handles_nonzero_exit(self, monkeypatch):
         """Non-zero exit code is treated as not installed."""
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 1, stdout=b"", stderr=b"error"
-            ),
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stdout=b"", stderr=b"error"),
         )
         versions = check_versions()
         for v in versions.values():
@@ -44,6 +42,7 @@ class TestCheckVersions:
 
     def test_handles_timeout(self, monkeypatch):
         """TimeoutExpired is caught and reported as not installed."""
+
         def _timeout(*a, **kw):
             raise subprocess.TimeoutExpired(cmd=a[0], timeout=10)
 
@@ -55,10 +54,9 @@ class TestCheckVersions:
     def test_strips_whitespace_from_output(self, monkeypatch):
         """Version output has whitespace stripped."""
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout=b"  1.0.0  \n\r\n"
-            ),
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"  1.0.0  \n\r\n"),
         )
         versions = check_versions()
         for v in versions.values():
@@ -67,10 +65,9 @@ class TestCheckVersions:
     def test_includes_kimigas(self, monkeypatch):
         """Kimigas is included in version checks."""
         monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 0, stdout=b"0.5.0\n"
-            ),
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"0.5.0\n"),
         )
         versions = check_versions()
         assert "kimigas" in versions

--- a/tests/unit/test_updater_notifier.py
+++ b/tests/unit/test_updater_notifier.py
@@ -38,9 +38,7 @@ class TestNotifyTelegram:
     @respx.mock
     def test_returns_true_on_success(self):
         """Function returns True when notification succeeds."""
-        respx.post("http://localhost:18789/api/message").mock(
-            return_value=httpx.Response(200)
-        )
+        respx.post("http://localhost:18789/api/message").mock(return_value=httpx.Response(200))
         result = notify_telegram("Test", gateway_port=18789, auth_token="tok")
         assert result is True
 


### PR DESCRIPTION
## Summary

Apply consistent code formatting across the codebase using `ruff format`.

## Changes

- 19 files reformatted
- 23 files already formatted
- No functional changes, only formatting

## Files Changed

- src/gasclaw/cli.py
- src/gasclaw/config.py
- src/gasclaw/health.py
- src/gasclaw/kimigas/key_pool.py
- src/gasclaw/openclaw/installer.py
- All test files (integration and unit)

## Test plan

- [x] All 226 unit tests pass
- [x] Lint passes with `ruff check src tests`
- [x] Format check passes with `ruff format --check src tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)