### PR TITLE
fix: add .coverage to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 venv/
 .env
 .pytest_cache/
+.coverage
 .ruff_cache/
 .mypy_cache/
 *.swp


### PR DESCRIPTION
## Summary

Add `.coverage` to `.gitignore` to prevent committing generated coverage files.

## Changes

- Add `.coverage` to `.gitignore` after `.pytest_cache/`

## Test plan

- [x] `make test` passes (465 tests)
- [x] `make lint` passes
- [x] `.coverage` file is now properly ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)