### PR TITLE
fix: handle PermissionError and OSError in run_doctor

### DIFF
--- a/src/gasclaw/openclaw/doctor.py
+++ b/src/gasclaw/openclaw/doctor.py
@@ -55,6 +55,18 @@ def run_doctor(*, repair: bool = False, timeout: int = 60) -> DoctorResult:
             returncode=-1,
             output="openclaw not installed or not found in PATH",
         )
+    except PermissionError:
+        return DoctorResult(
+            healthy=False,
+            returncode=-1,
+            output="openclaw binary exists but is not executable (permission denied)",
+        )
+    except OSError as e:
+        return DoctorResult(
+            healthy=False,
+            returncode=-1,
+            output=f"openclaw failed to execute: {e}",
+        )
     except subprocess.TimeoutExpired:
         return DoctorResult(
             healthy=False,

--- a/tests/unit/test_openclaw_doctor.py
+++ b/tests/unit/test_openclaw_doctor.py
@@ -76,6 +76,24 @@ class TestRunDoctor:
         assert result.healthy is False
         assert "timed out" in result.output.lower()
 
+    def test_handles_permission_error(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            raise PermissionError("Permission denied")
+
+        monkeypatch.setattr("gasclaw.openclaw.doctor.subprocess.run", mock_run)
+        result = run_doctor()
+        assert result.healthy is False
+        assert "permission" in result.output.lower()
+
+    def test_handles_os_error(self, monkeypatch):
+        def mock_run(cmd, **kwargs):
+            raise OSError("Some other OS error")
+
+        monkeypatch.setattr("gasclaw.openclaw.doctor.subprocess.run", mock_run)
+        result = run_doctor()
+        assert result.healthy is False
+        assert "failed to execute" in result.output.lower()
+
 
 class TestDoctorResult:
     def test_summary_healthy(self):


### PR DESCRIPTION
## Summary

Add explicit handling for `PermissionError` and generic `OSError` in `run_doctor()`. Previously only `FileNotFoundError` was handled, leaving other execution failures unhandled.

## Changes

- Add `PermissionError` handler with descriptive message (binary exists but not executable)
- Add generic `OSError` handler for other execution failures  
- Add unit tests for both new error cases

## Test plan

- [x] All 340 unit tests pass
- [x] Linting passes
- [x] New tests cover PermissionError and OSError cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)