### PR TITLE
fix: check HTTP status codes in notify_telegram

### DIFF
--- a/src/gasclaw/updater/notifier.py
+++ b/src/gasclaw/updater/notifier.py
@@ -34,13 +34,13 @@ def notify_telegram(
         headers["Authorization"] = f"Bearer {auth_token}"
 
     try:
-        httpx.post(
+        response = httpx.post(
             url,
             content=json.dumps({"message": message}),
             headers=headers,
             timeout=10.0,
         )
-        return True
+        return response.is_success
     except httpx.ConnectError as e:
         logger.warning("Failed to send notification: gateway not available (%s)", e)
         return False

--- a/tests/unit/test_updater_notifier.py
+++ b/tests/unit/test_updater_notifier.py
@@ -59,3 +59,24 @@ class TestNotifyTelegram:
         )
         result = notify_telegram("Test", gateway_port=18789)
         assert result is False
+
+    @respx.mock
+    def test_returns_false_on_4xx_error(self):
+        """Function returns False on 4xx HTTP status code."""
+        respx.post("http://localhost:18789/api/message").mock(return_value=httpx.Response(400))
+        result = notify_telegram("Test", gateway_port=18789)
+        assert result is False
+
+    @respx.mock
+    def test_returns_false_on_5xx_error(self):
+        """Function returns False on 5xx HTTP status code."""
+        respx.post("http://localhost:18789/api/message").mock(return_value=httpx.Response(500))
+        result = notify_telegram("Test", gateway_port=18789)
+        assert result is False
+
+    @respx.mock
+    def test_returns_true_on_201_created(self):
+        """Function returns True on 2xx HTTP status codes (not just 200)."""
+        respx.post("http://localhost:18789/api/message").mock(return_value=httpx.Response(201))
+        result = notify_telegram("Test", gateway_port=18789)
+        assert result is True


### PR DESCRIPTION
## Summary
Fixes a bug where `notify_telegram()` would return `True` even when the gateway returned 4xx or 5xx HTTP status codes.

## Problem
The function previously returned `True` for any response that didn't raise an exception, ignoring HTTP error status codes.

## Solution
Use `response.is_success` to properly verify 2xx status codes before returning `True`.

## Changes
- Modified `notify_telegram()` to check `response.is_success`
- Added 3 new tests for HTTP status code handling:
  - `test_returns_false_on_4xx_error`
  - `test_returns_false_on_5xx_error`
  - `test_returns_true_on_201_created`

## Test plan
- [x] `make test` passes (230 tests)
- [x] `make lint` passes
- [x] New tests verify correct behavior for 4xx/5xx/2xx responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)