### PR TITLE
fix: resolve line length lint errors in tests

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -406,5 +406,6 @@ class TestMaintainCommand:
         result = runner.invoke(app, ["maintain", "--interval", "60"])
 
         assert result.exit_code == 0
-        assert "Entering maintenance loop" in result.output or "Starting maintenance" in result.output
+        assert "Entering maintenance loop" in result.output or \
+               "Starting maintenance" in result.output
         assert "interval=60" in result.output or "60s" in result.output

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -229,7 +229,8 @@ class TestMergePR:
 
         assert result is True
         # Verify success message is logged
-        success_calls = [c for c in mock_logger.info.call_args_list if "Successfully merged" in str(c)]
+        success_calls = [c for c in mock_logger.info.call_args_list
+                         if "Successfully merged" in str(c)]
         assert len(success_calls) == 1
         assert "42" in str(success_calls[0])
 


### PR DESCRIPTION
## Summary
Fix E501 line too long errors in test files:
- test_cli.py:409 - split long assertion across two lines
- test_maintenance.py:232 - split list comprehension

## Test plan
- [x] `python -m ruff check src tests` passes
- [x] `python -m pytest tests/unit -v` passes (338 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)