### PR TITLE
style: fix ruff formatting in test_cli.py

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -72,8 +72,7 @@ class TestStartCommand:
         monkeypatch.setattr("gasclaw.cli.monitor_loop", mock_monitor)
 
         runner.invoke(
-            app,
-            ["start", "--gt-root", str(tmp_path), "--project-dir", str(project_override)]
+            app, ["start", "--gt-root", str(tmp_path), "--project-dir", str(project_override)]
         )
 
         assert len(monitor_calls) == 1


### PR DESCRIPTION
## Summary
Fix line break formatting in `tests/unit/test_cli.py` to pass ruff format check.

## Changes
- Combined split lines in `runner.invoke()` call

## Test plan
- [x] `ruff format --check src tests` passes
- [x] `python -m pytest tests/unit -v` passes (227 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)