### PR TITLE
test: improve test coverage to 100%

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -354,6 +354,115 @@ class TestCLIEdgeCases:
         assert "NOT COMPLIANT" in result.output or "not compliant" in result.output.lower()
 
 
+class TestMigrateCommand:
+    """Tests for migrate command (lines 193-210)."""
+
+    def test_migrate_successful(self, tmp_path, monkeypatch):
+        """migrate command succeeds when migration is successful."""
+        from gasclaw.migration import MigrationResult
+
+        def mock_migrate(*args, **kwargs):
+            return MigrationResult(
+                success=True,
+                dry_run=False,
+                gastown_detected=True,
+                migrated_keys=["KIMI_API_KEY"],
+                env_file_path=tmp_path / ".env",
+            )
+
+        monkeypatch.setattr("gasclaw.cli.run_migration", mock_migrate)
+
+        result = runner.invoke(app, ["migrate"])
+
+        assert result.exit_code == 0
+        assert "Migration complete" in result.output
+        assert "Next steps" in result.output
+
+    def test_migrate_successful_dry_run(self, tmp_path, monkeypatch):
+        """migrate --dry-run shows summary without next steps."""
+        from gasclaw.migration import MigrationResult
+
+        def mock_migrate(*args, **kwargs):
+            return MigrationResult(
+                success=True,
+                dry_run=True,
+                gastown_detected=True,
+            )
+
+        monkeypatch.setattr("gasclaw.cli.run_migration", mock_migrate)
+
+        result = runner.invoke(app, ["migrate", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "DRY RUN" in result.output or "dry run" in result.output.lower()
+
+    def test_migrate_failure_exits_with_code_1(self, tmp_path, monkeypatch):
+        """migrate command exits with code 1 when migration fails (lines 209-210)."""
+        from gasclaw.migration import MigrationResult
+
+        def mock_migrate(*args, **kwargs):
+            return MigrationResult(
+                success=False,
+                dry_run=False,
+                gastown_detected=False,
+                error_message="No Gastown installation found",
+            )
+
+        monkeypatch.setattr("gasclaw.cli.run_migration", mock_migrate)
+
+        result = runner.invoke(app, ["migrate"])
+
+        assert result.exit_code == 1
+
+    def test_migrate_displays_checking_message(self, monkeypatch):
+        """migrate command displays 'Checking for Gastown' message (line 193)."""
+        from gasclaw.migration import MigrationResult
+
+        def mock_migrate(*args, **kwargs):
+            return MigrationResult(
+                success=True,
+                dry_run=False,
+                gastown_detected=True,
+                migrated_keys=["KIMI_API_KEY"],
+            )
+
+        monkeypatch.setattr("gasclaw.cli.run_migration", mock_migrate)
+
+        result = runner.invoke(app, ["migrate"])
+
+        assert "Checking for Gastown" in result.output
+
+    def test_migrate_accepts_custom_paths(self, tmp_path, monkeypatch):
+        """migrate command accepts custom gastown-dir and env-file paths."""
+        from gasclaw.migration import MigrationResult
+
+        migrate_calls = []
+
+        def mock_migrate(**kwargs):
+            migrate_calls.append(kwargs)
+            return MigrationResult(
+                success=True,
+                dry_run=False,
+                gastown_detected=True,
+            )
+
+        monkeypatch.setattr("gasclaw.cli.run_migration", mock_migrate)
+
+        gt_dir = tmp_path / "custom_gt"
+        env_file = tmp_path / "custom.env"
+
+        result = runner.invoke(app, [
+            "migrate",
+            "--gastown-dir", str(gt_dir),
+            "--env-file", str(env_file),
+        ])
+
+        assert result.exit_code == 0
+        assert len(migrate_calls) == 1
+        assert migrate_calls[0]["gastown_dir"] == gt_dir
+        assert migrate_calls[0]["gasclaw_env_file"] == env_file
+
+
 class TestMaintainCommand:
     def test_maintain_once_runs_single_cycle(self, monkeypatch):
         """maintain --once runs a single maintenance cycle."""

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -378,6 +378,38 @@ class TestMigrate:
         assert result.success is False
         assert "Missing required configuration" in result.error_message
 
+    def test_creates_backup_via_config_file_detection(self, tmp_path, monkeypatch):
+        """Creates backup when gastown detected via config_file source without explicit gastown_dir (lines 372-374)."""
+        monkeypatch.delenv("KIMI_API_KEY", raising=False)
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+        monkeypatch.setenv("OPENCLAW_KIMI_KEY", "sk-oc")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:ABC")
+        monkeypatch.setenv("TELEGRAM_OWNER_ID", "123456")
+
+        # Create gastown config directory (will be found via search)
+        # Use DEFAULT_GASTOWN_DIRS path pattern
+        gt_dir = tmp_path / ".gt"
+        gt_dir.mkdir()
+        config_file = gt_dir / "config.json"
+        config_file.write_text(json.dumps({"kimi_api_key": "sk-from-config"}))
+
+        env_file = tmp_path / ".env"
+
+        # Don't pass gastown_dir - force detection via config_file source
+        # and the backup path at lines 372-374
+        with monkeypatch.context() as m:
+            m.setattr("gasclaw.migration.DEFAULT_GASTOWN_DIRS", [gt_dir])
+            result = migrate(
+                gastown_dir=None,  # Not passing explicit gastown_dir
+                gasclaw_env_file=env_file,
+                dry_run=False,
+                interactive=False,
+            )
+
+        assert result.success is True
+        assert result.backup_path is not None
+        assert result.backup_path.exists()
+
 
 class TestMigrationResult:
     """Tests for MigrationResult dataclass."""


### PR DESCRIPTION
## Summary

Improve test coverage from 99% to 100% by adding tests for previously uncovered code paths.

## Changes

- **CLI migrate command**: Add `TestMigrateCommand` class with 5 tests covering:
  - Successful migration with next steps output
  - Dry-run migration behavior
  - Failure exit code 1 handling
  - "Checking for Gastown" message display
  - Custom paths support

- **Migration backup**: Add `test_creates_backup_via_config_file_detection` covering:
  - Backup creation when Gastown detected via `config_file` source without explicit `gastown_dir`

## Test Results

- Total: 394 tests (6 new)
- Coverage: 100% (up from 99%)

## Test Plan

- [x] `python -m pytest tests/unit -v` passes (394 tests)
- [x] 100% code coverage verified
- [x] New tests follow existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)