### PR TITLE
fix: handle FileNotFoundError in run_command

### DIFF
--- a/src/gasclaw/maintenance.py
+++ b/src/gasclaw/maintenance.py
@@ -38,8 +38,26 @@ def run_command(
 
     Returns:
         CompletedProcess with returncode, stdout, stderr.
+
+    Raises:
+        subprocess.CalledProcessError: If check=True and command fails or binary not found.
+        subprocess.TimeoutExpired: If command times out.
     """
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        # Handle missing binary gracefully
+        binary = cmd[0] if cmd else "unknown"
+        result = subprocess.CompletedProcess(
+            args=cmd,
+            returncode=-1,
+            stdout="",
+            stderr=f"Command not found: {binary}",
+        )
+        if check:
+            raise subprocess.CalledProcessError(
+                result.returncode, cmd, result.stdout, result.stderr
+            ) from None
     if check and result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
     return result

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -40,6 +40,19 @@ class TestRunCommand:
         with pytest.raises(subprocess.TimeoutExpired):
             run_command(["sleep", "10"], timeout=1)
 
+    def test_handles_file_not_found(self):
+        """FileNotFoundError is converted to CalledProcessError when check=True."""
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            run_command(["nonexistent_binary_xyz"], check=True)
+        assert exc_info.value.returncode == -1
+        assert "not found" in exc_info.value.stderr.lower()
+
+    def test_returns_result_on_file_not_found_when_check_false(self):
+        """FileNotFoundError returns result with returncode -1 when check=False."""
+        result = run_command(["nonexistent_binary_xyz"], check=False)
+        assert result.returncode == -1
+        assert "not found" in result.stderr.lower()
+
 
 class TestGetOpenPRs:
     @patch("gasclaw.maintenance.run_command")


### PR DESCRIPTION
## Summary

Add graceful handling for `FileNotFoundError` in the `run_command` function in `maintenance.py`. This prevents unhandled exceptions when `git` or `gh` binaries are not installed.

## Changes

- `run_command` now catches `FileNotFoundError` and returns a `CompletedProcess` with:
  - `returncode=-1` to indicate the binary was not found
  - `stderr` containing a descriptive error message
- When `check=True`, raises `CalledProcessError` with the same information
- Added comprehensive tests for both `check=True` and `check=False` cases

## Test Plan

- [x] All 504 unit tests pass
- [x] Ruff linting passes
- [x] New tests cover the FileNotFoundError handling paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)