### PR TITLE
test: improve test coverage for kimigas exports and bootstrap

### DIFF
--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -484,3 +484,68 @@ class TestMonitorLoop:
 
         # Verify sleep was called with the config interval
         m_sleep.assert_called_with(42)
+
+    def test_keyboard_interrupt_logs_info(self, config, monkeypatch, caplog):
+        """monitor_loop logs info message on KeyboardInterrupt."""
+        import logging
+
+        caplog.set_level(logging.INFO)
+
+        def mock_check(**kw):
+            from gasclaw.health import HealthReport
+
+            return HealthReport(
+                dolt="healthy",
+                daemon="healthy",
+                mayor="healthy",
+                openclaw="healthy",
+                agents=["mayor"],
+            )
+
+        def mock_sleep(*a, **kw):
+            raise KeyboardInterrupt
+
+        activity_return = {"compliant": True, "last_commit_age": 100}
+        with (
+            patch("gasclaw.bootstrap.check_health", side_effect=mock_check),
+            patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return),
+            patch("gasclaw.bootstrap.notify_telegram"),
+            patch("time.sleep", side_effect=mock_sleep),
+        ):
+            monitor_loop(config, interval=1)
+
+        assert "Monitor loop stopped by user" in caplog.text
+
+    def test_compliant_defaults_to_true_when_missing(self, config, monkeypatch):
+        """monitor_loop treats missing 'compliant' key as True."""
+        check_count = 0
+        notify_calls = []
+
+        def mock_check(**kw):
+            nonlocal check_count
+            check_count += 1
+            if check_count >= 2:
+                raise KeyboardInterrupt
+            from gasclaw.health import HealthReport
+
+            return HealthReport(
+                dolt="healthy",
+                daemon="healthy",
+                mayor="healthy",
+                openclaw="healthy",
+                agents=["mayor"],
+            )
+
+        # Activity dict without 'compliant' key should default to True
+        activity_return = {"last_commit_age": 100}  # No 'compliant' key
+        with (
+            patch("gasclaw.bootstrap.check_health", side_effect=mock_check),
+            patch("gasclaw.bootstrap.check_agent_activity", return_value=activity_return),
+            patch("gasclaw.bootstrap.notify_telegram") as m_notify,
+            patch("time.sleep"),
+        ):
+            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            monitor_loop(config, interval=1)
+
+        # Should NOT send activity alert since compliant defaults to True
+        assert not any("ACTIVITY ALERT" in msg for msg in notify_calls)

--- a/tests/unit/test_kimigas_init.py
+++ b/tests/unit/test_kimigas_init.py
@@ -1,0 +1,76 @@
+"""Tests for kimigas package initialization."""
+
+from __future__ import annotations
+
+import gasclaw.kimigas as kimigas
+
+
+class TestPackageExports:
+    """Tests for kimigas package-level exports."""
+
+    def test_key_pool_exported(self):
+        """KeyPool class is exported from package."""
+        assert hasattr(kimigas, "KeyPool")
+        assert callable(kimigas.KeyPool)
+
+    def test_rate_limit_cooldown_exported(self):
+        """RATE_LIMIT_COOLDOWN constant is exported."""
+        assert hasattr(kimigas, "RATE_LIMIT_COOLDOWN")
+        assert isinstance(kimigas.RATE_LIMIT_COOLDOWN, int)
+
+    def test_credit_checker_exported(self):
+        """CreditChecker class is exported."""
+        assert hasattr(kimigas, "CreditChecker")
+        assert callable(kimigas.CreditChecker)
+
+    def test_credit_info_exported(self):
+        """CreditInfo dataclass is exported."""
+        assert hasattr(kimigas, "CreditInfo")
+
+    def test_check_key_credits_exported(self):
+        """check_key_credits function is exported."""
+        assert hasattr(kimigas, "check_key_credits")
+        assert callable(kimigas.check_key_credits)
+
+    def test_kimi_anthropic_base_url_exported(self):
+        """KIMI_ANTHROPIC_BASE_URL constant is exported."""
+        assert hasattr(kimigas, "KIMI_ANTHROPIC_BASE_URL")
+        assert isinstance(kimigas.KIMI_ANTHROPIC_BASE_URL, str)
+
+    def test_build_claude_env_exported(self):
+        """build_claude_env function is exported."""
+        assert hasattr(kimigas, "build_claude_env")
+        assert callable(kimigas.build_claude_env)
+
+    def test_all_exports_defined(self):
+        """__all__ is defined and contains expected exports."""
+        assert hasattr(kimigas, "__all__")
+        assert "KeyPool" in kimigas.__all__
+        assert "RATE_LIMIT_COOLDOWN" in kimigas.__all__
+        assert "CreditChecker" in kimigas.__all__
+        assert "CreditInfo" in kimigas.__all__
+        assert "check_key_credits" in kimigas.__all__
+        assert "KIMI_ANTHROPIC_BASE_URL" in kimigas.__all__
+        assert "build_claude_env" in kimigas.__all__
+
+    def test_all_is_list_of_strings(self):
+        """__all__ is a list of strings."""
+        assert isinstance(kimigas.__all__, list)
+        assert all(isinstance(item, str) for item in kimigas.__all__)
+
+    def test_module_docstring_exists(self):
+        """Package has a module-level docstring."""
+        assert kimigas.__doc__ is not None
+        assert "KimiGas" in kimigas.__doc__
+
+    def test_key_pool_can_be_instantiated(self):
+        """KeyPool can be instantiated from package export."""
+        pool = kimigas.KeyPool(keys=["sk-key1", "sk-key2"])
+        assert pool is not None
+
+    def test_credit_info_can_be_created(self):
+        """CreditInfo can be created from package export."""
+        info = kimigas.CreditInfo(key="sk-test", balance=100.0, total_used=50.0)
+        assert info.key == "sk-test"
+        assert info.balance == 100.0
+        assert info.total_used == 50.0


### PR DESCRIPTION
## Summary

Improves test coverage by adding tests for:
- `kimigas/__init__.py` package exports (12 tests)
- `monitor_loop` KeyboardInterrupt handling
- `activity.get(\"compliant\", True)` default behavior

## Test Plan

- [x] `python -m pytest tests/unit -v` passes (483 tests)
- [x] `ruff check src/ tests/` passes
- [x] New tests cover previously untested code paths

## Changes

- `tests/unit/test_kimigas_init.py`: New file testing all kimigas exports
- `tests/unit/test_bootstrap.py`: Added 2 tests for coverage gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)