### PR TITLE
docs: add missing optional env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,15 @@ TELEGRAM_OWNER_ID=123456789
 
 # Optional: Number of crew workers (default: 6)
 # GT_AGENT_COUNT=6
+
+# Optional: Directory for git activity checks (default: /project)
+# PROJECT_DIR=/project
+
+# Optional: Health check interval in seconds (default: 300)
+# MONITOR_INTERVAL=300
+
+# Optional: Max seconds between commits/PRs (default: 3600)
+# ACTIVITY_DEADLINE=3600
+
+# Optional: Dolt SQL server port (default: 3307)
+# DOLT_PORT=3307


### PR DESCRIPTION
## Summary

Added the missing optional environment variables to `.env.example`:
- `PROJECT_DIR` - Directory for git activity checks
- `MONITOR_INTERVAL` - Health check interval in seconds
- `ACTIVITY_DEADLINE` - Max seconds between commits/PRs
- `DOLT_PORT` - Dolt SQL server port

This helps users discover all available configuration options without needing to read the source code.

## Test plan

- [x] Verified all 469 tests pass
- [x] Verified `.env.example` format is consistent