### PR TITLE
fix(cli): handle KeyboardInterrupt during bootstrap

### DIFF
--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -75,6 +75,10 @@ def start(
     try:
         bootstrap(config, gt_root=gt_root)
         logger.info("Bootstrap completed successfully")
+    except KeyboardInterrupt:
+        logger.info("Bootstrap interrupted by user")
+        console.print("\n[yellow]Bootstrap interrupted by user[/yellow]")
+        raise typer.Exit(code=130) from None
     except Exception as e:
         logger.exception("Bootstrap failed")
         console.print(f"[red]Bootstrap failed:[/red] {e}")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -94,6 +94,20 @@ class TestStartCommand:
         assert "Bootstrap failed" in result.output
         assert "dolt connection failed" in result.output
 
+    def test_start_exits_on_keyboard_interrupt(self, config, monkeypatch, tmp_path):
+        """start command exits with code 130 if bootstrap is interrupted."""
+
+        def mock_bootstrap_interrupt(cfg, gt_root):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
+        monkeypatch.setattr("gasclaw.cli.bootstrap", mock_bootstrap_interrupt)
+
+        result = runner.invoke(app, ["start", "--gt-root", str(tmp_path)])
+
+        assert result.exit_code == 130
+        assert "interrupted" in result.output.lower()
+
 
 class TestStopCommand:
     def test_calls_stop_all(self, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes a UX issue where pressing Ctrl+C during bootstrap would show a full traceback instead of a clean exit.

## Changes

- Added KeyboardInterrupt handling in the bootstrap phase of the start command
- Exit code 130 (standard for SIGINT) is returned when interrupted
- Added corresponding test coverage

## Test plan

- [x] python -m pytest tests/unit/test_cli.py -v passes (21 tests)
- [x] Full test suite passes (318 tests)
- [x] ruff check src tests passes

🤖 Generated with Claude Code