### PR TITLE
docs: correct bootstrap step count in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- **Bootstrap**: 17-step startup sequence orchestrating all subsystems
+- **Bootstrap**: 12-step startup sequence orchestrating all subsystems
 - **Health Checks**: Monitor Dolt, daemon, mayor, OpenClaw, and agent activity
 - **Key Pool**: LRU key rotation with rate-limit cooldown
 - **Activity Compliance**: Enforces code push/PR every hour


### PR DESCRIPTION
## Summary
Fixes the bootstrap step count in the 0.1.0 release notes to match the corrected 12-step sequence.

## Changes
- Updated CHANGELOG feature description from "17-step" to "12-step"

## Test plan
- [x] `make test` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)