### PR TITLE
fix: remove unused imports and variables

### DIFF
--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from dataclasses import dataclass
 
 __all__ = ["GasclawConfig", "load_config"]

--- a/src/gasclaw/openclaw/skill_manager.py
+++ b/src/gasclaw/openclaw/skill_manager.py
@@ -30,7 +30,7 @@ def install_skills(
     try:
         skills_dst.mkdir(parents=True, exist_ok=True)
         logger.debug(f"Ensured skills destination exists: {skills_dst}")
-    except PermissionError as e:
+    except PermissionError:
         logger.error(f"Permission denied creating skills directory: {skills_dst}")
         raise
 


### PR DESCRIPTION
## Summary

Removes unused imports and variables to fix ruff lint warnings.

## Changes

- Remove unused `re` import from `config.py`
- Remove unused variable `e` from `skill_manager.py`

## Test plan

- [x] `make test` passes (312 tests)
- [x] `make lint` passes (no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)