### PR TITLE
test: add test for 204 No Content status code

### DIFF
--- a/tests/unit/test_updater_notifier.py
+++ b/tests/unit/test_updater_notifier.py
@@ -80,3 +80,10 @@ class TestNotifyTelegram:
         respx.post("http://localhost:18789/api/message").mock(return_value=httpx.Response(201))
         result = notify_telegram("Test", gateway_port=18789)
         assert result is True
+
+    @respx.mock
+    def test_returns_true_on_204_no_content(self):
+        """Function returns True on 204 No Content (2xx range)."""
+        respx.post("http://localhost:18789/api/message").mock(return_value=httpx.Response(204))
+        result = notify_telegram("Test", gateway_port=18789)
+        assert result is True


### PR DESCRIPTION
## Summary
Add test coverage for 204 No Content status code to ensure all 2xx codes
are treated as success.

## Changes
- Added `test_returns_true_on_204_no_content` test

## Test plan
- [x] All 231 unit tests pass
- [x] New test verifies 204 is treated as success