### PR TITLE
fix: align __version__ with pyproject.toml

### DIFF
--- a/src/gasclaw/__init__.py
+++ b/src/gasclaw/__init__.py
@@ -1,3 +1,3 @@
 """Gasclaw — Gastown + OpenClaw + KimiGas in one container."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -241,6 +242,22 @@ class TestVersionCommand:
         result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
         assert __version__ in result.output
+
+    def test_version_matches_pyproject_toml(self):
+        """__version__ matches the version in pyproject.toml."""
+        import tomllib
+
+        from gasclaw import __version__
+
+        pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            pyproject = tomllib.load(f)
+
+        expected_version = pyproject["project"]["version"]
+        assert __version__ == expected_version, (
+            f"Version mismatch: __init__.py has '{__version__}', "
+            f"pyproject.toml has '{expected_version}'"
+        )
 
 
 class TestCLIEdgeCases:


### PR DESCRIPTION
## Summary

Fixed version mismatch between `__init__.py` (0.1.0) and `pyproject.toml` (0.2.0).

## Changes

- Updated `__version__` in `src/gasclaw/__init__.py` to "0.2.0"
- Added test `test_version_matches_pyproject_toml` to prevent future mismatches

## Test plan

- [x] New test fails before fix (TDD)
- [x] New test passes after fix
- [x] All 343 unit tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)