### PR TITLE
test: improve coverage from 98% to 99%

### DIFF
--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -250,6 +250,26 @@ class TestProcessOpenPRs:
         assert result["failed"] == 1
         mock_merge.assert_not_called()
 
+    @patch("gasclaw.maintenance.merge_pr")
+    @patch("gasclaw.maintenance.fix_on_branch")
+    @patch("gasclaw.maintenance.checkout_and_test_pr")
+    @patch("gasclaw.maintenance.get_open_prs")
+    def test_handles_fixed_prs(self, mock_get_prs, mock_test, mock_fix, mock_merge):
+        """Test that PRs with successful fixes are counted correctly (line 204)."""
+        mock_get_prs.return_value = [
+            {"number": 1, "title": "Fix", "headRefName": "fix/1"},
+        ]
+        mock_test.return_value = False  # Tests fail
+        mock_fix.return_value = True  # But fix succeeds
+
+        result = process_open_prs()
+
+        assert result["total"] == 1
+        assert result["merged"] == 0
+        assert result["failed"] == 0
+        assert result["fixed"] == 1  # Line 204 coverage
+        mock_merge.assert_not_called()
+
     @patch("gasclaw.maintenance.get_open_prs")
     def test_handles_no_prs(self, mock_get_prs):
         mock_get_prs.return_value = []

--- a/tests/unit/test_openclaw_skill_manager.py
+++ b/tests/unit/test_openclaw_skill_manager.py
@@ -182,3 +182,44 @@ class TestInstallSkillsErrorHandling:
 
         with pytest.raises(OSError):
             install_skills(skills_src=src, skills_dst=dst)
+
+    def test_handles_permission_error_on_copytree(self, tmp_path, monkeypatch):
+        """PermissionError on copytree during skill copy is raised (lines 50-51)."""
+        src = tmp_path / "src-skills"
+        dst = tmp_path / "dst-skills"
+
+        # Create source skill
+        skill_dir = src / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Test")
+
+        # Mock copytree to raise PermissionError
+        import shutil
+        def mock_copytree(*args, **kwargs):
+            raise PermissionError("Permission denied copying")
+
+        monkeypatch.setattr(shutil, "copytree", mock_copytree)
+
+        with pytest.raises(PermissionError):
+            install_skills(skills_src=src, skills_dst=dst)
+
+    def test_handles_permission_error_on_chmod(self, tmp_path, monkeypatch):
+        """PermissionError when making script executable is raised (lines 63-65)."""
+        src = tmp_path / "src-skills"
+        dst = tmp_path / "dst-skills"
+
+        # Create source skill with script
+        skill_dir = src / "test-skill"
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Test")
+        (scripts_dir / "test.sh").write_text("#!/bin/bash\necho test")
+
+        # Mock chmod to raise PermissionError
+        def mock_chmod(*args, **kwargs):
+            raise PermissionError("Permission denied on chmod")
+
+        monkeypatch.setattr(Path, "chmod", mock_chmod)
+
+        with pytest.raises(PermissionError):
+            install_skills(skills_src=src, skills_dst=dst)


### PR DESCRIPTION
## Summary

Improves test coverage from 98% to 99% by adding tests for previously uncovered edge cases.

## Changes

- **maintenance.py**: Added test for `process_open_prs` when `fix_on_branch` succeeds (line 204)
  - Coverage: 92% → 93%
  
- **skill_manager.py**: Added tests for PermissionError handling
  - Test PermissionError on copytree (lines 50-51)  
  - Test PermissionError on chmod (lines 63-65)
  - Coverage: 88% → 100%

## Test plan

- [x] `make test` passes (312 tests)
- [x] Coverage improved to 99%
- [x] All new tests use mocking (no API keys needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)