### PR TITLE
docs: document decimal-only integer parsing behavior (closes #64)

### DIFF
--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -45,8 +45,12 @@ def _parse_keys(raw: str) -> list[str]:
 def _parse_positive_int(value: str, default: int, name: str = "") -> int:
     """Parse a positive integer, returning default if invalid.
 
+    Only decimal integers are supported. Octal (0o), hexadecimal (0x),
+    and binary (0b) prefixes are not recognized - the value is parsed
+    as base-10. Leading zeros are ignored (e.g., "007" becomes 7).
+
     Args:
-        value: The string value to parse.
+        value: The string value to parse (decimal only).
         default: The default to return if parsing fails or value is not positive.
         name: The name of the config variable (for warning messages).
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -312,6 +312,33 @@ class TestConfigEdgeCases:
         assert cfg.activity_deadline == 3600  # Default used
         assert "ACTIVITY_DEADLINE" in caplog.text
 
+    def test_octal_notation_parsed_as_decimal(self, monkeypatch, env_vars):
+        """Octal notation is parsed as decimal - Issue #64.
+
+        This is the documented behavior: only decimal integers are supported.
+        Users expecting Unix octal behavior will get decimal interpretation.
+        """
+        for k, v in env_vars(GT_AGENT_COUNT="0777").items():
+            monkeypatch.setenv(k, v)
+
+        cfg = load_config()
+        # int("0777") returns 777, not 511 (which would be octal 0o777)
+        assert cfg.gt_agent_count == 777
+
+    def test_octal_prefix_parsed_as_decimal(self, monkeypatch, env_vars, caplog):
+        """Explicit octal prefix (0o) is parsed as decimal, not octal."""
+        import logging
+
+        for k, v in env_vars(MONITOR_INTERVAL="0o755").items():
+            monkeypatch.setenv(k, v)
+
+        with caplog.at_level(logging.WARNING):
+            cfg = load_config()
+
+        # int("0o755") with base 10 raises ValueError
+        assert cfg.monitor_interval == 300  # Default used
+        assert "MONITOR_INTERVAL" in caplog.text
+
 
 class TestParsePositiveIntEdgeCases:
     """Tests for _parse_positive_int function edge cases."""


### PR DESCRIPTION
## Summary
Documents that _parse_positive_int() only supports decimal integers, not octal/hex/binary.

## Changes
- Updated docstring to document decimal-only parsing
- Added explicit tests for octal notation behavior

## Test Plan
- [x] All 257 unit tests pass
- [x] Added 2 new tests documenting octal behavior:
  - test_octal_notation_parsed_as_decimal
  - test_octal_prefix_parsed_as_decimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)