### PR TITLE
fix: improve stop_all exception handling (closes #68)

### DIFF
--- a/src/gasclaw/gastown/lifecycle.py
+++ b/src/gasclaw/gastown/lifecycle.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import time
 
 __all__ = ["start_dolt", "start_daemon", "start_mayor", "stop_all"]
+
+logger = logging.getLogger(__name__)
 
 
 def start_dolt(
@@ -76,11 +79,23 @@ def start_mayor(*, agent: str = "kimi-claude") -> None:
 
 
 def stop_all() -> None:
-    """Stop all Gastown services (mayor, daemon, dolt)."""
-    try:
-        subprocess.run(["gt", "mayor", "stop"], check=False)
-        subprocess.run(["gt", "daemon", "stop"], check=False)
-        subprocess.run(["dolt", "sql-server", "--stop"], check=False)
-    except OSError:
-        # Binaries not installed or permission denied - services likely not running
-        pass
+    """Stop all Gastown services (mayor, daemon, dolt).
+
+    All stop commands are attempted even if one fails. Exceptions are logged
+    but not raised to ensure best-effort shutdown.
+    """
+    commands = [
+        ["gt", "mayor", "stop"],
+        ["gt", "daemon", "stop"],
+        ["dolt", "sql-server", "--stop"],
+    ]
+
+    for cmd in commands:
+        try:
+            subprocess.run(cmd, check=False, timeout=30)
+        except FileNotFoundError:
+            logger.debug("Command not found: %s", cmd[0])
+        except subprocess.TimeoutExpired:
+            logger.warning("Timeout stopping service: %s", cmd)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Error stopping service %s: %s", cmd, e)

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -415,3 +415,126 @@ class TestStopAll:
         assert any("mayor" in s and "stop" in s for s in cmd_strs)
         assert any("daemon" in s and "stop" in s for s in cmd_strs)
         assert any("sql-server" in s and "--stop" in s for s in cmd_strs)
+
+
+class TestStopAllExceptionHandling:
+    """Tests for stop_all() exception handling - Issue #68."""
+
+    def test_all_commands_attempted_on_failure(self, monkeypatch):
+        """All stop commands are attempted even if one fails."""
+        calls = []
+
+        def mock_run(cmd, **kw):
+            calls.append((cmd, kw))
+            # First command succeeds, others fail
+            if "mayor" in cmd:
+                raise RuntimeError("mayor stop failed")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        stop_all()
+
+        # All three commands should have been attempted
+        assert len(calls) == 3
+        assert ["gt", "mayor", "stop"] in [c[0] for c in calls]
+        assert ["gt", "daemon", "stop"] in [c[0] for c in calls]
+        assert ["dolt", "sql-server", "--stop"] in [c[0] for c in calls]
+
+    def test_file_not_found_error_handled(self, monkeypatch, caplog):
+        """FileNotFoundError is handled gracefully."""
+        import logging
+
+        def mock_run(cmd, **kw):
+            raise FileNotFoundError("command not found")
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        with caplog.at_level(logging.DEBUG):
+            stop_all()
+
+        # Should complete without raising
+        assert "Command not found" in caplog.text
+
+    def test_timeout_expired_handled(self, monkeypatch, caplog):
+        """TimeoutExpired is handled gracefully."""
+        import logging
+
+        def mock_run(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        with caplog.at_level(logging.WARNING):
+            stop_all()
+
+        # Should complete without raising
+        assert "Timeout stopping service" in caplog.text
+
+    def test_permission_error_handled(self, monkeypatch, caplog):
+        """PermissionError (OSError) is handled gracefully."""
+        import logging
+
+        def mock_run(cmd, **kw):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        with caplog.at_level(logging.WARNING):
+            stop_all()
+
+        # Should complete without raising
+        assert "Error stopping service" in caplog.text
+
+    def test_runtime_error_handled(self, monkeypatch, caplog):
+        """RuntimeError is handled gracefully."""
+        import logging
+
+        def mock_run(cmd, **kw):
+            raise RuntimeError("unexpected error")
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        with caplog.at_level(logging.WARNING):
+            stop_all()
+
+        # Should complete without raising
+        assert "Error stopping service" in caplog.text
+
+    def test_all_commands_run_with_timeout(self, monkeypatch):
+        """All commands are run with 30 second timeout."""
+        calls = []
+
+        def mock_run(cmd, **kw):
+            calls.append((cmd, kw))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        stop_all()
+
+        # Check all commands have timeout=30
+        for _, kw in calls:
+            assert kw.get("timeout") == 30
+            assert kw.get("check") is False
+
+    def test_partial_failure_continues(self, monkeypatch):
+        """If one command fails, subsequent commands still run."""
+        calls = []
+
+        def mock_run(cmd, **kw):
+            calls.append((cmd, kw))
+            if "daemon" in cmd:
+                raise RuntimeError("daemon stop failed")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        stop_all()
+
+        # All three commands should have been attempted
+        assert len(calls) == 3
+        # Check order: mayor, daemon, dolt
+        assert "mayor" in calls[0][0]
+        assert "daemon" in calls[1][0]
+        assert "dolt" in calls[2][0]


### PR DESCRIPTION
## Summary
Improves the `stop_all()` function to handle all exception types and ensure all stop commands are attempted even if one fails.

## Changes
- Modified `stop_all()` to iterate through commands individually instead of sequentially in one try block
- Added proper exception handling for:
  - `FileNotFoundError` - command not found (debug log)
  - `subprocess.TimeoutExpired` - command timed out (warning log)
  - Generic `Exception` - any other error (warning log)
- Added 30-second timeout for each command
- Added logger for debugging

## Test Plan
- [x] All 243 unit tests pass
- [x] Added 7 new tests for exception handling:
  - `test_all_commands_attempted_on_failure`
  - `test_file_not_found_error_handled`
  - `test_timeout_expired_handled`
  - `test_permission_error_handled`
  - `test_runtime_error_handled`
  - `test_all_commands_run_with_timeout`
  - `test_partial_failure_continues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)