### PR TITLE
test: add missing test for stop command exception handling

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -151,6 +151,20 @@ class TestStopCommand:
         assert "Stopping all services..." in result.output
         assert "All services stopped" in result.output
 
+    def test_stop_exits_on_exception(self, monkeypatch):
+        """stop command exits with code 1 if stop_all raises an exception (lines 103-106)."""
+
+        def mock_stop_fail():
+            raise RuntimeError("service not running")
+
+        monkeypatch.setattr("gasclaw.cli.stop_all", mock_stop_fail)
+
+        result = runner.invoke(app, ["stop"])
+
+        assert result.exit_code == 1
+        assert "Error stopping services" in result.output
+        assert "service not running" in result.output
+
 
 class TestStatusCommand:
     def test_shows_health_status(self, monkeypatch):


### PR DESCRIPTION
## Summary

Adds missing test coverage for the `stop` command's exception handling path. This test ensures that when `stop_all()` raises an exception, the CLI exits with code 1 and displays an appropriate error message.

## Changes

- Added `test_stop_exits_on_exception` in `tests/unit/test_cli.py`
- Covers lines 103-106 in `src/gasclaw/cli.py`
- Brings `cli.py` to 100% test coverage

## Test plan

- [x] `make test` passes (all 344 tests)
- [x] `make lint` passes
- [x] New test covers previously uncovered error handling path

🤖 Generated with [Claude Code](https://claude.com/claude-code)