### PR TITLE
docs: update README and .env.example with missing env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,9 @@ TELEGRAM_OWNER_ID=123456789
 
 # Optional: Dolt SQL server port (default: 3307)
 # DOLT_PORT=3307
+
+# Optional: Directory for git activity checks (default: /project)
+# PROJECT_DIR=/project
+
+# Optional: Log level - DEBUG, INFO, WARNING, ERROR (default: INFO)
+# LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ docker compose build --build-arg TARGETARCH=arm64
 | `GT_AGENT_COUNT` | No | Crew worker count (default: 6) |
 | `MONITOR_INTERVAL` | No | Health check interval in seconds (default: 300) |
 | `ACTIVITY_DEADLINE` | No | Max seconds between commits (default: 3600) |
+| `DOLT_PORT` | No | Dolt SQL server port (default: 3307) |
+| `LOG_LEVEL` | No | Log level: DEBUG, INFO, WARNING, ERROR (default: INFO) |
 
 **Key separation:** Gastown and OpenClaw keys are completely separate pools. Keys are never shared unless you explicitly put the same key in both `GASTOWN_KIMI_KEYS` and `OPENCLAW_KIMI_KEY`.
 
@@ -92,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (483 tests)
+make test          # Unit tests only (485 tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary

Documentation update to fix inconsistencies:

- Update test count from 483 to 485 (current actual count)
- Add `DOLT_PORT` to README environment variables table
- Add `LOG_LEVEL` to README environment variables table
- Add `PROJECT_DIR` to .env.example (was missing)
- Add `LOG_LEVEL` to .env.example (was missing)

## Test plan

- [x] Verified all 485 tests still pass
- [x] No code changes, only documentation
- [x] Changes are consistent with actual config implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)