### PR TITLE
docs: standardize docstrings to use modern type hint names

### DIFF
--- a/src/gasclaw/gastown/installer.py
+++ b/src/gasclaw/gastown/installer.py
@@ -49,7 +49,7 @@ def setup_kimi_accounts(
     """Write ~/.kimi-accounts/<N>/config.toml for each key.
 
     Args:
-        keys: List of Kimi API keys.
+        keys: list of Kimi API keys.
         accounts_dir: Override for ~/.kimi-accounts.
     """
     if accounts_dir is None:

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -133,7 +133,7 @@ def check_agent_activity(
         deadline_seconds: Max allowed time since last activity.
 
     Returns:
-        Dict with last_commit_age (seconds), compliant (bool), and error (str|None).
+        dict with last_commit_age (seconds), compliant (bool), and error (str|None).
     """
     try:
         result = subprocess.run(

--- a/src/gasclaw/kimigas/proxy.py
+++ b/src/gasclaw/kimigas/proxy.py
@@ -18,7 +18,7 @@ def build_claude_env(api_key: str, *, config_dir: str | None = None) -> dict[str
         config_dir: Isolated Claude config directory. Defaults to ~/.claude-kimigas.
 
     Returns:
-        Dict of environment variables to set/override.
+        dict of environment variables to set/override.
     """
     return {
         "ANTHROPIC_BASE_URL": KIMI_ANTHROPIC_BASE_URL,

--- a/src/gasclaw/maintenance.py
+++ b/src/gasclaw/maintenance.py
@@ -48,7 +48,7 @@ def get_open_prs() -> list[dict]:
     """Get list of open PRs from GitHub.
 
     Returns:
-        List of PR dicts with number, title, branch, and author.
+        list of PR dicts with number, title, branch, and author.
     """
     try:
         result = run_command(
@@ -81,7 +81,7 @@ def get_open_issues() -> list[dict]:
     """Get list of open issues from GitHub.
 
     Returns:
-        List of issue dicts with number and title.
+        list of issue dicts with number and title.
     """
     try:
         result = run_command(
@@ -188,7 +188,7 @@ def process_open_prs() -> dict:
     """Process all open PRs: test and merge if passing.
 
     Returns:
-        Dict with counts of merged, failed, and fixed PRs.
+        dict with counts of merged, failed, and fixed PRs.
     """
     stats = {"merged": 0, "failed": 0, "fixed": 0, "total": 0}
 
@@ -222,7 +222,7 @@ def process_open_issues() -> dict:
     """Process open issues by creating fix branches and PRs.
 
     Returns:
-        Dict with counts of issues processed.
+        dict with counts of issues processed.
     """
     stats = {"processed": 0, "total": 0}
 
@@ -244,7 +244,7 @@ def run_maintenance_cycle() -> dict:
     """Run a single maintenance cycle.
 
     Returns:
-        Dict with summary of all actions taken.
+        dict with summary of all actions taken.
     """
     logger.info("Starting maintenance cycle")
 

--- a/src/gasclaw/updater/applier.py
+++ b/src/gasclaw/updater/applier.py
@@ -21,7 +21,7 @@ def apply_updates() -> dict[str, str]:
     """Run update commands for all dependencies.
 
     Returns:
-        Dict mapping dependency name to result string.
+        dict mapping dependency name to result string.
     """
     results: dict[str, str] = {}
     for name, cmd in _UPDATE_COMMANDS.items():

--- a/src/gasclaw/updater/checker.py
+++ b/src/gasclaw/updater/checker.py
@@ -22,7 +22,7 @@ def check_versions() -> dict[str, str]:
     """Get version strings for all dependencies.
 
     Returns:
-        Dict mapping dependency name to version string or "not installed".
+        dict mapping dependency name to version string or "not installed".
     """
     versions: dict[str, str] = {}
     for name, cmd in _VERSION_COMMANDS.items():


### PR DESCRIPTION
## Summary

Updates docstrings across the codebase to use modern type hint terminology (lowercase `dict`, `list`) instead of the legacy capitalized names (`Dict`, `List`). This aligns with PEP 585 and Python 3.9+ typing practices.

## Changes

- `health.py`: `Dict` → `dict` in docstring
- `maintenance.py`: `List` → `list`, `Dict` → `dict` in docstrings  
- `updater/applier.py`: `Dict` → `dict` in docstring
- `updater/checker.py`: `Dict` → `dict` in docstring
- `kimigas/proxy.py`: `Dict` → `dict` in docstring
- `gastown/installer.py`: `List` → `list` in docstring

## Test plan

- [x] All 349 unit tests pass
- [x] Ruff linting passes
- [x] No code changes - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)