### PR TITLE
test: add edge case tests for update_test_counts.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ All 507 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 507 tests)
+- [ ] `make test` passes (all 510 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (507 tests)
+make test          # Unit tests only (510 tests)
 make test-all      # Include integration tests
 
 # Lint

--- a/tests/unit/test_update_test_counts.py
+++ b/tests/unit/test_update_test_counts.py
@@ -128,6 +128,38 @@ class TestUpdateFile:
         assert content.count("75 tests") == 2
         assert "50 tests" not in content
 
+    def test_handles_case_insensitive_replacement(self, tmp_path: Path):
+        """Test updating 'Tests' with capital T."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("This project has 100 Tests in total.")
+
+        result = update_file(test_file, 100, 150)
+
+        assert result is True
+        assert "150 tests" in test_file.read_text()
+        assert "100 Tests" not in test_file.read_text()
+
+    def test_handles_singular_test(self, tmp_path: Path):
+        """Test updating singular 'test' count."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("Only 1 test exists.")
+
+        result = update_file(test_file, 1, 2)
+
+        assert result is True
+        assert "2 tests" in test_file.read_text()
+
+    def test_handles_from_to_pattern(self, tmp_path: Path):
+        """Test updating 'from X to Y' pattern for PR descriptions."""
+        test_file = tmp_path / "test.md"
+        test_file.write_text("Update test count from 100 to 200")
+
+        result = update_file(test_file, 200, 250)
+
+        assert result is True
+        content = test_file.read_text()
+        assert "from 100 to 250" in content
+
 
 class TestMain:
     """Tests for main function."""


### PR DESCRIPTION
## Summary

Add edge case tests for `update_test_counts.py` to improve test coverage for the documentation update script.

## Changes

- Add test for case insensitive replacement ("Tests" vs "tests")
- Add test for singular "test" count handling
- Add test for "from X to Y" pattern used in PR descriptions
- Update test count from 507 to 510 in CLAUDE.md and README.md

## Test Plan

- [x] All 510 unit tests pass
- [x] New tests verify edge cases in regex replacement patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)