### PR TITLE
feat: show rate_limited count in status command

### DIFF
--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -138,7 +138,11 @@ def status() -> None:
     if report.key_pool:
         avail = report.key_pool.get("available", "?")
         total = report.key_pool.get("total", "?")
-        table.add_row("key pool", f"{avail}/{total} available")
+        rl_count = report.key_pool.get("rate_limited", 0)
+        status_text = f"{avail}/{total} available"
+        if rl_count:
+            status_text += f" ({rl_count} rate-limited)"
+        table.add_row("key pool", status_text)
     if report.activity:
         compliant = report.activity.get("compliant", False)
         style = "green" if compliant else "red"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -211,9 +211,12 @@ class TestStatusCommand:
             "gasclaw.cli.check_agent_activity",
             lambda **kw: {"compliant": True, "last_commit_age": 300},
         )
+        def mock_status():
+            return {"total": 2, "available": 2, "rate_limited": 0}
+
         monkeypatch.setattr(
             "gasclaw.cli.KeyPool",
-            MagicMock(return_value=MagicMock(status=lambda: {"total": 2, "available": 2})),
+            MagicMock(return_value=MagicMock(status=mock_status)),
         )
 
         result = runner.invoke(app, ["status"])
@@ -352,6 +355,39 @@ class TestCLIEdgeCases:
 
         assert result.exit_code == 0
         assert "NOT COMPLIANT" in result.output or "not compliant" in result.output.lower()
+
+    def test_status_shows_rate_limited_count(self, config, monkeypatch):
+        """status command shows rate_limited count when keys are rate limited."""
+        from gasclaw.health import HealthReport
+
+        def mock_check_health(**kw):
+            return HealthReport(
+                dolt="healthy",
+                daemon="healthy",
+                mayor="healthy",
+                openclaw="healthy",
+                agents=["mayor"],
+            )
+
+        monkeypatch.setattr("gasclaw.cli.check_health", mock_check_health)
+        monkeypatch.setattr("gasclaw.cli.load_config", lambda: config)
+        monkeypatch.setattr(
+            "gasclaw.cli.check_agent_activity",
+            lambda **kw: {"compliant": True, "last_commit_age": 300},
+        )
+        def mock_status_rl():
+            return {"total": 5, "available": 3, "rate_limited": 2}
+
+        monkeypatch.setattr(
+            "gasclaw.cli.KeyPool",
+            MagicMock(return_value=MagicMock(status=mock_status_rl)),
+        )
+
+        result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0
+        assert "3/5 available" in result.output
+        assert "2 rate-limited" in result.output
 
 
 class TestMigrateCommand:


### PR DESCRIPTION
## Summary

Adds display of rate-limited key count to the `gasclaw status` command output. This helps users understand when keys are unavailable due to rate limiting.

## Changes

- Updated `src/gasclaw/cli.py` to include `rate_limited` count in status table (only shown when > 0)
- Added `test_status_shows_rate_limited_count` test
- Updated existing tests to include `rate_limited` field in mock status

## Test Plan

- [x] All 469 unit tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] New test covers rate_limited display behavior

## Example Output

```
key pool    3/5 available (2 rate-limited)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)