### PR TITLE
feat: add configurable DOLT_PORT environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ All 73 unit tests must pass. Never modify a test to make it pass — fix the cod
 | `GT_AGENT_COUNT` | No | `6` | Number of crew workers |
 | `MONITOR_INTERVAL` | No | `300` | Health check interval (seconds) |
 | `ACTIVITY_DEADLINE` | No | `3600` | Max seconds between commits |
+| `DOLT_PORT` | No | `3307` | Dolt SQL server port |
 
 ## PR Checklist
 

--- a/skills/gastown-health/scripts/gt-health.sh
+++ b/skills/gastown-health/scripts/gt-health.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 DEADLINE=${ACTIVITY_DEADLINE:-3600}
+DOLT_PORT=${DOLT_PORT:-3307}
 
 echo "=== Deep Health Check ==="
 echo ""
 
 # Service checks
-for svc in "dolt sql --port 3307 -q 'SELECT 1'" "gt daemon status" "gt mayor status"; do
+for svc in "dolt sql --port ${DOLT_PORT} -q 'SELECT 1'" "gt daemon status" "gt mayor status"; do
     name=$(echo "$svc" | awk '{print $1}')
     echo -n "$name: "
     if eval "$svc" &>/dev/null; then

--- a/skills/gastown-health/scripts/gt-status.sh
+++ b/skills/gastown-health/scripts/gt-status.sh
@@ -2,12 +2,14 @@
 # Quick Gastown status check
 set -euo pipefail
 
+DOLT_PORT=${DOLT_PORT:-3307}
+
 echo "=== Gastown Status ==="
 echo ""
 
 # Dolt
 echo -n "Dolt: "
-if dolt sql --port 3307 -q "SELECT 1" &>/dev/null; then
+if dolt sql --port "${DOLT_PORT}" -q "SELECT 1" &>/dev/null; then
     echo "HEALTHY"
 else
     echo "DOWN"

--- a/src/gasclaw/config.py
+++ b/src/gasclaw/config.py
@@ -27,6 +27,7 @@ class GasclawConfig:
     gt_agent_count: int = 6
     monitor_interval: int = 300  # seconds between health checks
     activity_deadline: int = 3600  # seconds — must see a push/PR within this window
+    dolt_port: int = 3307  # Port for dolt SQL server
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
@@ -111,6 +112,7 @@ def load_config() -> GasclawConfig:
         activity_deadline=_parse_positive_int(
             os.environ.get("ACTIVITY_DEADLINE", "3600"), 3600, "ACTIVITY_DEADLINE"
         ),
+        dolt_port=_parse_positive_int(os.environ.get("DOLT_PORT", "3307"), 3307, "DOLT_PORT"),
     )
 
     logger.debug("Loaded configuration with %d Gastown keys", len(keys))

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -101,15 +101,16 @@ def _list_agents() -> list[str]:
     return []
 
 
-def check_health(*, gateway_port: int = 18789) -> HealthReport:
+def check_health(*, gateway_port: int = 18789, dolt_port: int = 3307) -> HealthReport:
     """Run all health checks and return a complete report.
 
     Args:
         gateway_port: OpenClaw gateway port for connectivity check.
+        dolt_port: Dolt SQL server port for health check.
     """
     doctor = run_doctor()
     return HealthReport(
-        dolt=_check_service(["dolt", "sql", "--port", "3307", "-q", "SELECT 1"], "dolt"),
+        dolt=_check_service(["dolt", "sql", "--port", str(dolt_port), "-q", "SELECT 1"], "dolt"),
         daemon=_check_service(["gt", "daemon", "status"], "daemon"),
         mayor=_check_service(["gt", "mayor", "status"], "mayor"),
         openclaw=_check_openclaw_gateway(gateway_port),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -83,6 +83,7 @@ class TestLoadConfig:
         assert cfg.gt_agent_count == 6
         assert cfg.monitor_interval == 300
         assert cfg.activity_deadline == 3600
+        assert cfg.dolt_port == 3307
 
     def test_custom_optional_values(self, monkeypatch, env_vars):
         """Optional fields can be overridden."""
@@ -92,6 +93,7 @@ class TestLoadConfig:
             GT_AGENT_COUNT="8",
             MONITOR_INTERVAL="120",
             ACTIVITY_DEADLINE="1800",
+            DOLT_PORT="3308",
         ).items():
             monkeypatch.setenv(k, v)
         cfg = load_config()
@@ -100,6 +102,7 @@ class TestLoadConfig:
         assert cfg.gt_agent_count == 8
         assert cfg.monitor_interval == 120
         assert cfg.activity_deadline == 1800
+        assert cfg.dolt_port == 3308
 
     def test_keys_not_shared_by_default(self, monkeypatch, env_vars):
         """Gastown and OpenClaw keys are separate pools."""
@@ -166,6 +169,20 @@ class TestLoadConfig:
             monkeypatch.setenv(k, v)
         cfg = load_config()
         assert cfg.activity_deadline == 3600
+
+    def test_dolt_port_zero_defaults(self, monkeypatch, env_vars):
+        """Zero dolt_port defaults to 3307."""
+        for k, v in env_vars(DOLT_PORT="0").items():
+            monkeypatch.setenv(k, v)
+        cfg = load_config()
+        assert cfg.dolt_port == 3307
+
+    def test_dolt_port_negative_defaults(self, monkeypatch, env_vars):
+        """Negative dolt_port defaults to 3307."""
+        for k, v in env_vars(DOLT_PORT="-1").items():
+            monkeypatch.setenv(k, v)
+        cfg = load_config()
+        assert cfg.dolt_port == 3307
 
 
 class TestGasclawConfig:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -52,6 +52,42 @@ class TestCheckHealth:
         report = check_health(gateway_port=18789)
         assert report.dolt == "unhealthy"
 
+    def test_custom_dolt_port(self, monkeypatch, respx_mock: respx.MockRouter):
+        """Custom dolt_port is passed to the dolt command."""
+        respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
+
+        captured_cmds = []
+
+        def _mock_run(cmd, **kw):
+            captured_cmds.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
+
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+        report = check_health(gateway_port=18789, dolt_port=3308)
+        assert report.dolt == "healthy"
+        # Check that dolt command used the custom port
+        dolt_cmds = [c for c in captured_cmds if "dolt" in str(c)]
+        assert len(dolt_cmds) == 1
+        assert "3308" in dolt_cmds[0]
+
+    def test_default_dolt_port(self, monkeypatch, respx_mock: respx.MockRouter):
+        """Default dolt_port is 3307."""
+        respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
+
+        captured_cmds = []
+
+        def _mock_run(cmd, **kw):
+            captured_cmds.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout=b"ok")
+
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+        report = check_health(gateway_port=18789)
+        assert report.dolt == "healthy"
+        # Check that dolt command used the default port
+        dolt_cmds = [c for c in captured_cmds if "dolt" in str(c)]
+        assert len(dolt_cmds) == 1
+        assert "3307" in dolt_cmds[0]
+
     def test_agents_listed(self, monkeypatch, respx_mock: respx.MockRouter):
         respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Add support for customizing the Dolt SQL server port via the `DOLT_PORT` environment variable (default: 3307).

## Changes

- Add `dolt_port` field to `GasclawConfig` dataclass in `config.py`
- Parse `DOLT_PORT` from environment in `load_config()`
- Update `check_health()` in `health.py` to accept `dolt_port` parameter
- Update skill scripts (`gt-health.sh`, `gt-status.sh`) to use `DOLT_PORT` env var
- Add tests for `dolt_port` configuration (default, custom, zero/negative handling)
- Update CLAUDE.md documentation with the new environment variable

## Test Plan

- [x] All 363 unit tests pass
- [x] New tests added for dolt_port configuration
- [x] Ruff linting passes
- [x] Ruff formatting passes

## Example Usage

```bash
export DOLT_PORT=3308  # Use custom dolt port
gasclaw start
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)