### PR TITLE
feat: integrate gt feed for Telegram dashboard

### DIFF
--- a/src/gasclaw/gastown/gt_feed.py
+++ b/src/gasclaw/gastown/gt_feed.py
@@ -1,0 +1,249 @@
+"""Gastown activity feed for Telegram dashboard.
+
+Integrates gt status/log output to provide activity updates to Telegram.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ActivityEvent",
+    "GastownFeed",
+    "get_recent_activity",
+    "format_feed_for_telegram",
+]
+
+
+@dataclass
+class ActivityEvent:
+    """Single activity event from Gastown."""
+
+    type: str  # commit, pr, agent_start, agent_stop, etc.
+    timestamp: str
+    actor: str  # agent name or user
+    description: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "type": self.type,
+            "timestamp": self.timestamp,
+            "actor": self.actor,
+            "description": self.description,
+            "metadata": self.metadata,
+        }
+
+
+class GastownFeed:
+    """Reader for Gastown activity feed."""
+
+    def __init__(self, project_dir: str = "/project") -> None:
+        self.project_dir = project_dir
+
+    def _run_gt_command(self, args: list[str]) -> str | None:
+        """Run a gt command and return stdout."""
+        try:
+            result = subprocess.run(
+                ["gt"] + args,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=self.project_dir,
+            )
+            if result.returncode == 0:
+                return result.stdout
+            logger.warning(f"gt command failed: {' '.join(args)} - {result.stderr}")
+        except (OSError, subprocess.TimeoutExpired) as e:
+            logger.warning(f"Failed to run gt command: {e}")
+        return None
+
+    def get_agent_status(self) -> list[dict[str, Any]]:
+        """Get current agent status from gt status."""
+        output = self._run_gt_command(["status", "--json"])
+        if output:
+            try:
+                data = json.loads(output)
+                return data.get("agents", [])
+            except json.JSONDecodeError:
+                logger.warning("Failed to parse gt status JSON")
+        return []
+
+    def get_recent_commits(self, limit: int = 5) -> list[ActivityEvent]:
+        """Get recent commits from git log."""
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "log",
+                    f"-{limit}",
+                    "--format=%H|%ai|%an|%s",
+                    "--date=iso",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=self.project_dir,
+            )
+            if result.returncode == 0:
+                events = []
+                for line in result.stdout.strip().split("\n"):
+                    if "|" in line:
+                        parts = line.split("|", 3)
+                        if len(parts) == 4:
+                            hash_val, timestamp, author, message = parts
+                            events.append(
+                                ActivityEvent(
+                                    type="commit",
+                                    timestamp=timestamp,
+                                    actor=author,
+                                    description=message[:100],
+                                    metadata={"hash": hash_val[:8]},
+                                )
+                            )
+                return events
+        except (OSError, subprocess.TimeoutExpired) as e:
+            logger.warning(f"Failed to get git log: {e}")
+        return []
+
+    def get_recent_prs(self, limit: int = 5) -> list[ActivityEvent]:
+        """Get recent PRs from gt pr list or git log with merge commits."""
+        # Try to get merge commits as proxy for PR activity
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "log",
+                    f"-{limit * 2}",  # Get more to filter merges
+                    "--format=%H|%ai|%an|%s",
+                    "--merges",  # Only merge commits
+                    "--date=iso",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=self.project_dir,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                events = []
+                for line in result.stdout.strip().split("\n")[:limit]:
+                    if "|" in line:
+                        parts = line.split("|", 3)
+                        if len(parts) == 4:
+                            hash_val, timestamp, author, message = parts
+                            events.append(
+                                ActivityEvent(
+                                    type="pr_merge",
+                                    timestamp=timestamp,
+                                    actor=author,
+                                    description=message[:100],
+                                    metadata={"hash": hash_val[:8]},
+                                )
+                            )
+                return events
+        except (OSError, subprocess.TimeoutExpired) as e:
+            logger.warning(f"Failed to get merge commits: {e}")
+        return []
+
+    def get_feed(self, limit: int = 10) -> list[ActivityEvent]:
+        """Get combined feed of recent activity."""
+        commits = self.get_recent_commits(limit // 2)
+        prs = self.get_recent_prs(limit // 2)
+
+        # Combine and sort by timestamp
+        all_events = commits + prs
+        all_events.sort(key=lambda e: e.timestamp, reverse=True)
+
+        return all_events[:limit]
+
+    def get_summary(self) -> dict[str, Any]:
+        """Get activity summary for dashboard."""
+        agents = self.get_agent_status()
+        recent = self.get_feed(limit=5)
+
+        # Count events by type
+        commit_count = sum(1 for e in recent if e.type == "commit")
+        pr_count = sum(1 for e in recent if e.type == "pr_merge")
+
+        return {
+            "active_agents": len(agents),
+            "agent_names": [a.get("name", "unknown") for a in agents],
+            "recent_commits": commit_count,
+            "recent_prs": pr_count,
+            "recent_activity": [e.to_dict() for e in recent],
+            "status": "active" if agents else "idle",
+        }
+
+
+def get_recent_activity(
+    project_dir: str = "/project",
+    limit: int = 10,
+) -> list[ActivityEvent]:
+    """Convenience function to get recent activity.
+
+    Args:
+        project_dir: Project directory with git repository.
+        limit: Maximum number of events to return.
+
+    Returns:
+        List of ActivityEvent objects.
+    """
+    feed = GastownFeed(project_dir)
+    return feed.get_feed(limit)
+
+
+def format_feed_for_telegram(
+    summary: dict[str, Any],
+    *,
+    max_events: int = 5,
+) -> str:
+    """Format activity summary for Telegram message.
+
+    Args:
+        summary: Activity summary from GastownFeed.get_summary().
+        max_events: Maximum number of events to include.
+
+    Returns:
+        Formatted markdown string for Telegram.
+    """
+    lines = [
+        "📊 *Gastown Activity Dashboard*",
+        "",
+        f"🤖 *Active Agents:* {summary['active_agents']}",
+    ]
+
+    if summary.get("agent_names"):
+        agent_list = ", ".join(summary["agent_names"][:5])
+        lines.append(f"   {agent_list}")
+
+    lines.append("")
+    lines.append(f"📝 *Recent Commits:* {summary['recent_commits']}")
+    lines.append(f"🔀 *Recent PRs:* {summary['recent_prs']}")
+    lines.append("")
+
+    # Recent activity
+    events = summary.get("recent_activity", [])[:max_events]
+    if events:
+        lines.append("🕐 *Recent Activity:*")
+        for event in events:
+            emoji = "📝" if event["type"] == "commit" else "🔀"
+            desc = event["description"][:50]
+            if len(event["description"]) > 50:
+                desc += "..."
+            actor = event["actor"][:15]
+            lines.append(f"  {emoji} {desc} — _{actor}_")
+    else:
+        lines.append("🕐 *Recent Activity:* None")
+
+    lines.append("")
+    status_emoji = "🟢" if summary["status"] == "active" else "🟡"
+    lines.append(f"{status_emoji} *Status:* {summary['status'].upper()}")
+
+    return "\n".join(lines)

--- a/tests/unit/test_gt_feed.py
+++ b/tests/unit/test_gt_feed.py
@@ -1,0 +1,348 @@
+"""Tests for gastown.gt_feed module."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from gasclaw.gastown.gt_feed import (
+    ActivityEvent,
+    GastownFeed,
+    format_feed_for_telegram,
+    get_recent_activity,
+)
+
+
+class TestActivityEvent:
+    def test_basic_creation(self):
+        """ActivityEvent can be created with required fields."""
+        event = ActivityEvent(
+            type="commit",
+            timestamp="2026-03-02T10:00:00",
+            actor="test-agent",
+            description="Test commit message",
+        )
+        assert event.type == "commit"
+        assert event.actor == "test-agent"
+        assert event.description == "Test commit message"
+        assert event.metadata == {}
+
+    def test_to_dict(self):
+        """ActivityEvent converts to dict correctly."""
+        event = ActivityEvent(
+            type="pr_merge",
+            timestamp="2026-03-02T10:00:00",
+            actor="test-agent",
+            description="Merged PR #123",
+            metadata={"hash": "abc123"},
+        )
+        d = event.to_dict()
+        assert d["type"] == "pr_merge"
+        assert d["actor"] == "test-agent"
+        assert d["metadata"]["hash"] == "abc123"
+
+
+class TestGastownFeed:
+    def test_init(self):
+        """GastownFeed initializes with project directory."""
+        feed = GastownFeed(project_dir="/workspace/test")
+        assert feed.project_dir == "/workspace/test"
+
+    def test_default_project_dir(self):
+        """GastownFeed uses default project directory."""
+        feed = GastownFeed()
+        assert feed.project_dir == "/project"
+
+    def test_get_agent_status_success(self, monkeypatch):
+        """get_agent_status parses gt status output."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = json.dumps({"agents": [{"name": "agent1"}, {"name": "agent2"}]})
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        agents = feed.get_agent_status()
+
+        assert len(agents) == 2
+        assert agents[0]["name"] == "agent1"
+
+    def test_get_agent_status_failure(self, monkeypatch):
+        """get_agent_status returns empty list on failure."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 1
+                stdout = ""
+                stderr = "error"
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        agents = feed.get_agent_status()
+
+        assert agents == []
+
+    def test_get_agent_status_json_error(self, monkeypatch):
+        """get_agent_status handles invalid JSON."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = "invalid json"
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        agents = feed.get_agent_status()
+
+        assert agents == []
+
+    def test_get_recent_commits_success(self, monkeypatch):
+        """get_recent_commits parses git log output."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = "abc123|2026-03-02 10:00:00 +0000|Test User|Test commit message"
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        commits = feed.get_recent_commits(limit=1)
+
+        assert len(commits) == 1
+        assert commits[0].type == "commit"
+        assert commits[0].actor == "Test User"
+        assert commits[0].description == "Test commit message"
+        assert commits[0].metadata["hash"] == "abc123"
+
+    def test_get_recent_commits_truncates_long_messages(self, monkeypatch):
+        """get_recent_commits truncates messages over 100 chars."""
+        long_message = "a" * 150
+
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = f"abc123|2026-03-02 10:00:00 +0000|User|{long_message}"
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        commits = feed.get_recent_commits(limit=1)
+
+        assert len(commits[0].description) == 100
+
+    def test_get_recent_commits_empty(self, monkeypatch):
+        """get_recent_commits handles empty git log."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        commits = feed.get_recent_commits()
+
+        assert commits == []
+
+    def test_get_recent_commits_failure(self, monkeypatch):
+        """get_recent_commits handles git failure."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 1
+                stdout = ""
+                stderr = "error"
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        commits = feed.get_recent_commits()
+
+        assert commits == []
+
+    def test_get_recent_prs_success(self, monkeypatch):
+        """get_recent_prs parses merge commits."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = "abc123|2026-03-02 10:00:00 +0000|Test User|Merge pull request #123"
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        prs = feed.get_recent_prs(limit=1)
+
+        assert len(prs) == 1
+        assert prs[0].type == "pr_merge"
+        assert "Merge pull request" in prs[0].description
+
+    def test_get_feed_combines_events(self, monkeypatch):
+        """get_feed combines commits and PRs."""
+        commit_output = "abc1|2026-03-02 10:00:00 +0000|User|Commit message"
+        pr_output = "abc2|2026-03-02 11:00:00 +0000|User|Merge PR"
+
+        call_count = 0
+        def mock_run(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            class Result:
+                returncode = 0
+                stdout = commit_output if call_count == 1 else pr_output
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        events = feed.get_feed(limit=2)
+
+        assert len(events) == 2
+        # Should be sorted by timestamp (newest first)
+        assert events[0].type == "pr_merge"
+
+    def test_get_summary(self, monkeypatch):
+        """get_summary returns activity summary."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = json.dumps({"agents": [{"name": "agent1"}, {"name": "agent2"}]})
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        feed = GastownFeed()
+        summary = feed.get_summary()
+
+        assert summary["active_agents"] == 2
+        assert summary["agent_names"] == ["agent1", "agent2"]
+        assert "recent_activity" in summary
+
+
+class TestGetRecentActivity:
+    """Tests for convenience function."""
+
+    def test_get_recent_activity(self, monkeypatch):
+        """Convenience function returns activity events."""
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = "abc|2026-03-02 10:00:00 +0000|User|Message"
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+
+        events = get_recent_activity(project_dir="/tmp", limit=1)
+        assert len(events) == 1
+
+
+class TestFormatFeedForTelegram:
+    """Tests for Telegram formatting."""
+
+    def test_format_summary(self):
+        """format_feed_for_telegram creates markdown message."""
+        summary = {
+            "active_agents": 3,
+            "agent_names": ["agent1", "agent2", "agent3"],
+            "recent_commits": 5,
+            "recent_prs": 2,
+            "status": "active",
+            "recent_activity": [
+                {
+                    "type": "commit",
+                    "description": "Fix bug in parser",
+                    "actor": "agent1",
+                    "timestamp": "2026-03-02T10:00:00",
+                }
+            ],
+        }
+
+        message = format_feed_for_telegram(summary)
+
+        assert "Gastown Activity Dashboard" in message
+        assert "Active Agents:* 3" in message
+        assert "agent1" in message
+        assert "Recent Commits:* 5" in message
+        assert "Recent PRs:* 2" in message
+        assert "Fix bug in parser" in message
+        assert "🟢" in message  # Active status emoji
+
+    def test_format_empty_activity(self):
+        """format_feed_for_telegram handles no activity."""
+        summary = {
+            "active_agents": 0,
+            "agent_names": [],
+            "recent_commits": 0,
+            "recent_prs": 0,
+            "status": "idle",
+            "recent_activity": [],
+        }
+
+        message = format_feed_for_telegram(summary)
+
+        assert "Recent Activity:* None" in message
+        assert "🟡" in message  # Idle status emoji
+
+    def test_format_truncates_long_descriptions(self):
+        """format_feed_for_telegram truncates long descriptions."""
+        summary = {
+            "active_agents": 1,
+            "agent_names": ["agent1"],
+            "recent_commits": 1,
+            "recent_prs": 0,
+            "status": "active",
+            "recent_activity": [
+                {
+                    "type": "commit",
+                    "description": "a" * 100,
+                    "actor": "agent1",
+                    "timestamp": "2026-03-02T10:00:00",
+                }
+            ],
+        }
+
+        message = format_feed_for_telegram(summary)
+
+        assert "..." in message
+        # The truncated description line itself is < 60 chars
+        activity_line = [line for line in message.split('\n') if '📝 a' in line][0]
+        assert len(activity_line) < 70
+
+    def test_format_truncates_actor_names(self):
+        """format_feed_for_telegram truncates long actor names."""
+        summary = {
+            "active_agents": 1,
+            "agent_names": ["agent1"],
+            "recent_commits": 1,
+            "recent_prs": 0,
+            "status": "active",
+            "recent_activity": [
+                {
+                    "type": "commit",
+                    "description": "Test",
+                    "actor": "a" * 30,
+                    "timestamp": "2026-03-02T10:00:00",
+                }
+            ],
+        }
+
+        message = format_feed_for_telegram(summary)
+
+        assert "Test" in message


### PR DESCRIPTION
## Summary

Add gastown.gt_feed module to gather activity from Gastown and format it for Telegram dashboard display.

## Features

- `GastownFeed` class reads agent status and git activity
- `ActivityEvent` dataclass for structured event data
- Git log parsing for commits and PR merges
- Telegram markdown formatting with emojis
- Summary statistics (active agents, commits, PRs)

## APIs

```python
from gasclaw.gastown.gt_feed import get_recent_activity, format_feed_for_telegram

# Get recent activity
activity = get_recent_activity(project_dir="/project", limit=10)

# Format for Telegram
summary = GastownFeed().get_summary()
message = format_feed_for_telegram(summary)
```

## Example Telegram Output

📊 *Gastown Activity Dashboard*

🤖 *Active Agents:* 3
   agent1, agent2, agent3

📝 *Recent Commits:* 5
🔀 *Recent PRs:* 2

🕐 *Recent Activity:*
  📝 Fix bug in parser — _agent1_

🟢 *Status:* ACTIVE

## Test Plan

- [x] All 457 unit tests pass
- [x] 19 new tests for gt_feed module
- [x] Tests cover git log parsing, agent status, formatting

Closes #135