### PR TITLE
fix: check HTTP status codes in notify_telegram

### DIFF
--- a/src/gasclaw/updater/notifier.py
+++ b/src/gasclaw/updater/notifier.py
@@ -40,7 +40,7 @@ def notify_telegram(
             headers=headers,
             timeout=10.0,
         )
-        return response.is_success
+        return 200 <= response.status_code < 300
     except httpx.ConnectError as e:
         logger.warning("Failed to send notification: gateway not available (%s)", e)
         return False


### PR DESCRIPTION
## Summary
Replace `response.is_success` with explicit status code check for clarity.

## Changes
- Changed `return response.is_success` to `return 200 <= response.status_code < 300`
- This makes the HTTP status code verification explicit and clear

## Test plan
- [x] All 230 unit tests pass
- [x] Specific tests for 200, 201, 4xx, and 5xx status codes verified