### PR TITLE
fix: handle zero available keys in health report summary

### DIFF
--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -34,8 +34,9 @@ class HealthReport:
 
     def summary(self) -> str:
         """Human-readable summary string."""
-        # Handle both missing keys and None values
-        avail = self.key_pool.get("available") or "?"
+        # Handle both missing keys and None values (0 is valid for available)
+        avail = self.key_pool.get("available")
+        avail = "?" if avail is None else avail
         total = self.key_pool.get("total") or "?"
         lines = [
             f"Dolt: {self.dolt}",


### PR DESCRIPTION
## Summary

Fixed a bug in `HealthReport.summary()` where 0 available keys would display as `?/3 available` instead of `0/3 available`.

### Root Cause

The expression `self.key_pool.get("available") or "?"` treats 0 as falsy, so when no keys were available, it would show `?` instead of `0`.

### Fix

Changed to explicitly check for `None`:
```python
avail = self.key_pool.get("available")
avail = "?" if avail is None else avail
```

## Test Plan

- [x] `tests/integration/test_health_integration.py::TestHealthReportSummary::test_summary_with_issues` passes
- [x] All 434 tests passing (394 unit + 40 integration)
- [x] `python -m ruff check src tests` passes
- [x] `python -m ruff format --check src tests` passes
- [x] `python -m mypy src` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)