### PR TITLE
fix: add missing return type annotation to _parse_args

### DIFF
--- a/src/gasclaw/maintenance.py
+++ b/src/gasclaw/maintenance.py
@@ -11,6 +11,7 @@ Can be run as a standalone script or imported as a module.
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 import time
 
@@ -293,7 +294,7 @@ def maintenance_loop(interval: int = 300) -> None:
         notify_telegram("🛑 Maintenance loop stopped")
 
 
-def _parse_args(args: list[str] | None = None):
+def _parse_args(args: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments.
 
     Args:
@@ -302,8 +303,6 @@ def _parse_args(args: list[str] | None = None):
     Returns:
         Parsed arguments namespace.
     """
-    import argparse
-
     parser = argparse.ArgumentParser(description="Gasclaw maintenance loop")
     parser.add_argument("--once", action="store_true", help="Run once and exit (don't loop)")
     parser.add_argument(


### PR DESCRIPTION
## Summary
Add missing return type annotation to `_parse_args()` function in maintenance.py.

## Changes
- Add `argparse` import at module level (moved from inside function)
- Add `argparse.Namespace` return type annotation to `_parse_args()`
- Remove redundant import statement inside function body

## Benefits
- Improved type safety and IDE support
- Better code documentation
- Follows project conventions for type annotations

## Test plan
- [x] `make test` passes (all 342 tests)
- [x] `make lint` passes
- [x] 100% code coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)