### PR TITLE
refactor: optimize invalid_keys filter

### DIFF
--- a/src/gasclaw/kimigas/credit_checker.py
+++ b/src/gasclaw/kimigas/credit_checker.py
@@ -144,7 +144,7 @@ class CreditChecker:
         results = self.check_keys(api_keys)
 
         valid_keys = [r for r in results if r.valid and r.balance is not None]
-        invalid_keys = [r for r in results if r not in valid_keys]
+        invalid_keys = [r for r in results if not r.valid or r.balance is None]
 
         total_balance = sum(r.balance for r in valid_keys if r.balance)
         total_usage = sum(r.total_used for r in valid_keys if r.total_used)


### PR DESCRIPTION
## Summary

Optimization for the `invalid_keys` filter in `credit_checker.py` based on code review feedback.

## Changes

- Replace O(N*M) membership test (`r not in valid_keys`) with O(N) explicit condition
- New logic `not r.valid or r.balance is None` is clearer about intent
- A key is invalid if explicitly invalid OR has no balance data

## Rationale

The original fix used `r not in valid_keys` which performs a linear search through `valid_keys` for each result, resulting in O(N*M) complexity. The new explicit condition:
1. Is O(N) - single pass through results
2. Is more readable - directly expresses the invalidity criteria
3. Is consistent with the valid_keys condition

## Test plan

- [x] `make test` passes (505 tests)
- [x] `make lint` passes
- [x] Edge case test for valid key with None balance still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)