### PR TITLE
feat: add configurable timeout to maintenance functions

### DIFF
--- a/src/gasclaw/maintenance.py
+++ b/src/gasclaw/maintenance.py
@@ -45,8 +45,11 @@ def run_command(
     return result
 
 
-def get_open_prs() -> list[dict[str, Any]]:
+def get_open_prs(timeout: int = 120) -> list[dict[str, Any]]:
     """Get list of open PRs from GitHub.
+
+    Args:
+        timeout: Max seconds to wait for the command (default: 120).
 
     Returns:
         list of PR dicts with number, title, branch, and author.
@@ -65,6 +68,7 @@ def get_open_prs() -> list[dict[str, Any]]:
                 "number,title,headRefName,author",
             ],
             check=False,
+            timeout=timeout,
         )
         if result.returncode != 0:
             logger.warning("Failed to list PRs: %s", result.stderr)
@@ -79,8 +83,11 @@ def get_open_prs() -> list[dict[str, Any]]:
         return []
 
 
-def get_open_issues() -> list[dict[str, Any]]:
+def get_open_issues(timeout: int = 120) -> list[dict[str, Any]]:
     """Get list of open issues from GitHub.
+
+    Args:
+        timeout: Max seconds to wait for the command (default: 120).
 
     Returns:
         list of issue dicts with number and title.
@@ -89,6 +96,7 @@ def get_open_issues() -> list[dict[str, Any]]:
         result = run_command(
             ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--json", "number,title"],
             check=False,
+            timeout=timeout,
         )
         if result.returncode != 0:
             logger.warning("Failed to list issues: %s", result.stderr)

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -88,6 +88,19 @@ class TestGetOpenPRs:
 
         assert result == []
 
+    @patch("gasclaw.maintenance.run_command")
+    def test_accepts_custom_timeout(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "[]"
+        mock_run.return_value = mock_result
+
+        get_open_prs(timeout=30)
+
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get("timeout") == 30
+
 
 class TestGetOpenIssues:
     @patch("gasclaw.maintenance.run_command")
@@ -115,6 +128,19 @@ class TestGetOpenIssues:
         result = get_open_issues()
 
         assert result == []
+
+    @patch("gasclaw.maintenance.run_command")
+    def test_accepts_custom_timeout(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "[]"
+        mock_run.return_value = mock_result
+
+        get_open_issues(timeout=60)
+
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get("timeout") == 60
 
 
 class TestCheckoutAndTestPR:


### PR DESCRIPTION
## Summary

Add explicit timeout parameter to `get_open_prs()` and `get_open_issues()` functions in maintenance.py to allow customizable timeouts when querying the GitHub API.

## Changes

- Added `timeout` parameter (default: 120) to `get_open_prs()`
- Added `timeout` parameter (default: 120) to `get_open_issues()`
- Added corresponding unit tests for the new timeout parameter

## Test plan

- [x] `python -m pytest tests/unit/test_maintenance.py -v` passes (42 tests)
- [x] `python -m pytest tests/unit -v` passes (359 tests total)
- [x] 100% code coverage maintained
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)