### PR TITLE
style: fix lint issues and extend ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,4 @@ target-version = "py313"
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP"]
+select = ["E", "F", "I", "UP", "W", "B", "C4", "SIM", "PERF"]

--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -51,8 +51,10 @@ def main(
 
 @app.command()
 def start(
-    gt_root: Path = typer.Option(Path("/workspace/gt"), help="Gastown root directory"),
-    project_dir: Path | None = typer.Option(
+    gt_root: Path = typer.Option(  # noqa: B008
+        Path("/workspace/gt"), help="Gastown root directory"
+    ),
+    project_dir: Path | None = typer.Option(  # noqa: B008
         None, help="Project directory for activity checks (overrides config)"
     ),
 ) -> None:

--- a/src/gasclaw/kimigas/key_pool.py
+++ b/src/gasclaw/kimigas/key_pool.py
@@ -6,6 +6,7 @@ rather than account discovery.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
@@ -64,10 +65,8 @@ class KeyPool:
             os.replace(temp_path, state_file)
         except Exception:
             # Clean up temp file on failure
-            try:
+            with contextlib.suppress(OSError):
                 os.unlink(temp_path)
-            except OSError:
-                pass
             raise
 
     def get_key(self) -> str:

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -101,9 +101,11 @@ class TestBootstrap:
         assert order.index("mayor") < order.index("notify")
 
     def test_error_propagation(self, config, tmp_path):
-        with patch("gasclaw.bootstrap.setup_kimi_accounts", side_effect=RuntimeError("boom")):
-            with pytest.raises(RuntimeError, match="boom"):
-                bootstrap(config, gt_root=tmp_path)
+        with (
+            patch("gasclaw.bootstrap.setup_kimi_accounts", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            bootstrap(config, gt_root=tmp_path)
 
     def test_rollback_on_dolt_failure(self, config, tmp_path):
         """Rollback stops dolt if it was started before failure."""

--- a/tests/unit/test_gastown_installer.py
+++ b/tests/unit/test_gastown_installer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
 import tomlkit
 
 from gasclaw.gastown.installer import gastown_install, setup_kimi_accounts
@@ -87,7 +88,7 @@ class TestGastownInstall:
         monkeypatch.setattr(subprocess, "run", mock_run)
         try:
             gastown_install(gt_root=tmp_path, rig_url="/project")
-            assert False, "Expected CalledProcessError"
+            pytest.fail("Expected CalledProcessError")
         except subprocess.CalledProcessError as e:
             assert e.returncode == 1
             assert "install" in str(e.cmd)
@@ -104,7 +105,7 @@ class TestGastownInstall:
         monkeypatch.setattr(subprocess, "run", mock_run)
         try:
             gastown_install(gt_root=tmp_path, rig_url="/project")
-            assert False, "Expected CalledProcessError"
+            pytest.fail("Expected CalledProcessError")
         except subprocess.CalledProcessError as e:
             assert e.returncode == 2
             assert "rig" in str(e.cmd)
@@ -118,7 +119,7 @@ class TestGastownInstall:
         monkeypatch.setattr(subprocess, "run", raise_not_found)
         try:
             gastown_install(gt_root=tmp_path, rig_url="/project")
-            assert False, "Expected FileNotFoundError"
+            pytest.fail("Expected FileNotFoundError")
         except FileNotFoundError:
             pass
 
@@ -131,7 +132,7 @@ class TestGastownInstall:
         monkeypatch.setattr(subprocess, "run", raise_timeout)
         try:
             gastown_install(gt_root=tmp_path, rig_url="/project")
-            assert False, "Expected TimeoutExpired"
+            pytest.fail("Expected TimeoutExpired")
         except subprocess.TimeoutExpired:
             pass
 

--- a/tests/unit/test_gastown_lifecycle.py
+++ b/tests/unit/test_gastown_lifecycle.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 from gasclaw.gastown.lifecycle import start_daemon, start_dolt, start_mayor, stop_all
 
 
@@ -47,12 +49,8 @@ class TestStartDolt:
                 return 0
 
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: DeadProcess())
-        try:
+        with pytest.raises(RuntimeError, match="exited early"):
             start_dolt(data_dir="/tmp/dolt-data", port=3307, timeout=1)
-            assert False, "Expected RuntimeError"
-        except RuntimeError as e:
-            assert "exited early" in str(e)
-            assert "1" in str(e)
 
     def test_raises_timeout_if_never_ready(self, monkeypatch):
         """If dolt never becomes ready, raise TimeoutError."""
@@ -76,11 +74,9 @@ class TestStartDolt:
             "run",
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
         )
-        try:
+        with pytest.raises(TimeoutError) as exc_info:
             start_dolt(data_dir="/tmp/dolt-data", port=3307, timeout=1)
-            assert False, "Expected TimeoutError"
-        except TimeoutError as e:
-            assert "not ready" in str(e).lower() or "timeout" in str(e).lower()
+        assert "not ready" in str(exc_info.value).lower() or "timeout" in str(exc_info.value).lower()
 
     def test_uses_custom_data_dir(self, monkeypatch):
         """start_dolt passes custom data_dir to dolt command."""
@@ -161,10 +157,8 @@ class TestStartDolt:
                 return 0
 
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: DeadProcess())
-        try:
+        with pytest.raises(RuntimeError):
             start_dolt(data_dir="/tmp/dolt", port=3307, timeout=1)
-        except RuntimeError:
-            pass
 
         assert len(terminate_called) == 1
         assert len(wait_called) == 1
@@ -192,10 +186,8 @@ class TestStartDolt:
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
         )
 
-        try:
+        with pytest.raises(TimeoutError):
             start_dolt(data_dir="/tmp/dolt", port=3307, timeout=1)
-        except TimeoutError:
-            pass
 
         assert len(terminate_called) == 1
 
@@ -228,10 +220,8 @@ class TestStartDolt:
             lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"not ready"),
         )
 
-        try:
+        with pytest.raises(TimeoutError):
             start_dolt(data_dir="/tmp/dolt", port=3307, timeout=1)
-        except TimeoutError:
-            pass
 
         assert len(terminate_called) == 1
         assert len(kill_called) == 1
@@ -255,11 +245,9 @@ class TestStartDaemon:
             "run",
             lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("daemon failed")),
         )
-        try:
+        with pytest.raises(RuntimeError) as exc_info:
             start_daemon()
-            assert False, "Expected RuntimeError"
-        except RuntimeError as e:
-            assert "daemon" in str(e).lower() or "failed" in str(e).lower()
+        assert "daemon" in str(exc_info.value).lower() or "failed" in str(exc_info.value).lower()
 
     def test_handles_missing_binary(self, monkeypatch):
         """start_daemon raises FileNotFoundError if gt not installed."""
@@ -268,11 +256,8 @@ class TestStartDaemon:
             raise FileNotFoundError("gt not found")
 
         monkeypatch.setattr(subprocess, "run", raise_not_found)
-        try:
+        with pytest.raises(FileNotFoundError):
             start_daemon()
-            assert False, "Expected FileNotFoundError"
-        except FileNotFoundError:
-            pass
 
 
 class TestStartMayor:
@@ -295,11 +280,9 @@ class TestStartMayor:
             "run",
             lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("mayor failed")),
         )
-        try:
+        with pytest.raises(RuntimeError) as exc_info:
             start_mayor(agent="kimi-claude")
-            assert False, "Expected RuntimeError"
-        except RuntimeError as e:
-            assert "mayor" in str(e).lower() or "failed" in str(e).lower()
+        assert "mayor" in str(exc_info.value).lower() or "failed" in str(exc_info.value).lower()
 
     def test_handles_missing_binary(self, monkeypatch):
         """start_mayor raises FileNotFoundError if gt not installed."""
@@ -308,11 +291,8 @@ class TestStartMayor:
             raise FileNotFoundError("gt not found")
 
         monkeypatch.setattr(subprocess, "run", raise_not_found)
-        try:
+        with pytest.raises(FileNotFoundError):
             start_mayor(agent="kimi-claude")
-            assert False, "Expected FileNotFoundError"
-        except FileNotFoundError:
-            pass
 
 
 class TestStopAll:

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import time
 
 import pytest
@@ -194,7 +195,7 @@ class TestKeyPoolAtomicWrite:
         pool = KeyPool(["k1"], state_dir=tmp_path)
 
         # Make os.fdopen fail to trigger cleanup
-        original_fdopen = __builtins__["open"] if "open" in __builtins__ else open
+        original_fdopen = __builtins__.get("open", open)
 
         def fail_on_fdopen(*args, **kwargs):
             if args and hasattr(args[0], "__class__") and "int" in str(type(args[0])):
@@ -203,10 +204,8 @@ class TestKeyPoolAtomicWrite:
 
         monkeypatch.setattr("os.fdopen", fail_on_fdopen)
 
-        try:
+        with contextlib.suppress(OSError):
             pool._save_state({"test": "data"})
-        except OSError:
-            pass
 
         # Temp file should be cleaned up
         temp_files = list(tmp_path.glob(".key-rotation-*.tmp"))

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,7 +29,7 @@ class TestRunCommand:
         assert "hello" in result.stdout
 
     def test_raises_on_failure_when_check_true(self):
-        with pytest.raises(Exception):
+        with pytest.raises(subprocess.CalledProcessError):
             run_command(["false"], check=True)
 
     def test_returns_result_on_failure_when_check_false(self):
@@ -36,7 +37,7 @@ class TestRunCommand:
         assert result.returncode != 0
 
     def test_respects_timeout(self):
-        with pytest.raises(Exception):
+        with pytest.raises(subprocess.TimeoutExpired):
             run_command(["sleep", "10"], timeout=1)
 
 


### PR DESCRIPTION
## Summary

Fix multiple lint issues found by extended ruff rules and add more comprehensive linting to pyproject.toml.

## Changes

- **SIM105**: Use `contextlib.suppress()` instead of `try/except/pass` patterns
- **B011**: Replace `assert False` with `pytest.raises()` / `pytest.fail()` in tests
- **B017**: Use specific exceptions instead of blind `Exception` catches
- **SIM117**: Combine nested `with` statements for cleaner code
- **SIM401**: Use `dict.get()` instead of if blocks for builtins access
- **B008**: Add noqa comments for typer.Option patterns (false positives)
- **pyproject.toml**: Extend lint rules with W, B, C4, SIM, PERF

## Test Plan

- [x] All 342 unit tests pass
- [x] Ruff linting passes with extended rules
- [x] No functional changes, only code style improvements

🤖 Generated with Claude Code