### PR TITLE
test: extend whitespace test with tabs and newlines

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -108,11 +108,12 @@ class TestLoadConfig:
         cfg = load_config()
         assert cfg.openclaw_kimi_key not in cfg.gastown_kimi_keys
 
-    def test_whitespace_only_env_vars_treated_as_missing(self, monkeypatch, env_vars):
-        """Whitespace-only env vars should be treated as missing."""
+    @pytest.mark.parametrize("whitespace", ["", " ", "  ", "\t", "\n", " \t\n "])
+    def test_whitespace_only_env_vars_treated_as_missing(self, monkeypatch, env_vars, whitespace):
+        """Whitespace-only env vars should be treated as missing (spaces, tabs, newlines)."""
         for k, v in env_vars().items():
             monkeypatch.setenv(k, v)
-        monkeypatch.setenv("GASTOWN_KIMI_KEYS", "   ")
+        monkeypatch.setenv("GASTOWN_KIMI_KEYS", whitespace)
         with pytest.raises(ValueError, match="GASTOWN_KIMI_KEYS"):
             load_config()
 


### PR DESCRIPTION
## Summary

Extends the whitespace-only environment variable test to cover more edge cases including tabs, newlines, and mixed whitespace.

## Changes

- Converted `test_whitespace_only_env_vars_treated_as_missing` to use `pytest.mark.parametrize`
- Added test cases for: empty string, spaces, tabs, newlines, and mixed whitespace
- Ensures config validation correctly rejects all forms of whitespace-only values

## Test plan

- [x] `make test` passes (all 349 tests)
- [x] `make lint` passes
- [x] New parametrized test covers 6 whitespace variations

🤖 Generated with [Claude Code](https://claude.com/claude-code)