### PR TITLE
docs: update test count from 469 to 483

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 469 unit tests — all mocked, no API keys needed
+tests/unit/             # 483 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 469 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 483 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 469 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 469 tests)
+- [ ] `make test` passes (all 483 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (469 tests)
+make test          # Unit tests only (483 tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary
Update documentation files to reflect the current test count of 483 unit tests (was 469).

## Changes
- CLAUDE.md: Update 3 references to test count
- README.md: Update 1 reference to test count

## Test plan
- [x] `make test` passes (483 tests)
- [x] `make lint` passes
- [x] Documentation only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)