### PR TITLE
fix: resolve ruff linting issues

### DIFF
--- a/src/gasclaw/kimigas/__init__.py
+++ b/src/gasclaw/kimigas/__init__.py
@@ -7,7 +7,7 @@ from gasclaw.kimigas.credit_checker import (
     CreditInfo,
     check_key_credits,
 )
-from gasclaw.kimigas.key_pool import KeyPool, RATE_LIMIT_COOLDOWN
+from gasclaw.kimigas.key_pool import RATE_LIMIT_COOLDOWN, KeyPool
 from gasclaw.kimigas.proxy import KIMI_ANTHROPIC_BASE_URL, build_claude_env
 
 __all__ = [

--- a/tests/unit/test_gt_feed.py
+++ b/tests/unit/test_gt_feed.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 import subprocess
 
-import pytest
-
 from gasclaw.gastown.gt_feed import (
     ActivityEvent,
     GastownFeed,

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -837,7 +837,9 @@ class TestCheckAgentActivityClockSkew:
         report = check_health(gateway_port=18789)
         assert report.openclaw == "unhealthy"
 
-    def test_check_health_with_oserror_on_service_check(self, monkeypatch, respx_mock: respx.MockRouter):
+    def test_check_health_with_oserror_on_service_check(
+        self, monkeypatch, respx_mock: respx.MockRouter
+    ):
         """check_health handles OSError on service checks - covers lines 55-58, 64-67."""
         respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
 

--- a/tests/unit/test_kimi_credit_checker.py
+++ b/tests/unit/test_kimi_credit_checker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import httpx
-import pytest
 import respx
 
 from gasclaw.kimigas.credit_checker import (
@@ -193,7 +192,7 @@ class TestCreditChecker:
     @respx.mock
     def test_yuan_amount_not_converted(self):
         """Yuan amounts (small numbers) are not converted."""
-        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+        respx.get("https://api.kimi.com/v1/users/me/balance").mock(
             return_value=httpx.Response(
                 200,
                 json={"data": {"available_balance": 50.5, "total_usage": 10.25}},
@@ -210,7 +209,7 @@ class TestCreditChecker:
     @respx.mock
     def test_large_amount_not_converted(self):
         """Large amounts are preserved as-is (no conversion)."""
-        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+        respx.get("https://api.kimi.com/v1/users/me/balance").mock(
             return_value=httpx.Response(
                 200,
                 json={"data": {"available_balance": 1234567, "total_usage": 890123}},
@@ -227,7 +226,7 @@ class TestCreditChecker:
     @respx.mock
     def test_none_amount_handled(self):
         """None amounts are handled gracefully."""
-        route = respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+        respx.get("https://api.kimi.com/v1/users/me/balance").mock(
             return_value=httpx.Response(
                 200,
                 json={"data": {"available_balance": None, "total_usage": None}},

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -204,7 +204,7 @@ class TestMigrateConfig:
         assert "Failed to write env file" in result["error"]
 
     def test_migrate_config_without_env_file(self, tmp_path, monkeypatch):
-        """migrate_config without env_file returns success with keys - dry run mode (lines 313-316)."""
+        """migrate_config without env_file returns success - dry run mode (lines 313-316)."""
         monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
         monkeypatch.setenv("KIMI_API_KEY", "sk-dryrun-key")
         monkeypatch.setenv("OPENCLAW_KIMI_KEY", "sk-oc")

--- a/tests/unit/test_openclaw_lifecycle.py
+++ b/tests/unit/test_openclaw_lifecycle.py
@@ -104,10 +104,10 @@ class TestStartOpenclaw:
             patch("subprocess.Popen", return_value=mock_proc),
             patch("httpx.get", side_effect=httpx.ConnectError("refused")),
             patch("time.sleep"),
+            pytest.raises(TimeoutError),
         ):
             # Cleanup exceptions don't propagate - the original TimeoutError does
-            with pytest.raises(TimeoutError):
-                start_openclaw(port=18789, timeout=1)
+            start_openclaw(port=18789, timeout=1)
 
         mock_proc.terminate.assert_called_once()
         mock_proc.kill.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes 9 ruff linting issues across 6 files:

- **I001**: Import block formatting in `kimigas/__init__.py`
- **F401**: Unused `pytest` imports in `test_gt_feed.py` and `test_kimi_credit_checker.py`
- **F841**: Unused `route` variables in `test_kimi_credit_checker.py`
- **E501**: Line too long in `test_health.py` and `test_migration.py`
- **SIM117**: Nested with statements in `test_openclaw_lifecycle.py`

## Test plan
- [x] `python -m ruff check src tests` passes
- [x] `python -m pytest tests/unit -v` passes (457 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)