### PR TITLE
fix: handle OSError in subprocess calls

### DIFF
--- a/src/gasclaw/gastown/lifecycle.py
+++ b/src/gasclaw/gastown/lifecycle.py
@@ -81,6 +81,6 @@ def stop_all() -> None:
         subprocess.run(["gt", "mayor", "stop"], check=False)
         subprocess.run(["gt", "daemon", "stop"], check=False)
         subprocess.run(["dolt", "sql-server", "--stop"], check=False)
-    except FileNotFoundError:
-        # Binaries not installed - services likely not running
+    except OSError:
+        # Binaries not installed or permission denied - services likely not running
         pass

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -56,7 +56,7 @@ def _check_service(cmd: list[str], service_name: str) -> str:
     try:
         result = subprocess.run(cmd, capture_output=True, timeout=10)
         return "healthy" if result.returncode == 0 else "unhealthy"
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
         return "unhealthy"
 
 
@@ -86,7 +86,7 @@ def _list_agents() -> list[str]:
         )
         if result.returncode == 0:
             return [line.strip() for line in result.stdout.decode().splitlines() if line.strip()]
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
         pass
     return []
 

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -349,6 +349,16 @@ class TestStopAll:
         # Should not raise even though binaries are missing
         stop_all()
 
+    def test_handles_oserror_gracefully(self, monkeypatch):
+        """stop_all handles OSError (e.g., permission denied) gracefully."""
+
+        def mock_run(*a, **kw):
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        # Should not raise even though we get permission denied
+        stop_all()
+
     def test_handles_partial_failure(self, monkeypatch):
         """stop_all continues even if one service fails to stop."""
         calls = []

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -184,6 +184,17 @@ class TestCheckServiceErrorHandling:
         result = _check_service(["gt", "daemon", "status"], "daemon")
         assert result == "unhealthy"
 
+    def test_check_service_oserror(self, monkeypatch):
+        """Test _check_service returns 'unhealthy' on OSError (e.g., permission denied)."""
+        from gasclaw.health import _check_service
+
+        def _raise_oserror(*a, **kw):
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(subprocess, "run", _raise_oserror)
+        result = _check_service(["gt", "daemon", "status"], "daemon")
+        assert result == "unhealthy"
+
     def test_git_error_returns_non_compliant(self, monkeypatch, tmp_path):
         """Git command failure returns non-compliant activity."""
         git_dir = tmp_path / "git_repo"
@@ -269,6 +280,17 @@ class TestListAgentsErrorHandling:
             raise subprocess.TimeoutExpired(cmd=a[0] if a else "cmd", timeout=10)
 
         monkeypatch.setattr(subprocess, "run", _raise_timeout)
+        result = _list_agents()
+        assert result == []
+
+    def test_list_agents_oserror(self, monkeypatch):
+        """Test _list_agents returns empty list on OSError (e.g., permission denied)."""
+        from gasclaw.health import _list_agents
+
+        def _raise_oserror(*a, **kw):
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(subprocess, "run", _raise_oserror)
         result = _list_agents()
         assert result == []
 


### PR DESCRIPTION
## Summary
Extend exception handling to catch OSError (parent of FileNotFoundError) in health checks and lifecycle operations.

## Changes
- health.py: Catch OSError in _check_service and _list_agents
- lifecycle.py: Catch OSError in stop_all
- Added unit tests for OSError handling (permission denied scenarios)

## Test plan
- [x] All 234 unit tests pass
- [x] New tests verify OSError handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)