### PR TITLE
fix: show ?/? instead of None/None for missing key pool values (closes #65)

### DIFF
--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -35,8 +35,9 @@ class HealthReport:
 
     def summary(self) -> str:
         """Human-readable summary string."""
-        avail = self.key_pool.get("available", "?")
-        total = self.key_pool.get("total", "?")
+        # Handle both missing keys and None values
+        avail = self.key_pool.get("available") or "?"
+        total = self.key_pool.get("total") or "?"
         lines = [
             f"Dolt: {self.dolt}",
             f"Daemon: {self.daemon}",

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -460,6 +460,30 @@ class TestHealthReportSummary:
         summary = report.summary()
         assert "?" in summary  # Should show ? for unknown values
 
+    def test_summary_with_none_key_pool_values(self):
+        """Summary shows ?/? instead of None/None for None values - Issue #65."""
+        report = HealthReport(
+            dolt="healthy",
+            agents=["mayor"],
+            key_pool={"total": None, "available": None},
+        )
+        summary = report.summary()
+        # Should show ?/? not None/None
+        assert "None" not in summary
+        assert "?/?" in summary or "Keys: ?/" in summary
+
+    def test_summary_with_partial_none_key_pool(self):
+        """Summary handles partial None values in key_pool."""
+        report = HealthReport(
+            dolt="healthy",
+            agents=["mayor"],
+            key_pool={"total": 5, "available": None},
+        )
+        summary = report.summary()
+        # Should show ?/5 (available is None -> ?, total is 5)
+        assert "None" not in summary
+        assert "?/5" in summary or "?/" in summary
+
     def test_summary_with_none_activity_age(self):
         """Summary handles None last_commit_age in activity."""
         report = HealthReport(


### PR DESCRIPTION
## Summary
Fixes HealthReport.summary() to show \"?/?\" instead of \"None/None\" when key_pool values are None.

## Changes
- Use `or \"?\"` pattern to handle both missing keys and None values
- Added tests for None key pool values

## Test Plan
- [x] All 255 unit tests pass
- [x] Added 2 new tests for None key pool handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)