### PR TITLE
feat: add documentation website with MkDocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/api/bootstrap.md
+++ b/docs/api/bootstrap.md
@@ -1,0 +1,75 @@
+# Bootstrap API
+
+The bootstrap module handles the startup sequence for Gasclaw.
+
+## Functions
+
+### `bootstrap(config, gt_root)`
+
+Run the full bootstrap sequence.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `config` | `GasclawConfig` | Validated gasclaw configuration |
+| `gt_root` | `Path` | Where to install Gastown (default: `/workspace/gt`) |
+
+**Raises:**
+
+- `RuntimeError`: If bootstrap fails, after attempting rollback
+
+**Bootstrap Sequence:**
+
+1. Setup Kimi accounts for Gastown agents
+2. Write agent config
+3. Install Gastown
+4. Start Dolt
+5. Configure OpenClaw
+6. Install skills
+7. Run openclaw doctor
+8. Start OpenClaw gateway
+9. Start gt daemon
+10. Start mayor agent
+11. Send startup notification
+
+**Example:**
+
+```python
+from gasclaw.bootstrap import bootstrap
+from gasclaw.config import load_config
+
+config = load_config()
+bootstrap(config)
+```
+
+---
+
+### `monitor_loop(config, interval)`
+
+Foreground health monitor loop.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `config` | `GasclawConfig` | Gasclaw configuration |
+| `interval` | `int \| None` | Seconds between checks (default from config) |
+
+**Behavior:**
+
+- Runs health checks at regular intervals
+- Sends Telegram notifications for:
+  - Activity violations (no commits within deadline)
+  - Service failures (dolt, daemon, mayor down)
+- Continues until interrupted (Ctrl+C)
+
+**Example:**
+
+```python
+from gasclaw.bootstrap import monitor_loop
+from gasclaw.config import load_config
+
+config = load_config()
+monitor_loop(config)  # Uses config.monitor_interval
+```

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,0 +1,73 @@
+# Config API
+
+Configuration loading and validation from environment variables.
+
+## Classes
+
+### `GasclawConfig`
+
+Dataclass representing Gasclaw configuration.
+
+**Attributes:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `gastown_kimi_keys` | `list[str]` | Colon-separated Kimi keys for Gastown |
+| `openclaw_kimi_key` | `str` | Kimi key for OpenClaw |
+| `telegram_bot_token` | `str` | Telegram bot token |
+| `telegram_owner_id` | `str` | Telegram owner user ID |
+| `gt_rig_url` | `str` | Git URL or path for rig (default: `/project`) |
+| `project_dir` | `str` | Directory for git activity checks (default: `/project`) |
+| `gt_agent_count` | `int` | Number of crew workers (default: 6) |
+| `monitor_interval` | `int` | Health check interval in seconds (default: 300) |
+| `activity_deadline` | `int` | Max seconds between commits (default: 3600) |
+| `dolt_port` | `int` | Dolt SQL server port (default: 3307) |
+
+**Validation:**
+
+- `telegram_owner_id` must be numeric
+- `project_dir` should be absolute path
+- `gt_rig_url` should be path or URL
+
+---
+
+## Functions
+
+### `load_config()`
+
+Load and validate configuration from environment variables.
+
+**Returns:**
+
+- `GasclawConfig`: Validated configuration object
+
+**Raises:**
+
+- `ValueError`: If required environment variables are not set
+
+**Example:**
+
+```python
+from gasclaw.config import load_config
+
+config = load_config()
+print(f"Loaded {len(config.gastown_kimi_keys)} keys")
+print(f"Monitor interval: {config.monitor_interval}s")
+```
+
+**Environment Variables:**
+
+```bash
+# Required
+export GASTOWN_KIMI_KEYS="sk-key1:sk-key2"
+export OPENCLAW_KIMI_KEY="sk-overseer"
+export TELEGRAM_BOT_TOKEN="123:ABC"
+export TELEGRAM_OWNER_ID="999999999"
+
+# Optional
+export GT_RIG_URL="/project"
+export GT_AGENT_COUNT=6
+export MONITOR_INTERVAL=300
+export ACTIVITY_DEADLINE=3600
+export DOLT_PORT=3307
+```

--- a/docs/api/health.md
+++ b/docs/api/health.md
@@ -1,0 +1,106 @@
+# Health API
+
+Health checks for all gasclaw subsystems.
+
+## Classes
+
+### `HealthReport`
+
+Complete health report for the gasclaw system.
+
+**Attributes:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `dolt` | `str` | Dolt status: "healthy", "unhealthy", or "unknown" |
+| `daemon` | `str` | Daemon status: "healthy", "unhealthy", or "unknown" |
+| `mayor` | `str` | Mayor status: "healthy", "unhealthy", or "unknown" |
+| `openclaw` | `str` | OpenClaw status: "healthy", "unhealthy", or "unknown" |
+| `openclaw_doctor` | `str` | Doctor status: "healthy" or "unhealthy" |
+| `agents` | `list[str]` | List of active agent names |
+| `key_pool` | `dict` | Key pool statistics |
+| `activity` | `dict` | Activity compliance data |
+
+**Methods:**
+
+#### `summary()`
+
+Return human-readable summary string.
+
+```python
+report = check_health()
+print(report.summary())
+# Dolt: healthy
+# Daemon: healthy
+# Mayor: healthy
+# OpenClaw: healthy
+# Agents: 3 active (mayor, crew-1, crew-2)
+```
+
+---
+
+## Functions
+
+### `check_health(gateway_port, dolt_port)`
+
+Run all health checks and return a complete report.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `gateway_port` | `int` | 18789 | OpenClaw gateway port |
+| `dolt_port` | `int` | 3307 | Dolt SQL server port |
+
+**Returns:**
+
+- `HealthReport`: Complete health report
+
+**Example:**
+
+```python
+from gasclaw.health import check_health
+
+report = check_health()
+if report.dolt == "unhealthy":
+    print("Dolt is down!")
+if len(report.agents) < 3:
+    print("Not enough agents running")
+```
+
+---
+
+### `check_agent_activity(project_dir, deadline_seconds)`
+
+Check if there has been recent git activity.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `project_dir` | `str` | "/project" | Directory containing git repo |
+| `deadline_seconds` | `int` | 3600 | Max allowed time since last activity |
+
+**Returns:**
+
+```python
+{
+    "last_commit_age": 1800,  # seconds since last commit
+    "compliant": True,        # within deadline
+    "error": None             # or error message
+}
+```
+
+**Example:**
+
+```python
+from gasclaw.health import check_agent_activity
+
+activity = check_agent_activity(
+    project_dir="/workspace/gasclaw",
+    deadline_seconds=3600
+)
+
+if not activity["compliant"]:
+    print(f"No commits in {activity['last_commit_age']}s!")
+```

--- a/docs/api/key-pool.md
+++ b/docs/api/key-pool.md
@@ -1,0 +1,120 @@
+# Key Pool API
+
+LRU key rotation with rate-limit cooldown.
+
+## Classes
+
+### `KeyPool`
+
+Manages a pool of API keys with LRU rotation.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `keys` | `list[str]` | List of API keys |
+| `cooldown_seconds` | `int` | Cooldown after rate limit (default: 300) |
+
+**Attributes:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `available` | `int` | Number of available (non-cooldown) keys |
+| `total` | `int` | Total number of keys |
+
+---
+
+## Methods
+
+### `get_key()`
+
+Get the least-recently-used available key.
+
+**Returns:**
+
+- `str`: API key
+- `None`: If no keys available
+
+**Example:**
+
+```python
+from gasclaw.kimigas.key_pool import KeyPool
+
+pool = KeyPool(["sk-key1", "sk-key2", "sk-key3"])
+key = pool.get_key()
+if key:
+    use_key_for_request(key)
+```
+
+---
+
+### `report_rate_limit(key)`
+
+Report that a key hit a rate limit.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | `str` | The rate-limited key |
+
+**Behavior:**
+
+- Moves key to cooldown queue
+- Key unavailable for `cooldown_seconds`
+
+**Example:**
+
+```python
+response = make_api_request(key)
+if response.status_code == 429:
+    pool.report_rate_limit(key)
+    # Get a different key
+    new_key = pool.get_key()
+```
+
+---
+
+### `is_available(key)`
+
+Check if a key is currently available.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `key` | `str` | Key to check |
+
+**Returns:**
+
+- `bool`: True if key is available
+
+---
+
+## Example Usage
+
+```python
+from gasclaw.kimigas.key_pool import KeyPool
+
+# Create pool with 5-minute cooldown
+pool = KeyPool(
+    keys=["sk-1", "sk-2", "sk-3"],
+    cooldown_seconds=300
+)
+
+# Get key for request
+key = pool.get_key()
+if not key:
+    raise Exception("No keys available")
+
+# Make request
+response = requests.post(
+    "https://api.example.com/v1/chat",
+    headers={"Authorization": f"Bearer {key}"}
+)
+
+# Handle rate limit
+if response.status_code == 429:
+    pool.report_rate_limit(key)
+    # Will get different key next time
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,222 @@
+# Architecture
+
+Gasclaw combines three components into a single autonomous maintenance system.
+
+## Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Gasclaw                              │
+├─────────────────────────────────────────────────────────────┤
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │   Gastown    │  │   OpenClaw   │  │   KimiGas    │      │
+│  │   (Agents)   │  │  (Overseer)  │  │  (Key Pool)  │      │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘      │
+│         │                 │                 │              │
+│         └─────────────────┼─────────────────┘              │
+│                           │                                │
+│                    ┌──────┴──────┐                        │
+│                    │  Bootstrap  │                        │
+│                    │   & Monitor │                        │
+│                    └──────┬──────┘                        │
+│                           │                                │
+│                    ┌──────┴──────┐                        │
+│                    │   Telegram  │                        │
+│                    │  (Reports)  │                        │
+│                    └─────────────┘                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Gastown (Agents)
+
+Gastown is the agent framework that runs AI workers.
+
+### Components
+
+- **Daemon**: Manages agent lifecycle
+- **Mayor**: Overseer agent for high-level decisions
+- **Crew**: Worker agents that perform tasks
+
+### Key Pool
+
+Each agent gets its own Kimi API key from `GASTOWN_KIMI_KEYS`:
+
+```
+~/.kimi-accounts/
+├── 1/config.toml   # Key 1 for agent 1
+├── 2/config.toml   # Key 2 for agent 2
+└── 3/config.toml   # Key 3 for agent 3
+```
+
+## OpenClaw (Overseer)
+
+OpenClaw monitors all agents and enforces compliance.
+
+### Responsibilities
+
+- Monitor agent health and activity
+- Enforce activity benchmark (commits every hour)
+- Rotate keys on rate limits
+- Restart failed agents
+- Handle Telegram communication
+
+### Configuration
+
+OpenClaw config at `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "channels": {
+    "telegram": {
+      "botToken": "...",
+      "dmPolicy": "allowlist",
+      "allowFrom": [999999999]
+    }
+  },
+  "gateway": {
+    "port": 18789,
+    "auth": { "token": "..." }
+  }
+}
+```
+
+### Skills
+
+Skills are installed to `~/.openclaw/skills/`:
+
+- `gastown-health`: Health check commands
+- `gastown-keys`: Key management commands
+- `gastown-update`: Update commands
+- `gastown-agents`: Agent control commands
+
+## KimiGas (Key Pool)
+
+KimiGas manages API keys with LRU rotation and rate-limit cooldown.
+
+### Features
+
+- **LRU Rotation**: Least-recently-used key is selected first
+- **Cooldown**: Rate-limited keys are quarantined for 5 minutes
+- **Separate Pools**: Agents and overseer have independent key pools
+
+### Key States
+
+```
+Available ──► In Use ──► Rate Limited ──► Cooldown ──► Available
+               │              │
+               └──────────────┘ (auto-rotate on 429)
+```
+
+## Bootstrap Sequence
+
+```
+┌─────────────────┐
+│  Load Config    │
+└────────┬────────┘
+         ▼
+┌─────────────────┐
+│ Setup Kimi      │
+│ Accounts        │
+└────────┬────────┘
+         ▼
+┌─────────────────┐     ┌─────────────────┐
+│ Install         │────►│  Start Dolt     │
+│ Gastown         │     └────────┬────────┘
+└─────────────────┘              ▼
+                          ┌─────────────────┐
+                          │ Configure       │
+                          │ OpenClaw        │
+                          └────────┬────────┘
+                                   ▼
+                          ┌─────────────────┐
+                          │ Install Skills  │
+                          └────────┬────────┘
+                                   ▼
+                          ┌─────────────────┐
+                          │ Run Doctor      │
+                          └────────┬────────┘
+                                   ▼
+                          ┌─────────────────┐
+                          │ Start Services  │
+                          │ (daemon, mayor) │
+                          └────────┬────────┘
+                                   ▼
+                          ┌─────────────────┐
+                          │ Start Monitor   │
+                          │ Loop            │
+                          └─────────────────┘
+```
+
+## Health Monitoring
+
+The monitor loop runs continuously:
+
+```python
+while True:
+    report = check_health()      # Check all services
+    activity = check_activity()  # Check git activity
+
+    if not activity.compliant:
+        notify_telegram("ACTIVITY ALERT")
+
+    if any_service_unhealthy:
+        notify_telegram("SERVICE DOWN")
+
+    sleep(interval)
+```
+
+### Health Checks
+
+| Service | Check Method |
+|---------|-------------|
+| Dolt | `dolt sql -q "SELECT 1"` |
+| Daemon | `gt daemon status` |
+| Mayor | `gt mayor status` |
+| OpenClaw | `GET http://localhost:18789/health` |
+| Agents | `gt status --agents` |
+
+## Communication Flow
+
+```
+GitHub API ◄────► Gasclaw ◄────► OpenClaw ◄────► Telegram
+                      │
+                      ▼
+                Gastown Agents
+                      │
+                      ▼
+                 Dolt (State)
+```
+
+1. **GitHub**: PRs, issues, commits
+2. **Gasclaw**: Orchestrates actions
+3. **OpenClaw**: Makes decisions, sends Telegram updates
+4. **Telegram**: User notifications and commands
+5. **Gastown**: Executes tasks
+6. **Dolt**: Stores all state via beads
+
+## Data Flow
+
+### State Management
+
+All state is stored in Dolt via beads (bd CLI):
+
+```bash
+bd create --name "task-123" --content "Fix bug"
+bd list
+bd search --query "bug"
+bd close --name "task-123"
+```
+
+### Configuration
+
+- Environment variables: Runtime config
+- `~/.openclaw/openclaw.json`: OpenClaw config
+- `~/.kimi-accounts/`: API key configs
+- `/workspace/gt/`: Gastown installation
+
+## Security
+
+- API keys never logged or exposed
+- Telegram allowlist restricts access
+- Auth tokens for gateway authentication
+- Separate key pools prevent cascade failures

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,143 @@
+# Configuration
+
+Gasclaw uses environment variables for all configuration. This makes it easy to deploy in containers and keeps secrets out of code.
+
+## Required Variables
+
+### GASTOWN_KIMI_KEYS
+
+Colon-separated list of Kimi API keys for Gastown agents.
+
+```bash
+export GASTOWN_KIMI_KEYS="sk-abc123:sk-def456:sk-ghi789"
+```
+
+Each key corresponds to one agent account. The more keys you provide, the more agents can run in parallel.
+
+### OPENCLAW_KIMI_KEY
+
+Kimi API key for OpenClaw (the overseer). This should be different from the Gastown keys.
+
+```bash
+export OPENCLAW_KIMI_KEY="sk-overseer-key"
+```
+
+!!! note "Separate Key Pool"
+    OpenClaw uses a separate key pool from Gastown agents. This ensures the overseer can always function even if all agent keys are rate-limited.
+
+### TELEGRAM_BOT_TOKEN
+
+Your Telegram bot token from @BotFather.
+
+```bash
+export TELEGRAM_BOT_TOKEN="123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
+```
+
+### TELEGRAM_OWNER_ID
+
+Your Telegram user ID (numeric). The bot will only respond to messages from this user.
+
+```bash
+export TELEGRAM_OWNER_ID="2045995148"
+```
+
+!!! tip "Finding Your User ID"
+    Message @userinfobot on Telegram to get your user ID.
+
+## Optional Variables
+
+### GT_RIG_URL
+
+Git URL or path for the Gastown rig (project repository).
+
+```bash
+export GT_RIG_URL="/project"           # Local path
+export GT_RIG_URL="https://github.com/user/repo"  # Git URL
+```
+
+**Default:** `/project`
+
+### GT_AGENT_COUNT
+
+Number of crew worker agents to run.
+
+```bash
+export GT_AGENT_COUNT=6
+```
+
+**Default:** `6`
+
+### MONITOR_INTERVAL
+
+Seconds between health checks.
+
+```bash
+export MONITOR_INTERVAL=300  # 5 minutes
+```
+
+**Default:** `300` (5 minutes)
+
+### ACTIVITY_DEADLINE
+
+Maximum seconds allowed between code commits. If no activity is detected within this window, an alert is sent.
+
+```bash
+export ACTIVITY_DEADLINE=3600  # 1 hour
+```
+
+**Default:** `3600` (1 hour)
+
+### DOLT_PORT
+
+Port for the Dolt SQL server.
+
+```bash
+export DOLT_PORT=3307
+```
+
+**Default:** `3307`
+
+### PROJECT_DIR
+
+Directory for git activity checks.
+
+```bash
+export PROJECT_DIR="/workspace/gasclaw"
+```
+
+**Default:** `/project`
+
+## Example Configuration
+
+Create a `.env` file:
+
+```bash
+# Required
+GASTOWN_KIMI_KEYS="sk-key1:sk-key2:sk-key3"
+OPENCLAW_KIMI_KEY="sk-overseer"
+TELEGRAM_BOT_TOKEN="123:ABC"
+TELEGRAM_OWNER_ID="999999999"
+
+# Optional (with defaults shown)
+GT_RIG_URL="/project"
+GT_AGENT_COUNT=6
+MONITOR_INTERVAL=300
+ACTIVITY_DEADLINE=3600
+DOLT_PORT=3307
+```
+
+Load it with:
+
+```bash
+set -a && source .env && set +a
+```
+
+## Validation
+
+Gasclaw validates configuration on startup:
+
+- `TELEGRAM_OWNER_ID` must be numeric
+- `GASTOWN_KIMI_KEYS` must contain at least one valid key
+- Path variables should be absolute paths
+
+If validation fails, the bootstrap will exit with a clear error message.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,68 @@
+# Installation
+
+## Requirements
+
+- Python 3.11+
+- Git
+- Dolt
+- Gastown CLI (`gt`)
+- OpenClaw CLI (`openclaw`)
+
+## Install Dependencies
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/gastown-publish/gasclaw.git
+cd gasclaw
+```
+
+### 2. Set Up Python Environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+
+# Install in development mode
+make dev
+```
+
+### 3. Install External Tools
+
+Install Dolt, Gastown, and OpenClaw according to their respective documentation.
+
+## Verify Installation
+
+Run the test suite to verify everything is working:
+
+```bash
+make test
+```
+
+You should see all tests passing:
+
+```
+============================= test session starts ==============================
+platform linux -- Python 3.13.12, pytest-9.0.2
+collecting ... collected 408 items
+
+tests/unit/... ............................................... [100%]
+
+============================== 408 passed in 11s ==============================
+```
+
+## Development Mode
+
+For development, install additional tools:
+
+```bash
+make dev        # Install dev dependencies
+make lint       # Run ruff linting
+make test       # Run unit tests
+make test-all   # Run all tests including integration
+```
+
+## Next Steps
+
+- [Configure environment variables](configuration.md)
+- [Run your first bootstrap](quickstart.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,119 @@
+# Quick Start
+
+This guide will get you up and running with Gasclaw in minutes.
+
+## Prerequisites
+
+Ensure you have:
+
+1. Installed Gasclaw (`make dev`)
+2. Set all [required environment variables](configuration.md)
+3. Verified installation with `make test`
+
+## Start Gasclaw
+
+Run the bootstrap sequence:
+
+```bash
+python -m gasclaw
+```
+
+Or use the CLI:
+
+```bash
+gasclaw start
+```
+
+## Bootstrap Sequence
+
+When you start Gasclaw, it runs a 13-step sequence:
+
+1. **Setup Kimi accounts** - Configure API keys for agents
+2. **Write agent config** - Create Gastown configuration
+3. **Install Gastown** - Set up the rig and project
+4. **Start Dolt** - Launch the SQL server
+5. **Configure OpenClaw** - Write overseer configuration
+6. **Install skills** - Copy OpenClaw skills to `~/.openclaw/skills/`
+7. **Run doctor** - Verify system health
+8. **Start OpenClaw gateway** - Launch the overseer
+9. **Start gt daemon** - Launch Gastown daemon
+10. **Start mayor** - Launch the mayor agent
+11. **Send notification** - "Gasclaw is up and running"
+12. **Enter monitor loop** - Continuous health checks
+
+You'll see output like:
+
+```
+INFO  Setting up Kimi accounts (3 keys)
+INFO  Writing agent config to /workspace/gt
+INFO  Installing Gastown with rig_url=/project
+INFO  Starting Dolt
+INFO  Configuring OpenClaw in /root/.openclaw
+INFO  Installing skills
+INFO  Running openclaw doctor
+INFO  Starting OpenClaw gateway
+INFO  Starting gt daemon
+INFO  Starting mayor agent
+INFO  All services started successfully
+INFO  Sending startup notification
+INFO  Starting monitor loop with interval=300 seconds
+```
+
+## Verify It's Working
+
+### Check Status
+
+```bash
+gasclaw status
+```
+
+### Send a Telegram Message
+
+Send a message to your bot. It should respond if OpenClaw is running correctly.
+
+### Check Logs
+
+View OpenClaw logs:
+
+```bash
+openclaw logs
+```
+
+### Health Endpoint
+
+Check the gateway health:
+
+```bash
+curl http://localhost:18789/health
+```
+
+## Stop Gasclaw
+
+Press `Ctrl+C` to stop the monitor loop. The system will shut down gracefully.
+
+Or use:
+
+```bash
+gasclaw stop
+```
+
+## What Happens Next
+
+Once running, Gasclaw will:
+
+1. **Check PRs** - Review and merge open PRs that pass tests
+2. **Fix issues** - Work on open GitHub issues
+3. **Maintain coverage** - Add tests for untested code
+4. **Monitor health** - Watch all services and alert on failures
+5. **Enforce activity** - Ensure code is committed every hour
+
+You'll receive Telegram notifications for all significant events.
+
+## Troubleshooting
+
+If something goes wrong:
+
+1. Check logs: `openclaw logs`
+2. Verify env vars: `env | grep -E 'KIMI|TELEGRAM'`
+3. Run doctor: `openclaw doctor --repair`
+4. See [Troubleshooting](../troubleshooting.md) for common issues

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,103 @@
+# Gasclaw
+
+[![Tests](https://img.shields.io/badge/tests-408%20passing-brightgreen)]()
+[![License](https://img.shields.io/badge/license-MIT-blue)]()
+
+**Single-container deployment combining Gastown + OpenClaw + KimiGas**
+
+Gasclaw is an autonomous code maintenance system that deploys AI agents to monitor, fix, and improve your codebase. It combines three powerful components:
+
+- **Gastown**: Agent framework for running AI workers
+- **OpenClaw**: Overseer that monitors agents and enforces compliance
+- **KimiGas**: Key pool management with LRU rotation for rate limiting
+
+## Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/gastown-publish/gasclaw.git
+cd gasclaw
+
+# Set up environment
+python -m venv .venv
+source .venv/bin/activate
+make dev
+
+# Configure environment variables
+export GASTOWN_KIMI_KEYS="sk-xxx:sk-yyy:sk-zzz"
+export OPENCLAW_KIMI_KEY="sk-aaa"
+export TELEGRAM_BOT_TOKEN="123:ABC"
+export TELEGRAM_OWNER_ID="999999999"
+
+# Start gasclaw
+python -m gasclaw
+```
+
+## Features
+
+### Autonomous Maintenance
+- Monitors open PRs and merges them after tests pass
+- Fixes open issues automatically
+- Maintains test coverage
+- Sends Telegram reports on all actions
+
+### Activity Compliance
+- Enforces code activity every hour (`ACTIVITY_DEADLINE=3600`)
+- Tracks git commits, pushes, and PRs
+- Alerts when no activity detected
+
+### Key Management
+- Separate key pools for agents and overseer
+- LRU rotation with 5-minute cooldown on rate limits
+- Automatic key health monitoring
+
+### Health Monitoring
+- Monitors all services: Dolt, daemon, mayor, OpenClaw
+- Foreground health check loop
+- Telegram notifications on service failures
+
+## Project Structure
+
+```
+src/gasclaw/
+├── cli.py              # Typer CLI: start, stop, status, update
+├── config.py           # Environment variable configuration
+├── bootstrap.py        # 13-step startup sequence
+├── health.py           # Health checks and activity compliance
+├── gastown/            # Gastown integration
+│   ├── agent_config.py
+│   ├── installer.py
+│   └── lifecycle.py
+├── kimigas/            # Key pool management
+│   ├── key_pool.py
+│   └── proxy.py
+├── openclaw/           # OpenClaw integration
+│   ├── installer.py
+│   ├── lifecycle.py
+│   └── skill_manager.py
+└── updater/            # Version checking and updates
+    ├── checker.py
+    ├── applier.py
+    └── notifier.py
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GASTOWN_KIMI_KEYS` | Yes | — | Colon-separated Kimi keys for Gastown |
+| `OPENCLAW_KIMI_KEY` | Yes | — | Kimi key for OpenClaw (separate pool) |
+| `TELEGRAM_BOT_TOKEN` | Yes | — | Telegram bot token |
+| `TELEGRAM_OWNER_ID` | Yes | — | Telegram owner user ID |
+| `GT_RIG_URL` | No | `/project` | Git URL or path for rig |
+| `GT_AGENT_COUNT` | No | `6` | Number of crew workers |
+| `MONITOR_INTERVAL` | No | `300` | Health check interval (seconds) |
+| `ACTIVITY_DEADLINE` | No | `3600` | Max seconds between commits |
+| `DOLT_PORT` | No | `3307` | Dolt SQL server port |
+
+## Next Steps
+
+- Read the [Installation Guide](getting-started/installation.md)
+- Learn about [Configuration](getting-started/configuration.md)
+- Understand the [Architecture](architecture.md)
+- Check [Troubleshooting](troubleshooting.md) for common issues

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,259 @@
+# Troubleshooting
+
+Common issues and their solutions.
+
+## Bootstrap Failures
+
+### "GASTOWN_KIMI_KEYS is not set"
+
+**Cause**: Required environment variable missing.
+
+**Solution**:
+
+```bash
+export GASTOWN_KIMI_KEYS="sk-key1:sk-key2"
+```
+
+### "TELEGRAM_OWNER_ID must be numeric"
+
+**Cause**: Owner ID contains non-numeric characters.
+
+**Solution**:
+
+```bash
+# Correct
+export TELEGRAM_OWNER_ID="2045995148"
+
+# Incorrect
+export TELEGRAM_OWNER_ID="@username"
+```
+
+### "Dolt process exited early"
+
+**Cause**: Port conflict or existing Dolt instance.
+
+**Solution**:
+
+```bash
+# Check if Dolt is already running
+pgrep -f "dolt sql-server"
+
+# Stop existing Dolt
+dolt sql-server --stop
+
+# Or use a different port
+export DOLT_PORT=3308
+```
+
+### "openclaw not found"
+
+**Cause**: OpenClaw CLI not installed or not in PATH.
+
+**Solution**:
+
+```bash
+# Install OpenClaw
+# (Follow OpenClaw installation instructions)
+
+# Verify
+which openclaw
+```
+
+## Telegram Issues
+
+### Bot not responding to messages
+
+**Symptoms**: Bot is online but doesn't answer.
+
+**Diagnosis**:
+
+```bash
+# Check if gateway is accessible
+curl http://localhost:18789/health
+
+# Check owner ID
+echo $TELEGRAM_OWNER_ID  # Should be numeric
+
+# Check OpenClaw logs
+openclaw logs
+```
+
+**Solutions**:
+
+1. **Verify owner_id is integer**: Check `~/.openclaw/openclaw.json`:
+   ```json
+   {
+     "channels": {
+       "telegram": {
+         "allowFrom": [999999999]  // Must be int, not string
+       }
+     }
+   }
+   ```
+
+2. **Restart OpenClaw**:
+   ```bash
+   openclaw gateway stop
+   openclaw gateway start
+   ```
+
+3. **Verify bot token**:
+   ```bash
+   curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe"
+   ```
+
+### Not receiving notifications
+
+**Cause**: Gateway not running or wrong chat ID.
+
+**Solution**:
+
+```bash
+# Check gateway health
+curl http://localhost:18789/health
+
+# Verify chat ID matches owner ID
+# They should be the same for DMs
+```
+
+## Key and Rate Limiting
+
+### "Rate limit exceeded"
+
+**Symptoms**: API calls return 429 errors.
+
+**Solution**:
+
+1. Wait 5 minutes for cooldown
+2. Add more keys to `GASTOWN_KIMI_KEYS`
+3. Check key pool status via Telegram: `/keys`
+
+### "No keys available"
+
+**Cause**: All keys are rate-limited or invalid.
+
+**Solution**:
+
+```bash
+# Check key validity
+curl https://api.kimi.com/coding/v1/models \
+  -H "Authorization: Bearer sk-your-key"
+
+# Update keys
+export GASTOWN_KIMI_KEYS="sk-newkey1:sk-newkey2"
+```
+
+## Activity Compliance
+
+### "ACTIVITY ALERT: No commits"
+
+**Cause**: No git activity within `ACTIVITY_DEADLINE`.
+
+**Solution**:
+
+This is working as intended. The alert reminds you to push code. To resolve:
+
+```bash
+# Make a commit
+git add .
+git commit -m "activity: keepalive"
+git push
+```
+
+To adjust the deadline:
+
+```bash
+export ACTIVITY_DEADLINE=7200  # 2 hours
+```
+
+## Health Check Failures
+
+### SERVICE DOWN: dolt
+
+**Diagnosis**:
+
+```bash
+dolt sql --port 3307 -q "SELECT 1"
+echo $?  # Should be 0
+```
+
+**Solution**:
+
+```bash
+# Restart Dolt
+dolt sql-server --stop
+dolt sql-server --port 3307 &
+```
+
+### SERVICE DOWN: daemon
+
+**Solution**:
+
+```bash
+# Restart daemon
+gt daemon stop
+gt daemon start
+```
+
+### SERVICE DOWN: mayor
+
+**Solution**:
+
+```bash
+# Restart mayor
+gt mayor stop
+gt mayor start --agent kimi-claude
+```
+
+### SERVICE DOWN: openclaw
+
+**Solution**:
+
+```bash
+# Restart gateway
+openclaw gateway stop
+openclaw gateway start
+```
+
+## Debugging
+
+### Enable Debug Logging
+
+```bash
+export LOG_LEVEL=DEBUG
+python -m gasclaw
+```
+
+### Check Configuration
+
+```python
+python -c "
+from gasclaw.config import load_config
+config = load_config()
+print(f'Keys: {len(config.gastown_kimi_keys)}')
+print(f'Owner ID: {config.telegram_owner_id}')
+print(f'Interval: {config.monitor_interval}')
+"
+```
+
+### Run Doctor
+
+```bash
+openclaw doctor --repair
+```
+
+### Test Telegram
+
+```bash
+curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -d chat_id="${TELEGRAM_OWNER_ID}" \
+  -d text="Test message"
+```
+
+## Getting Help
+
+If issues persist:
+
+1. Check logs: `openclaw logs`, `gt logs`
+2. Run tests: `make test`
+3. File an issue with logs and config (redact secrets)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,55 @@
+site_name: Gasclaw
+site_description: Single-container deployment combining Gastown + OpenClaw + KimiGas
+site_url: https://gastown-publish.github.io/gasclaw/
+repo_url: https://github.com/gastown-publish/gasclaw
+repo_name: gastown-publish/gasclaw
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+plugins:
+  - search
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Configuration: getting-started/configuration.md
+    - Quick Start: getting-started/quickstart.md
+  - Architecture: architecture.md
+  - API Reference:
+    - Bootstrap: api/bootstrap.md
+    - Config: api/config.md
+    - Health: api/health.md
+    - Key Pool: api/key-pool.md
+  - Troubleshooting: troubleshooting.md
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - admonition
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - attr_list
+  - md_in_html


### PR DESCRIPTION
## Summary

Closes #123 - Add documentation website using MkDocs with Material theme.

## Changes

- **mkdocs.yml**: MkDocs configuration with Material theme
- **docs/**: Complete documentation site:
  - `index.md`: Home page with overview
  - `getting-started/`: Installation, configuration, quick start
  - `architecture.md`: System architecture and data flow
  - `api/`: API reference documentation
  - `troubleshooting.md`: Common issues and solutions
- **.github/workflows/docs.yml**: Auto-deploy to GitHub Pages on push to main

## Features

- Material Design theme with dark/light mode toggle
- Search functionality
- Syntax highlighting for code blocks
- Responsive design for mobile
- Automatic deployment via GitHub Actions

## Preview

After merge, site will be available at:
https://gastown-publish.github.io/gasclaw/

## Test plan

- [x] All 408 unit tests pass
- [x] `mkdocs serve` works locally
- [x] GitHub Actions workflow is valid

🤖 Generated with Claude Code