### PR TITLE
fix: remove unused imports and fix ruff B008 lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "W", "B", "C4", "SIM", "PERF"]
+ignore = ["B008"]
 
 [tool.mypy]
 python_version = "3.13"

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -3,11 +3,8 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from gasclaw.migration import (
     MigrationResult,


### PR DESCRIPTION
## Summary
- Remove unused `os`, `MagicMock`, and `pytest` imports from `test_migration.py`
- Add B008 to ruff ignore list for Typer's `typer.Option` pattern (standard CLI pattern)

## Test plan
- [x] `python -m pytest tests/unit -q` passes (381 tests)
- [x] `python -m ruff check src tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)