### PR TITLE
docs: update test count from 73 to 465+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 73 unit tests — all mocked, no API keys needed
+tests/unit/             # 465+ unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 73 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 465 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 73 unit tests must pass. Never modify a test to make it pass — fix the cod
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 73+ tests)
+- [ ] `make test` passes (all 465+ tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only
+make test          # Unit tests only (465+ tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary

Documentation incorrectly stated 73 unit tests, but the codebase actually has 465 unit tests (as shown by `pytest tests/unit -v`). This PR updates all references to reflect the correct count.

## Changes

- README.md: Update test count in Quick Start section
- CLAUDE.md: Update test count in:
  - Project Structure section
  - Testing section  
  - PR Checklist

## Test plan

- [x] Verified all 465 tests pass
- [x] 100% code coverage maintained
- [x] No code changes, only documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)