### PR TITLE
fix: add explicit version constraints for typer/click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 description = "Gastown + OpenClaw + KimiGas in one container"
 requires-python = ">=3.13"
 dependencies = [
-    "typer>=0.21.0",
+    "typer>=0.21.0,<0.25.0",
+    "click>=8.0.0,<9.0.0",
     "httpx>=0.28.0",
     "pydantic>=2.10.0",
     "tomlkit>=0.13.0",


### PR DESCRIPTION
## Summary
Fixes #58 - Add explicit version constraints for typer and click to prevent future version incompatibility issues.

## Changes
- Added upper bound to typer: `>=0.21.0,<0.25.0`
- Added explicit click dependency: `>=8.0.0,<9.0.0`

## Test plan
- [x] All 236 unit tests pass
- [x] `pip check` shows no dependency conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)