### PR TITLE
style: apply ruff formatting to 7 files

### DIFF
--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -32,21 +32,15 @@ class GasclawConfig:
         """Validate configuration after initialization."""
         # Validate telegram_owner_id is numeric
         if self.telegram_owner_id and not self.telegram_owner_id.isdigit():
-            raise ValueError(
-                f"TELEGRAM_OWNER_ID must be numeric, got: {self.telegram_owner_id}"
-            )
+            raise ValueError(f"TELEGRAM_OWNER_ID must be numeric, got: {self.telegram_owner_id}")
 
         # Validate paths are absolute
         if self.project_dir and not self.project_dir.startswith("/"):
-            logger.warning(
-                f"PROJECT_DIR should be an absolute path, got: {self.project_dir}"
-            )
+            logger.warning(f"PROJECT_DIR should be an absolute path, got: {self.project_dir}")
 
         # Validate gt_rig_url
         if self.gt_rig_url and not self.gt_rig_url.startswith(("/", "http", "https")):
-            logger.warning(
-                f"GT_RIG_URL should be a path or URL, got: {self.gt_rig_url}"
-            )
+            logger.warning(f"GT_RIG_URL should be a path or URL, got: {self.gt_rig_url}")
 
 
 def _require_env(name: str) -> str:

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -165,4 +165,3 @@ def check_agent_activity(
         "compliant": False,
         "error": "failed to get git log",
     }
-

--- a/src/gasclaw/maintenance.py
+++ b/src/gasclaw/maintenance.py
@@ -52,8 +52,15 @@ def get_open_prs() -> list[dict]:
     try:
         result = run_command(
             [
-                "gh", "pr", "list", "--repo", REPO, "--state", "open",
-                "--json", "number,title,headRefName,author",
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                REPO,
+                "--state",
+                "open",
+                "--json",
+                "number,title,headRefName,author",
             ],
             check=False,
         )
@@ -62,6 +69,7 @@ def get_open_prs() -> list[dict]:
             return []
 
         import json
+
         return json.loads(result.stdout)
     except Exception as e:
         logger.error("Error getting open PRs: %s", e)
@@ -84,6 +92,7 @@ def get_open_issues() -> list[dict]:
             return []
 
         import json
+
         return json.loads(result.stdout)
     except Exception as e:
         logger.error("Error getting open issues: %s", e)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -81,6 +81,7 @@ class TestStartCommand:
 
     def test_start_exits_on_bootstrap_failure(self, config, monkeypatch, tmp_path):
         """start command exits with code 1 if bootstrap raises an exception."""
+
         def mock_bootstrap_fail(cfg, gt_root):
             raise RuntimeError("dolt connection failed")
 
@@ -295,6 +296,7 @@ class TestMaintainCommand:
 
     def test_maintain_once_exits_on_failure(self, monkeypatch):
         """maintain --once exits with error on failure."""
+
         def fail_cycle():
             raise RuntimeError("API error")
 

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -44,10 +44,18 @@ class TestGetOpenPRs:
     @patch("gasclaw.maintenance.run_command")
     def test_returns_parsed_prs(self, mock_run):
         mock_prs = [
-            {"number": 1, "title": "Fix bug", "headRefName": "fix/bug",
-             "author": {"login": "user"}},
-            {"number": 2, "title": "Add feature", "headRefName": "feat/thing",
-             "author": {"login": "user"}},
+            {
+                "number": 1,
+                "title": "Fix bug",
+                "headRefName": "fix/bug",
+                "author": {"login": "user"},
+            },
+            {
+                "number": 2,
+                "title": "Add feature",
+                "headRefName": "feat/thing",
+                "author": {"login": "user"},
+            },
         ]
         mock_result = MagicMock()
         mock_result.returncode = 0
@@ -148,6 +156,7 @@ class TestCheckoutAndTestPR:
     @patch("gasclaw.maintenance.run_command")
     def test_logs_stdout_on_test_failure(self, mock_run, mock_logger):
         """Test that stdout is logged when tests fail (lines 122-124)."""
+
         def side_effect(cmd, **kwargs):
             if "pytest" in cmd:
                 mock_result = MagicMock()
@@ -177,8 +186,14 @@ class TestMergePR:
         assert result is True
         calls = [call[0][0] for call in mock_run.call_args_list]
         assert [
-            "gh", "pr", "merge", "42", "--repo", "gastown-publish/gasclaw",
-            "--squash", "--delete-branch",
+            "gh",
+            "pr",
+            "merge",
+            "42",
+            "--repo",
+            "gastown-publish/gasclaw",
+            "--squash",
+            "--delete-branch",
         ] in calls
         assert ["git", "checkout", "main"] in calls
 

--- a/tests/unit/test_openclaw_skill_manager.py
+++ b/tests/unit/test_openclaw_skill_manager.py
@@ -175,6 +175,7 @@ class TestInstallSkillsErrorHandling:
 
         # Mock copytree to raise OSError
         import shutil
+
         def mock_copytree(*args, **kwargs):
             raise OSError("Disk full")
 
@@ -195,6 +196,7 @@ class TestInstallSkillsErrorHandling:
 
         # Mock copytree to raise PermissionError
         import shutil
+
         def mock_copytree(*args, **kwargs):
             raise PermissionError("Permission denied copying")
 

--- a/tests/unit/test_updater_checker.py
+++ b/tests/unit/test_updater_checker.py
@@ -106,6 +106,7 @@ class TestCheckerLogging:
 
     def test_logs_warning_on_timeout(self, monkeypatch, caplog):
         """Timeout logs warning."""
+
         def raise_timeout(*a, **kw):
             raise subprocess.TimeoutExpired(cmd=a[0], timeout=10)
 


### PR DESCRIPTION
## Summary
Apply ruff formatting fixes to 7 files that had formatting inconsistencies.

## Changes
- Formatted `src/gasclaw/config.py`, `health.py`, `maintenance.py`
- Formatted `tests/unit/test_cli.py`, `test_maintenance.py`
- Formatted `test_openclaw_skill_manager.py`, `test_updater_checker.py`

## Verification
- [x] `python -m pytest tests/unit -q` passes (317 tests)
- [x] `python -m ruff check src tests` passes
- [x] `python -m ruff format --check src tests` passes

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)