### PR TITLE
docs: fix bootstrap sequence numbering in docstring

### DIFF
--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -1,19 +1,18 @@
 """Startup orchestration for gasclaw.
 
 Bootstrap sequence:
- 1. Load config from env vars (already done by caller)
- 2. Setup Kimi accounts
- 3. Write agent config
- 4. Install Gastown
- 5. Start Dolt
- 6. Configure OpenClaw
- 7. Install skills
- 8. Run openclaw doctor
- 9. Start OpenClaw gateway
-10. Start gt daemon
-11. Start Mayor
-12. Send "Gasclaw is up" via Telegram
-13. Enter health monitor loop (foreground)
+ 1. Setup Kimi accounts
+ 2. Write agent config
+ 3. Install Gastown
+ 4. Start Dolt
+ 5. Configure OpenClaw
+ 6. Install skills
+ 7. Run openclaw doctor
+ 8. Start OpenClaw gateway
+ 9. Start gt daemon
+10. Start Mayor
+11. Send "Gasclaw is up" via Telegram
+12. Enter health monitor loop (foreground)
 
 Rollback on failure:
 - If bootstrap fails at any step, previously started services are stopped


### PR DESCRIPTION
## Summary
Fixed the bootstrap sequence numbering in the module docstring to match the actual implementation.

### Problem
- Docstring listed 13 steps with step 1 as \"Load config from env vars\"
- Config loading is actually done by the caller before `bootstrap()` is called
- The code comments showed 12 steps (1-12), causing a mismatch

### Fix
- Updated docstring to show the correct 12-step sequence
- Step numbers now match the implementation comments

## Test plan
- [x] All 507 unit tests pass
- [x] No functional changes - documentation only
- [x] Verified step numbers match code comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)