### PR TITLE
docs: update test count from 507 to 510 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 507 unit tests — all mocked, no API keys needed
+tests/unit/             # 510 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 507 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 510 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 


### PR DESCRIPTION
## Summary

Updates the test count in CLAUDE.md from 507 to 510 to reflect the current number of unit tests.

## Test plan

- [x] Verified actual test count with \`python -m pytest tests/unit\` (510 tests)
- [x] No code changes, documentation only
- [x] All 510 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)