### PR TITLE
fix: correctly count keys with no balance as invalid

### DIFF
--- a/src/gasclaw/kimigas/credit_checker.py
+++ b/src/gasclaw/kimigas/credit_checker.py
@@ -144,7 +144,7 @@ class CreditChecker:
         results = self.check_keys(api_keys)
 
         valid_keys = [r for r in results if r.valid and r.balance is not None]
-        invalid_keys = [r for r in results if not r.valid]
+        invalid_keys = [r for r in results if r not in valid_keys]
 
         total_balance = sum(r.balance for r in valid_keys if r.balance)
         total_usage = sum(r.total_used for r in valid_keys if r.total_used)

--- a/tests/unit/test_kimi_credit_checker.py
+++ b/tests/unit/test_kimi_credit_checker.py
@@ -278,6 +278,41 @@ class TestCheckKeyGenericException:
         assert "Unexpected error" in result.error
 
 
+class TestPoolSummaryEdgeCases:
+    """Tests for pool summary edge cases."""
+
+    @respx.mock
+    def test_valid_key_with_none_balance_counts_as_invalid(self):
+        """Keys with valid=True but balance=None should be counted as invalid.
+
+        This tests the fix for a bug where keys with no balance data were
+        not being properly counted in either valid or invalid categories.
+        """
+        route = respx.get("https://api.kimi.com/v1/users/me/balance")
+        route.side_effect = [
+            # First key: valid with balance
+            httpx.Response(
+                200,
+                json={"data": {"available_balance": 100.0, "total_usage": 50.0}},
+            ),
+            # Second key: valid response but no balance data (None)
+            httpx.Response(
+                200,
+                json={"data": {"available_balance": None, "total_usage": None}},
+            ),
+            # Third key: explicitly invalid (401)
+            httpx.Response(401, json={"error": "Unauthorized"}),
+        ]
+
+        checker = CreditChecker()
+        summary = checker.get_pool_summary(["sk-valid", "sk-no-balance", "sk-invalid"])
+
+        assert summary["total_keys"] == 3
+        assert summary["valid_keys"] == 1  # Only sk-valid
+        assert summary["invalid_keys"] == 2  # sk-no-balance AND sk-invalid
+        assert summary["total_balance"] == 100.0
+
+
 class TestParseAmountEdgeCases:
     """Tests for _parse_amount edge cases (lines 178-179)."""
 


### PR DESCRIPTION
## Summary

Fixed a bug in `credit_checker.py` where keys that are valid but have no balance data were not being properly counted in the pool summary.

## Changes

- Fixed `get_pool_summary()` to correctly categorize keys with `valid=True` but `balance=None` as invalid
- Added test case to verify the edge case

## Test plan

- [x] `make test` passes (505 tests)
- [x] `make lint` passes
- [x] New test covers the edge case

🤖 Generated with [Claude Code](https://claude.com/claude-code)