### PR TITLE
fix: remove duplicate PROJECT_DIR entry from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,5 @@ TELEGRAM_OWNER_ID=123456789
 # Optional: Dolt SQL server port (default: 3307)
 # DOLT_PORT=3307
 
-# Optional: Directory for git activity checks (default: /project)
-# PROJECT_DIR=/project
-
 # Optional: Log level - DEBUG, INFO, WARNING, ERROR (default: INFO)
 # LOG_LEVEL=INFO


### PR DESCRIPTION
## Summary

Removes a duplicate `PROJECT_DIR` environment variable entry from `.env.example`.

## Details

The `PROJECT_DIR` variable was documented twice in the file:
- First occurrence: lines 19-20
- Second occurrence: lines 31-32

This removes the second (duplicate) occurrence to avoid confusion.

## Test Plan

- [x] Verified `.env.example` has no duplicate entries
- [x] No code changes - documentation fix only