### PR TITLE
feat: add Kimi API credit usage checker per key

### DIFF
--- a/src/gasclaw/kimigas/__init__.py
+++ b/src/gasclaw/kimigas/__init__.py
@@ -1,0 +1,21 @@
+"""KimiGas module: Kimi API key pool and credit checking."""
+
+from __future__ import annotations
+
+from gasclaw.kimigas.credit_checker import (
+    CreditChecker,
+    CreditInfo,
+    check_key_credits,
+)
+from gasclaw.kimigas.key_pool import KeyPool, RATE_LIMIT_COOLDOWN
+from gasclaw.kimigas.proxy import KIMI_ANTHROPIC_BASE_URL, build_claude_env
+
+__all__ = [
+    "KeyPool",
+    "RATE_LIMIT_COOLDOWN",
+    "CreditChecker",
+    "CreditInfo",
+    "check_key_credits",
+    "KIMI_ANTHROPIC_BASE_URL",
+    "build_claude_env",
+]

--- a/src/gasclaw/kimigas/credit_checker.py
+++ b/src/gasclaw/kimigas/credit_checker.py
@@ -1,0 +1,192 @@
+"""Kimi API credit usage checker per key.
+
+Queries Kimi API billing endpoints to check credit balance and usage per API key.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+KIMI_API_BASE = "https://api.kimi.com"
+logger = logging.getLogger(__name__)
+
+__all__ = ["CreditInfo", "CreditChecker", "check_key_credits"]
+
+
+@dataclass
+class CreditInfo:
+    """Credit information for a single API key."""
+
+    key: str  # masked key for identification
+    balance: float | None = None  # remaining balance in CNY
+    total_used: float | None = None  # total usage in CNY
+    currency: str = "CNY"
+    valid: bool = True  # key is valid and active
+    error: str | None = None  # error message if query failed
+
+    @property
+    def key_hash(self) -> str:
+        """Return masked key identifier (last 8 chars)."""
+        return f"...{self.key[-8:]}" if len(self.key) > 8 else self.key
+
+
+class CreditChecker:
+    """Check credit usage for Kimi API keys."""
+
+    def __init__(self, base_url: str = KIMI_API_BASE) -> None:
+        self.base_url = base_url
+
+    def _mask_key(self, key: str) -> str:
+        """Return masked key for display (last 8 chars only)."""
+        return f"...{key[-8:]}" if len(key) > 8 else key
+
+    def check_key(self, api_key: str) -> CreditInfo:
+        """Check credit for a single API key.
+
+        Args:
+            api_key: The Kimi API key to check.
+
+        Returns:
+            CreditInfo with balance and usage data.
+        """
+        masked = self._mask_key(api_key)
+
+        # Kimi API v1 billing endpoint
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                # Query user/balance endpoint
+                response = client.get(
+                    f"{self.base_url}/v1/users/me/balance",
+                    headers=headers,
+                )
+
+                if response.status_code == 401:
+                    return CreditInfo(
+                        key=masked,
+                        valid=False,
+                        error="Invalid API key",
+                    )
+
+                if response.status_code == 429:
+                    return CreditInfo(
+                        key=masked,
+                        valid=True,
+                        error="Rate limited - try again later",
+                    )
+
+                response.raise_for_status()
+                data: dict[str, Any] = response.json()
+
+                # Kimi API returns balance in yuan/cents
+                balance = data.get("data", {}).get("available_balance")
+                total_used = data.get("data", {}).get("total_usage")
+                currency = data.get("data", {}).get("currency", "CNY")
+
+                return CreditInfo(
+                    key=masked,
+                    balance=_parse_amount(balance),
+                    total_used=_parse_amount(total_used),
+                    currency=currency,
+                    valid=True,
+                )
+
+        except httpx.HTTPStatusError as e:
+            logger.warning(f"HTTP error checking key {masked}: {e.response.status_code}")
+            return CreditInfo(
+                key=masked,
+                valid=False,
+                error=f"HTTP {e.response.status_code}",
+            )
+        except httpx.RequestError as e:
+            logger.warning(f"Request error checking key {masked}: {e}")
+            return CreditInfo(
+                key=masked,
+                valid=False,
+                error=f"Request failed: {e}",
+            )
+        except Exception as e:
+            logger.warning(f"Error checking key {masked}: {e}")
+            return CreditInfo(
+                key=masked,
+                valid=False,
+                error=str(e),
+            )
+
+    def check_keys(self, api_keys: list[str]) -> list[CreditInfo]:
+        """Check credits for multiple API keys.
+
+        Args:
+            api_keys: List of Kimi API keys to check.
+
+        Returns:
+            List of CreditInfo for each key.
+        """
+        return [self.check_key(key) for key in api_keys]
+
+    def get_pool_summary(self, api_keys: list[str]) -> dict[str, Any]:
+        """Get aggregated credit summary for a key pool.
+
+        Args:
+            api_keys: List of Kimi API keys.
+
+        Returns:
+            Dict with total balance, usage, and per-key details.
+        """
+        results = self.check_keys(api_keys)
+
+        valid_keys = [r for r in results if r.valid and r.balance is not None]
+        invalid_keys = [r for r in results if not r.valid]
+
+        total_balance = sum(r.balance for r in valid_keys if r.balance)
+        total_usage = sum(r.total_used for r in valid_keys if r.total_used)
+
+        return {
+            "total_keys": len(api_keys),
+            "valid_keys": len(valid_keys),
+            "invalid_keys": len(invalid_keys),
+            "total_balance": total_balance,
+            "total_usage": total_usage,
+            "currency": "CNY",
+            "keys": [
+                {
+                    "key": r.key_hash,
+                    "balance": r.balance,
+                    "total_used": r.total_used,
+                    "valid": r.valid,
+                    "error": r.error,
+                }
+                for r in results
+            ],
+        }
+
+
+def _parse_amount(amount: Any) -> float | None:
+    """Parse amount from API response."""
+    if amount is None:
+        return None
+    try:
+        return round(float(amount), 2)
+    except (ValueError, TypeError):
+        return None
+
+
+def check_key_credits(api_keys: list[str]) -> dict[str, Any]:
+    """Convenience function to check credits for a list of keys.
+
+    Args:
+        api_keys: List of Kimi API keys.
+
+    Returns:
+        Aggregated credit summary.
+    """
+    checker = CreditChecker()
+    return checker.get_pool_summary(api_keys)

--- a/tests/unit/test_kimi_credit_checker.py
+++ b/tests/unit/test_kimi_credit_checker.py
@@ -1,0 +1,261 @@
+"""Tests for kimigas.credit_checker module."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from gasclaw.kimigas.credit_checker import (
+    CreditChecker,
+    CreditInfo,
+    check_key_credits,
+)
+
+
+class TestCreditInfo:
+    def test_key_hash_masks_key(self):
+        """Key hash returns masked identifier."""
+        info = CreditInfo(key="sk-test-key-1234abcd")
+        assert info.key_hash == "...1234abcd"
+
+    def test_key_hash_short_key(self):
+        """Short key returns as-is."""
+        info = CreditInfo(key="short")
+        assert info.key_hash == "short"
+
+    def test_default_values(self):
+        """CreditInfo has sensible defaults."""
+        info = CreditInfo(key="test")
+        assert info.balance is None
+        assert info.total_used is None
+        assert info.currency == "CNY"
+        assert info.valid is True
+        assert info.error is None
+
+
+class TestCreditChecker:
+    def test_mask_key(self):
+        """Key masking shows only last 8 chars."""
+        checker = CreditChecker()
+        masked = checker._mask_key("sk-test-key-1234abcd")
+        assert masked == "...1234abcd"
+
+    def test_mask_key_short(self):
+        """Short key returns as-is."""
+        checker = CreditChecker()
+        masked = checker._mask_key("short")
+        assert masked == "short"
+
+    @respx.mock
+    def test_check_key_success(self):
+        """Successful credit check returns CreditInfo."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "available_balance": 100.0,
+                        "total_usage": 50.0,
+                        "currency": "CNY",
+                    }
+                },
+            )
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test-key")
+
+        assert result.valid is True
+        assert result.balance == 100.0
+        assert result.total_used == 50.0
+        assert result.currency == "CNY"
+        assert route.called
+
+    @respx.mock
+    def test_check_key_invalid_auth(self):
+        """401 response returns invalid CreditInfo."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(401, json={"error": "Unauthorized"})
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-invalid-key")
+
+        assert result.valid is False
+        assert result.error == "Invalid API key"
+        assert route.called
+
+    @respx.mock
+    def test_check_key_rate_limited(self):
+        """429 response returns rate limited info."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(429, json={"error": "Rate limited"})
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test-key")
+
+        assert result.valid is True  # key is still valid
+        assert "Rate limited" in result.error
+        assert route.called
+
+    @respx.mock
+    def test_check_key_server_error(self):
+        """500 response returns error info."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(500, json={"error": "Server error"})
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test-key")
+
+        assert result.valid is False
+        assert "HTTP 500" in result.error
+        assert route.called
+
+    @respx.mock
+    def test_check_key_network_error(self):
+        """Network error returns error info."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test-key")
+
+        assert result.valid is False
+        assert "Request failed" in result.error
+        assert route.called
+
+    @respx.mock
+    def test_check_keys_multiple(self):
+        """Check multiple keys returns list of CreditInfo."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"available_balance": 50.0, "total_usage": 10.0}},
+            )
+        )
+
+        checker = CreditChecker()
+        results = checker.check_keys(["sk-key1", "sk-key2"])
+
+        assert len(results) == 2
+        assert all(r.valid for r in results)
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_get_pool_summary(self):
+        """Pool summary aggregates key data."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance")
+        route.side_effect = [
+            httpx.Response(
+                200,
+                json={"data": {"available_balance": 100.0, "total_usage": 50.0}},
+            ),
+            httpx.Response(
+                200,
+                json={"data": {"available_balance": 200.0, "total_usage": 100.0}},
+            ),
+        ]
+
+        checker = CreditChecker()
+        summary = checker.get_pool_summary(["sk-key1", "sk-key2"])
+
+        assert summary["total_keys"] == 2
+        assert summary["valid_keys"] == 2
+        assert summary["invalid_keys"] == 0
+        assert summary["total_balance"] == 300.0  # 100 + 200
+        assert summary["total_usage"] == 150.0  # 50 + 100
+        assert len(summary["keys"]) == 2
+
+    @respx.mock
+    def test_get_pool_summary_with_invalid_key(self):
+        """Pool summary handles mix of valid and invalid keys."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance")
+        route.side_effect = [
+            httpx.Response(
+                200,
+                json={"data": {"available_balance": 100.0, "total_usage": 50.0}},
+            ),
+            httpx.Response(401, json={"error": "Unauthorized"}),
+        ]
+
+        checker = CreditChecker()
+        summary = checker.get_pool_summary(["sk-valid", "sk-invalid"])
+
+        assert summary["total_keys"] == 2
+        assert summary["valid_keys"] == 1
+        assert summary["invalid_keys"] == 1
+        assert summary["total_balance"] == 100.0
+
+    @respx.mock
+    def test_yuan_amount_not_converted(self):
+        """Yuan amounts (small numbers) are not converted."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"available_balance": 50.5, "total_usage": 10.25}},
+            )
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test")
+
+        # Small amounts (< 10000) are treated as yuan
+        assert result.balance == 50.5
+        assert result.total_used == 10.25
+
+    @respx.mock
+    def test_large_amount_not_converted(self):
+        """Large amounts are preserved as-is (no conversion)."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"available_balance": 1234567, "total_usage": 890123}},
+            )
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test")
+
+        # Amounts are preserved as-is from API
+        assert result.balance == 1234567.0
+        assert result.total_used == 890123.0
+
+    @respx.mock
+    def test_none_amount_handled(self):
+        """None amounts are handled gracefully."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"available_balance": None, "total_usage": None}},
+            )
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test")
+
+        assert result.balance is None
+        assert result.total_used is None
+
+
+class TestCheckKeyCredits:
+    """Tests for the convenience function."""
+
+    @respx.mock
+    def test_check_key_credits(self):
+        """Convenience function returns summary."""
+        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"available_balance": 100.0, "total_usage": 50.0}},
+            )
+        )
+
+        summary = check_key_credits(["sk-key1"])
+
+        assert summary["total_keys"] == 1
+        assert summary["valid_keys"] == 1
+        assert route.called


### PR DESCRIPTION
## Summary

Add credit_checker module to query Kimi API billing endpoints and check credit balance and usage per API key.

## Features

- `CreditChecker` class with per-key and batch checking
- `CreditInfo` dataclass for structured results
- Key masking for secure logging (shows only last 8 chars)
- Error handling for invalid keys (401) and rate limits (429)
- Pool summary with aggregated totals across all keys

## APIs

```python
from gasclaw.kimigas import check_key_credits, CreditChecker

# Convenience function
summary = check_key_credits(["sk-key1", "sk-key2"])

# Detailed usage
checker = CreditChecker()
info = checker.check_key("sk-key1")  # CreditInfo
summary = checker.get_pool_summary(["sk-key1", "sk-key2"])
```

## Test Plan

- [x] All 438 unit tests pass
- [x] 17 new tests for credit checker
- [x] Tests cover success, auth errors, rate limits, network errors
- [x] Tests cover pool summary aggregation

Closes #133