### PR TITLE
docs: update test count from 465 to 467

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 465+ unit tests — all mocked, no API keys needed
+tests/unit/             # 467+ unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 465 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 467 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 465 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 465+ tests)
+- [ ] `make test` passes (all 467+ tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (465+ tests)
+make test          # Unit tests only (467+ tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary

Update test count references in documentation files to reflect the current number of unit tests (467).

## Changes

- README.md: Update test count from 465+ to 467+
- CLAUDE.md: Update test count from 465+ to 467+ in 3 locations

## Test plan

- [x] Verified `python -m pytest tests/unit` shows 467 tests
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)