### PR TITLE
feat: add --project-dir option to start command

### DIFF
--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -46,6 +46,9 @@ def main(
 @app.command()
 def start(
     gt_root: Path = typer.Option(Path("/workspace/gt"), help="Gastown root directory"),
+    project_dir: Path | None = typer.Option(
+        None, help="Project directory for activity checks (overrides config)"
+    ),
 ) -> None:
     """Start gasclaw: bootstrap all services and enter monitor loop."""
     try:
@@ -53,6 +56,10 @@ def start(
     except ValueError as e:
         console.print(f"[red]Config error:[/red] {e}")
         raise typer.Exit(code=1) from None
+
+    # Override project_dir if provided via CLI
+    if project_dir is not None:
+        config.project_dir = str(project_dir)
 
     console.print("[bold]Starting gasclaw...[/bold]")
     bootstrap(config, gt_root=gt_root)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -54,6 +54,32 @@ class TestStartCommand:
         assert len(monitor_calls) == 1
         assert "Starting gasclaw" in result.output
 
+    def test_start_with_project_dir_override(self, config, monkeypatch, tmp_path):
+        """start command overrides project_dir when provided via --project-dir."""
+        monitor_calls = []
+        project_override = tmp_path / "custom_project"
+        project_override.mkdir()
+
+        def mock_bootstrap(cfg, gt_root):
+            pass
+
+        def mock_monitor(cfg):
+            monitor_calls.append(cfg)
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
+        monkeypatch.setattr("gasclaw.cli.bootstrap", mock_bootstrap)
+        monkeypatch.setattr("gasclaw.cli.monitor_loop", mock_monitor)
+
+        runner.invoke(
+            app,
+            ["start", "--gt-root", str(tmp_path), "--project-dir", str(project_override)]
+        )
+
+        assert len(monitor_calls) == 1
+        assert monitor_calls[0].project_dir == str(project_override)
+        # KeyboardInterrupt causes exit code 130, which is expected
+
 
 class TestStopCommand:
     def test_calls_stop_all(self, monkeypatch):


### PR DESCRIPTION
## Summary

Adds a `--project-dir` CLI option to the `start` command that allows overriding the project directory for activity checks at runtime. This is useful when you want to monitor a different directory than the default without changing the environment config.

## Changes

- Added `--project-dir` option to `gasclaw start` command
- When provided, overrides `config.project_dir` before bootstrap
- Added test to verify the override works correctly

## Test plan

- [x] `make test` passes (227 tests)
- [x] `make lint` passes
- [x] New test added for `--project-dir` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)