### PR TITLE
feat: add GitHub Actions for Docker image build and publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,105 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - docker-compose.yml
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/unit -v
+
+      - name: Run lint
+        run: |
+          pip install ruff
+          ruff check src tests
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=,suffix=,format=short
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
     "respx>=0.22.0",
     "ruff>=0.14.0",
     "mypy>=1.15.0",
+    "pyyaml>=6.0.0",
 ]
 
 [project.scripts]

--- a/tests/unit/test_docker_workflow.py
+++ b/tests/unit/test_docker_workflow.py
@@ -1,0 +1,74 @@
+"""Tests for GitHub Actions Docker workflow validation."""
+
+from __future__ import annotations
+
+import yaml
+
+
+class TestDockerWorkflow:
+    """Validate Docker CI/CD workflow configuration."""
+
+    def test_workflow_yaml_is_valid(self):
+        """Docker workflow YAML parses correctly."""
+        workflow_path = ".github/workflows/docker.yml"
+        with open(workflow_path) as f:
+            workflow = yaml.safe_load(f)
+
+        assert workflow["name"] == "Build and Publish Docker Image"
+        # 'on' in YAML is parsed as True (boolean)
+        assert True in workflow or "on" in workflow
+        assert "jobs" in workflow
+
+    def test_workflow_has_required_jobs(self):
+        """Workflow has test and build jobs."""
+        workflow_path = ".github/workflows/docker.yml"
+        with open(workflow_path) as f:
+            workflow = yaml.safe_load(f)
+
+        assert "test" in workflow["jobs"]
+        assert "build" in workflow["jobs"]
+        assert workflow["jobs"]["build"]["needs"] == "test"
+
+    def test_build_job_has_multi_platform(self):
+        """Build job configures multi-platform builds."""
+        workflow_path = ".github/workflows/docker.yml"
+        with open(workflow_path) as f:
+            workflow = yaml.safe_load(f)
+
+        build_steps = workflow["jobs"]["build"]["steps"]
+        build_push_step = next(
+            s for s in build_steps if s.get("id") == "push"
+        )
+
+        assert "linux/amd64" in build_push_step["with"]["platforms"]
+        assert "linux/arm64" in build_push_step["with"]["platforms"]
+
+    def test_workflow_uses_ghcr(self):
+        """Workflow targets GitHub Container Registry."""
+        workflow_path = ".github/workflows/docker.yml"
+        with open(workflow_path) as f:
+            workflow = yaml.safe_load(f)
+
+        assert workflow["env"]["REGISTRY"] == "ghcr.io"
+        assert workflow["env"]["IMAGE_NAME"] == "${{ github.repository }}"
+
+    def test_workflow_triggers_on_push_to_main(self):
+        """Workflow triggers on push to main branch."""
+        workflow_path = ".github/workflows/docker.yml"
+        with open(workflow_path) as f:
+            workflow = yaml.safe_load(f)
+
+        # 'on' in YAML is parsed as True (boolean)
+        triggers = workflow.get(True) or workflow.get("on")
+        assert "push" in triggers
+        assert "main" in triggers["push"]["branches"]
+
+    def test_workflow_triggers_on_tags(self):
+        """Workflow triggers on version tags."""
+        workflow_path = ".github/workflows/docker.yml"
+        with open(workflow_path) as f:
+            workflow = yaml.safe_load(f)
+
+        # 'on' in YAML is parsed as True (boolean)
+        triggers = workflow.get(True) or workflow.get("on")
+        assert "v*" in triggers["push"]["tags"]


### PR DESCRIPTION
## Summary

Add CI/CD workflow to automatically build and publish multi-platform Docker images to GitHub Container Registry (ghcr.io).

## Changes

- New workflow `.github/workflows/docker.yml`:
  - Multi-platform builds (linux/amd64, linux/arm64)
  - Triggers on push to main, version tags (v*), and PRs affecting Docker files
  - Caching with GitHub Actions cache
  - Artifact attestations for security
  - Requires tests to pass before building

- Added `pyyaml` as dev dependency for workflow validation tests
- Added 6 unit tests to validate workflow configuration

## Test Plan

- [x] All 419 unit tests pass
- [x] New workflow YAML is valid
- [x] Tests verify multi-platform configuration
- [x] Tests verify GHCR registry target

Closes #136