### PR TITLE
test: add pragma to exclude __main__ block from coverage

### DIFF
--- a/src/gasclaw/maintenance.py
+++ b/src/gasclaw/maintenance.py
@@ -319,4 +319,4 @@ def main(args: list[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover


### PR DESCRIPTION
## Summary

Added `# pragma: no cover` to the `__main__` block in `maintenance.py` to achieve 100% test coverage.

The `if __name__ == "__main__": main()` line is a standard Python entry point idiom that can only be executed when the module is run as a script. This pattern is conventionally excluded from coverage metrics since:
1. It contains no logic - just a function call
2. It's tested indirectly through tests on `main()` itself
3. All code paths within `main()` are already covered

## Test plan

- [x] `make test` passes (all 317 tests)
- [x] `make lint` passes
- [x] Coverage is now 100% (806/806 statements)

## Coverage Report

```
Name                                    Stmts   Miss  Cover
-----------------------------------------------------------
...
src/gasclaw/maintenance.py              132      0   100%
-----------------------------------------------------------
TOTAL                                   806      0   100%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)