### PR TITLE
fix: add return type annotation to __post_init__

### DIFF
--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -28,7 +28,7 @@ class GasclawConfig:
     monitor_interval: int = 300  # seconds between health checks
     activity_deadline: int = 3600  # seconds — must see a push/PR within this window
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate configuration after initialization."""
         # Validate telegram_owner_id is numeric
         if self.telegram_owner_id and not self.telegram_owner_id.isdigit():


### PR DESCRIPTION
## Summary
Add missing return type annotation to `GasclawConfig.__post_init__()` method.

## Changes
- Add `-> None` return type annotation to `__post_init__`

## Benefits
- Consistent with project type hint conventions
- Better IDE support and type checking

## Test plan
- [x] `make test` passes (all 342 tests)
- [x] `make lint` passes
- [x] 100% code coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)