### PR TITLE
fix: handle PermissionError in subprocess calls consistently

### DIFF
--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -157,7 +157,7 @@ def check_agent_activity(
                 "compliant": age <= deadline_seconds,
                 "error": None,
             }
-    except (FileNotFoundError, subprocess.TimeoutExpired, ValueError):
+    except (OSError, subprocess.TimeoutExpired, ValueError):
         pass
 
     return {

--- a/src/gasclaw/updater/applier.py
+++ b/src/gasclaw/updater/applier.py
@@ -35,7 +35,7 @@ def apply_updates() -> dict[str, str]:
                 stderr = result.stderr.decode().strip()[:200]
                 results[name] = f"failed: {stderr}"
                 logger.error(f"{name} update failed: {stderr}")
-        except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        except (OSError, subprocess.TimeoutExpired) as e:
             results[name] = f"error: {e}"
             logger.error(f"{name} update error: {e}")
     return results

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -272,6 +272,22 @@ class TestCheckServiceErrorHandling:
         assert activity["compliant"] is False
         assert activity["last_commit_age"] is None
 
+    def test_permission_error_returns_non_compliant(self, monkeypatch, tmp_path):
+        """PermissionError returns non-compliant."""
+        git_dir = tmp_path / "git_repo"
+        git_dir.mkdir()
+        git_dot_git = git_dir / ".git"
+        git_dot_git.mkdir()
+
+        def raise_permission_error(*a, **kw):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(subprocess, "run", raise_permission_error)
+        activity = check_agent_activity(project_dir=str(git_dir), deadline_seconds=3600)
+        assert activity["compliant"] is False
+        assert activity["last_commit_age"] is None
+        assert activity["error"] is not None
+
 
 class TestListAgentsErrorHandling:
     """Tests for _list_agents() exception handling."""

--- a/tests/unit/test_updater_applier.py
+++ b/tests/unit/test_updater_applier.py
@@ -50,6 +50,16 @@ class TestApplyUpdates:
         results = apply_updates()
         assert any("error" in v.lower() or "not found" in v.lower() for v in results.values())
 
+    def test_handles_permission_error(self, monkeypatch):
+        """PermissionError is caught and reported."""
+
+        def raise_permission_error(*a, **kw):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(subprocess, "run", raise_permission_error)
+        results = apply_updates()
+        assert any("error" in v.lower() or "permission" in v.lower() for v in results.values())
+
     def test_stderr_truncation_on_failure(self, monkeypatch):
         """Long stderr is truncated to 200 chars."""
         long_error = b"x" * 500


### PR DESCRIPTION
## Summary

Replace FileNotFoundError with OSError in exception handling to catch all subprocess execution failures including PermissionError.

## Changes

- health.py check_agent_activity: Catch OSError instead of FileNotFoundError
- applier.py apply_updates: Catch OSError instead of FileNotFoundError
- Add tests for PermissionError handling in both modules

## Rationale

FileNotFoundError only catches the case where the executable doesn't exist. OSError is the parent class that also catches PermissionError (when an executable exists but isn't executable) and other OS-level errors.

## Test plan

- [x] New test `test_permission_error_returns_non_compliant` passes
- [x] New test `test_handles_permission_error` passes  
- [x] All 342 unit tests pass
- [x] 100% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)