### PR TITLE
refactor: simplify _load_state by removing redundant variable

### DIFF
--- a/src/gasclaw/kimigas/key_pool.py
+++ b/src/gasclaw/kimigas/key_pool.py
@@ -41,8 +41,7 @@ class KeyPool:
         state_file = self._state_dir / "key-rotation.json"
         if state_file.is_file():
             try:
-                data: dict[str, Any] = json.loads(state_file.read_text())
-                return data
+                return json.loads(state_file.read_text())
             except (json.JSONDecodeError, OSError):
                 pass
         return {}


### PR DESCRIPTION
## Summary
Simplifies the `_load_state()` method in `key_pool.py` by removing the intermediate `data` variable and returning `json.loads()` directly.

## Changes
- Removed redundant variable assignment in `_load_state()`
- No functional changes

## Test plan
- [x] All 26 key pool tests pass
- [x] Full test suite passes (465 tests)
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)