### PR TITLE
feat: publish maintainer Docker image to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,8 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
+  GHCR_REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -63,19 +64,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Container Registry
+      - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/gasclaw
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -100,6 +110,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/tests/unit/test_docker_workflow.py
+++ b/tests/unit/test_docker_workflow.py
@@ -49,8 +49,32 @@ class TestDockerWorkflow:
         with open(workflow_path) as f:
             workflow = yaml.safe_load(f)
 
-        assert workflow["env"]["REGISTRY"] == "ghcr.io"
+        assert workflow["env"]["GHCR_REGISTRY"] == "ghcr.io"
         assert workflow["env"]["IMAGE_NAME"] == "${{ github.repository }}"
+
+    def test_workflow_uses_dockerhub(self):
+        """Workflow targets Docker Hub."""
+        workflow_path = ".github/workflows/docker.yml"
+        with open(workflow_path) as f:
+            workflow = yaml.safe_load(f)
+
+        assert workflow["env"]["DOCKERHUB_REGISTRY"] == "docker.io"
+
+    def test_workflow_has_dockerhub_login(self):
+        """Workflow logs in to Docker Hub."""
+        workflow_path = ".github/workflows/docker.yml"
+        with open(workflow_path) as f:
+            workflow = yaml.safe_load(f)
+
+        build_steps = workflow["jobs"]["build"]["steps"]
+        dockerhub_login = next(
+            (s for s in build_steps if "Docker Hub" in s.get("name", "")),
+            None
+        )
+        assert dockerhub_login is not None
+        assert dockerhub_login["uses"] == "docker/login-action@v3"
+        assert "DOCKERHUB_USERNAME" in dockerhub_login["with"].get("username", "")
+        assert "DOCKERHUB_TOKEN" in dockerhub_login["with"].get("password", "")
 
     def test_workflow_triggers_on_push_to_main(self):
         """Workflow triggers on push to main branch."""


### PR DESCRIPTION
## Summary

Extend the Docker CI/CD workflow to also publish images to Docker Hub in addition to GitHub Container Registry.

## Changes

- Add Docker Hub login step using repository secrets
- Configure multi-registry image metadata
- Add DOCKERHUB_REGISTRY environment variable
- Add tests for Docker Hub configuration

## Required Secrets

Add these secrets to the repository:
- `DOCKERHUB_USERNAME` - Docker Hub username
- `DOCKERHUB_TOKEN` - Docker Hub access token

## Published Images

Images will be published to:
- `ghcr.io/gastown-publish/gasclaw`
- `docker.io/{username}/gasclaw`

## Test Plan

- [x] All 421 unit tests pass
- [x] Tests verify Docker Hub registry configuration
- [x] Tests verify Docker Hub login step

Closes #134