### PR TITLE
docs: update test count from 467-468 to 469 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 468 unit tests — all mocked, no API keys needed
+tests/unit/             # 469 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 467 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 469 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 467 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 467+ tests)
+- [ ] `make test` passes (all 469 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format


### PR DESCRIPTION
## Summary
Update test count references in CLAUDE.md from 467-468 to 469.

## Changes
- Line 36: 468 → 469
- Line 56: 467 → 469  
- Line 101: 467+ → 469

## Test plan
- [x] `make test` passes (all 469 tests)
- [x] Only documentation changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)