### PR TITLE
feat: add script to automate test count updates in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 483 unit tests — all mocked, no API keys needed
+tests/unit/             # 502 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 483 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 502 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 483 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 483 tests)
+- [ ] `make test` passes (all 502 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (485 tests)
+make test          # Unit tests only (502 tests)
 make test-all      # Include integration tests
 
 # Lint

--- a/scripts/update_test_counts.py
+++ b/scripts/update_test_counts.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Update test counts in documentation files.
+
+This script runs the test suite, counts the tests, and updates
+all references in documentation files (README.md, CLAUDE.md, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_FILES = ["README.md", "CLAUDE.md"]
+
+
+def count_tests(test_path: str = "tests/unit") -> int:
+    """Run pytest in collect-only mode and count tests.
+
+    Args:
+        test_path: Path to test directory or file.
+
+    Returns:
+        Number of tests found.
+
+    Raises:
+        subprocess.CalledProcessError: If pytest fails.
+    """
+    result = subprocess.run(
+        ["python", "-m", "pytest", test_path, "--collect-only"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Look for "collected X items" or "X items collected" in output
+    match = re.search(r"(\d+)\s+items?\s+collected|collected\s+(\d+)\s+items?", result.stdout)
+    if match:
+        # One of the groups will have the number
+        return int(match.group(1) or match.group(2))
+    raise RuntimeError(f"Could not parse test count from output: {result.stdout[:500]}")
+
+
+def update_file(filepath: Path, old_count: int, new_count: int) -> bool:
+    """Update test count references in a file.
+
+    Args:
+        filepath: Path to the file to update.
+        old_count: The old test count to replace.
+        new_count: The new test count.
+
+    Returns:
+        True if file was modified, False otherwise.
+    """
+    if not filepath.exists():
+        return False
+
+    content = filepath.read_text()
+    original = content
+
+    # Replace various formats of test count references
+    patterns = [
+        # "485 tests" -> "486 tests"
+        (rf"\b{old_count}\s+tests?\b", f"{new_count} tests"),
+        # "485 unit tests" -> "486 unit tests"
+        (rf"\b{old_count}\s+unit\s+tests?\b", f"{new_count} unit tests"),
+        # "from 484 to 485" -> "from 484 to 486" (for PR descriptions)
+        (rf"from\s+(\d+)\s+to\s+{old_count}\b", rf"from \1 to {new_count}"),
+        # "test count from 484 to 485" pattern
+        (rf"test count from {old_count} to {new_count}", f"test count from {old_count} to {new_count}"),
+    ]
+
+    for pattern, replacement in patterns:
+        content = re.sub(pattern, replacement, content, flags=re.IGNORECASE)
+
+    if content != original:
+        filepath.write_text(content)
+        return True
+    return False
+
+
+def main(args: list[str] | None = None) -> int:
+    """Main entry point.
+
+    Args:
+        args: Command line arguments.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    parser = argparse.ArgumentParser(
+        description="Update test counts in documentation files"
+    )
+    parser.add_argument(
+        "--test-path",
+        default="tests/unit",
+        help="Path to tests (default: tests/unit)",
+    )
+    parser.add_argument(
+        "--old-count",
+        type=int,
+        help="Old test count (auto-detected if not provided)",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help=f"Files to update (default: {' '.join(DEFAULT_FILES)})",
+    )
+    parsed = parser.parse_args(args)
+
+    files = parsed.files or DEFAULT_FILES
+
+    try:
+        new_count = count_tests(parsed.test_path)
+        print(f"Found {new_count} tests")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to count tests: {e}", file=sys.stderr)
+        print(f"stderr: {e.stderr}", file=sys.stderr)
+        return 1
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # Try to detect old count from first file
+    old_count = parsed.old_count
+    if old_count is None:
+        for filename in files:
+            filepath = Path(filename)
+            if filepath.exists():
+                content = filepath.read_text()
+                # Look for patterns like "485 tests" or "485 unit tests"
+                match = re.search(r"(\d+)\s+(?:unit\s+)?tests?\b", content, re.IGNORECASE)
+                if match:
+                    old_count = int(match.group(1))
+                    print(f"Detected old count: {old_count} (from {filename})")
+                    break
+
+        if old_count is None:
+            print("Could not detect old test count, using new_count - 1")
+            old_count = new_count - 1
+
+    if old_count == new_count:
+        print(f"Test count is already up to date ({new_count})")
+        return 0
+
+    updated = []
+    for filename in files:
+        filepath = Path(filename)
+        if update_file(filepath, old_count, new_count):
+            print(f"Updated {filename}: {old_count} -> {new_count}")
+            updated.append(filename)
+        else:
+            print(f"No changes needed in {filename}")
+
+    if updated:
+        print(f"\nUpdated test count in: {', '.join(updated)}")
+    else:
+        print("\nNo files were modified")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_update_test_counts.py
+++ b/tests/unit/test_update_test_counts.py
@@ -1,0 +1,222 @@
+"""Tests for scripts/update_test_counts.py."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.update_test_counts import count_tests, main, update_file
+
+
+class TestCountTests:
+    """Tests for count_tests function."""
+
+    def test_parses_collected_items_line(self):
+        """Test parsing the standard pytest collect output."""
+        mock_result = MagicMock()
+        mock_result.stdout = "\n".join([
+            "test_module.py::test_one",
+            "test_module.py::test_two",
+            "",
+            "========================== 2 items collected ==========================",
+        ])
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = count_tests("tests/unit")
+
+        assert result == 2
+        mock_run.assert_called_once_with(
+            ["python", "-m", "pytest", "tests/unit", "--collect-only"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def test_parses_alternative_format(self):
+        """Test parsing 'collected X items' format."""
+        mock_result = MagicMock()
+        mock_result.stdout = "collected 42 items\n\ntest_module.py::test_one"
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = count_tests("tests/")
+
+        assert result == 42
+
+    def test_raises_on_subprocess_failure(self):
+        """Test that subprocess errors are propagated."""
+        error = subprocess.CalledProcessError(1, "pytest")
+        error.stderr = "collection failed"
+
+        with patch("subprocess.run", side_effect=error):
+            with pytest.raises(subprocess.CalledProcessError):
+                count_tests()
+
+    def test_raises_when_pattern_not_found(self):
+        """Test error when test count cannot be parsed."""
+        mock_result = MagicMock()
+        mock_result.stdout = "some unexpected output"
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="Could not parse test count"):
+                count_tests()
+
+
+class TestUpdateFile:
+    """Tests for update_file function."""
+
+    def test_updates_test_count(self, tmp_path: Path):
+        """Test updating test count in a file."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("This project has 100 tests.")
+
+        result = update_file(test_file, 100, 150)
+
+        assert result is True
+        content = test_file.read_text()
+        assert "150 tests" in content
+        assert "100 tests" not in content
+
+    def test_updates_unit_tests_phrase(self, tmp_path: Path):
+        """Test updating 'unit tests' phrase."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("We have 200 unit tests in our suite.")
+
+        result = update_file(test_file, 200, 250)
+
+        assert result is True
+        assert "250 unit tests" in test_file.read_text()
+
+    def test_no_change_when_file_missing(self, tmp_path: Path):
+        """Test handling of missing file."""
+        missing_file = tmp_path / "nonexistent.md"
+
+        result = update_file(missing_file, 100, 150)
+
+        assert result is False
+
+    def test_no_change_when_count_not_found(self, tmp_path: Path):
+        """Test no modification when old count not present."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("This file has no test count.")
+
+        result = update_file(test_file, 100, 150)
+
+        assert result is False
+        assert test_file.read_text() == "This file has no test count."
+
+    def test_handles_multiple_occurrences(self, tmp_path: Path):
+        """Test updating multiple occurrences of same count."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("We have 50 tests. Out of 50 tests, all pass.")
+
+        result = update_file(test_file, 50, 75)
+
+        assert result is True
+        content = test_file.read_text()
+        assert content.count("75 tests") == 2
+        assert "50 tests" not in content
+
+
+class TestMain:
+    """Tests for main function."""
+
+    def test_exits_zero_on_success(self):
+        """Test successful execution returns 0."""
+        with patch("scripts.update_test_counts.count_tests", return_value=500):
+            with patch("scripts.update_test_counts.update_file", return_value=True):
+                with patch("pathlib.Path.exists", return_value=True):
+                    with patch("pathlib.Path.read_text", return_value="We have 485 tests"):
+                        result = main([])
+
+        assert result == 0
+
+    def test_exits_one_on_count_failure(self):
+        """Test exit code 1 when test counting fails."""
+        error = subprocess.CalledProcessError(1, "pytest")
+        error.stderr = "error"
+
+        with patch("scripts.update_test_counts.count_tests", side_effect=error):
+            result = main([])
+
+        assert result == 1
+
+    def test_skips_update_when_count_unchanged(self):
+        """Test no updates when test count hasn't changed."""
+        with patch("scripts.update_test_counts.count_tests", return_value=485):
+            with patch("pathlib.Path.exists", return_value=True):
+                with patch("pathlib.Path.read_text", return_value="We have 485 tests"):
+                    with patch("scripts.update_test_counts.update_file") as mock_update:
+                        result = main([])
+
+        assert result == 0
+        mock_update.assert_not_called()
+
+    def test_accepts_custom_test_path(self):
+        """Test --test-path argument is passed to count_tests."""
+        with patch("scripts.update_test_counts.count_tests") as mock_count:
+            mock_count.return_value = 100
+            with patch("pathlib.Path.exists", return_value=False):
+                main(["--test-path", "tests/integration"])
+
+        mock_count.assert_called_once_with("tests/integration")
+
+    def test_accepts_custom_files(self, tmp_path: Path):
+        """Test specifying custom files to update."""
+        custom_file = tmp_path / "custom.md"
+        custom_file.write_text("This project has 10 tests.")
+
+        with patch("scripts.update_test_counts.count_tests", return_value=20):
+            with patch("scripts.update_test_counts.DEFAULT_FILES", []):
+                result = main([str(custom_file)])
+
+        assert result == 0
+        assert "20 tests" in custom_file.read_text()
+
+    def test_uses_old_count_from_argument(self):
+        """Test --old-count argument bypasses auto-detection."""
+        test_file = Path("test.md")
+
+        with patch("scripts.update_test_counts.count_tests", return_value=200):
+            with patch("scripts.update_test_counts.update_file") as mock_update:
+                with patch("pathlib.Path.exists", return_value=True):
+                    with patch("pathlib.Path.read_text", return_value="We have 100 tests"):
+                        main(["--old-count", "150", "test.md"])
+
+        mock_update.assert_called_once()
+        args = mock_update.call_args
+        assert args[0][1] == 150  # old_count
+        assert args[0][2] == 200  # new_count
+
+
+class TestMainEdgeCases:
+    """Edge case tests for main function."""
+
+    def test_handles_no_files_found(self):
+        """Test behavior when no documentation files exist."""
+        with patch("scripts.update_test_counts.count_tests", return_value=100):
+            with patch("pathlib.Path.exists", return_value=False):
+                with patch("scripts.update_test_counts.update_file") as mock_update:
+                    result = main([])
+
+        assert result == 0
+        # update_file still gets called, but returns False for missing files
+        assert mock_update.call_count == len(["README.md", "CLAUDE.md"])
+
+    def test_falls_back_to_new_count_minus_one(self):
+        """Test fallback when old count cannot be detected."""
+        with patch("scripts.update_test_counts.count_tests", return_value=100):
+            with patch("pathlib.Path.exists", return_value=True):
+                with patch("pathlib.Path.read_text", return_value="No test count here"):
+                    with patch("scripts.update_test_counts.update_file") as mock_update:
+                        main([])
+
+        # Should fall back to new_count - 1 = 99
+        mock_update.assert_called()
+        args = mock_update.call_args
+        assert args[0][1] == 99  # old_count = 100 - 1


### PR DESCRIPTION
## Summary

Adds a utility script to automatically update test count references in documentation files when new tests are added.

## Changes

- **scripts/update_test_counts.py**: New script that:
  - Runs `pytest --collect-only` to count tests
  - Auto-detects old count from existing documentation
  - Updates multiple formats: "N tests", "N unit tests", etc.
  - Supports custom files via CLI arguments
  
- **tests/unit/test_update_test_counts.py**: Comprehensive test suite with 17 tests covering:
  - Test counting and parsing
  - File update operations
  - CLI argument handling
  - Edge cases

- **README.md & CLAUDE.md**: Updated test count from 485 to 502

## Test plan

- [x] All 502 unit tests pass
- [x] New script tested with `python scripts/update_test_counts.py`
- [x] Verified README.md is correctly updated
- [x] Verified CLAUDE.md is correctly updated

## Usage

```bash
# Update default files (README.md, CLAUDE.md)
python scripts/update_test_counts.py

# Update specific files
python scripts/update_test_counts.py docs/guide.md docs/faq.md

# Specify custom test path
python scripts/update_test_counts.py --test-path tests/integration
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)