### PR TITLE
fix: export bootstrap and load_config from gasclaw package

### DIFF
--- a/src/gasclaw/__init__.py
+++ b/src/gasclaw/__init__.py
@@ -13,5 +13,8 @@ Example:
 
 from __future__ import annotations
 
+from gasclaw.bootstrap import bootstrap
+from gasclaw.config import load_config
+
 __version__ = "0.2.0"
-__all__ = ["__version__"]
+__all__ = ["__version__", "bootstrap", "load_config"]

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -31,6 +31,8 @@ class TestPackageMetadata:
         """__all__ is defined and contains expected exports."""
         assert hasattr(gasclaw, "__all__")
         assert "__version__" in gasclaw.__all__
+        assert "bootstrap" in gasclaw.__all__
+        assert "load_config" in gasclaw.__all__
 
     def test_all_is_list_of_strings(self):
         """__all__ is a list of strings."""
@@ -47,3 +49,13 @@ class TestPackageMetadata:
         assert "Example:" in gasclaw.__doc__
         assert "load_config" in gasclaw.__doc__
         assert "bootstrap" in gasclaw.__doc__
+
+    def test_bootstrap_exported(self):
+        """bootstrap function is exported from package."""
+        assert hasattr(gasclaw, "bootstrap")
+        assert callable(gasclaw.bootstrap)
+
+    def test_load_config_exported(self):
+        """load_config function is exported from package."""
+        assert hasattr(gasclaw, "load_config")
+        assert callable(gasclaw.load_config)


### PR DESCRIPTION
## Summary

The package docstring showed an example using `from gasclaw import load_config, bootstrap`, but these functions were not actually exported from the package. This fixes the discrepancy.

## Changes

- `src/gasclaw/__init__.py`: Import and export `bootstrap` and `load_config`
- `tests/unit/test_init.py`: Add tests to verify exports work correctly

## Test plan

- [x] All 467 tests pass
- [x] 100% coverage maintained
- [x] Verified `from gasclaw import load_config, bootstrap` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)