### PR TITLE
fix: reject inf/nan values in credit amount parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 510 unit tests — all mocked, no API keys needed
+tests/unit/             # 513 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 510 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 513 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 510 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 510 tests)
+- [ ] `make test` passes (all 513 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (510 tests)
+make test          # Unit tests only (513 tests)
 make test-all      # Include integration tests
 
 # Lint

--- a/src/gasclaw/kimigas/credit_checker.py
+++ b/src/gasclaw/kimigas/credit_checker.py
@@ -174,7 +174,11 @@ def _parse_amount(amount: Any) -> float | None:
     if amount is None:
         return None
     try:
-        return round(float(amount), 2)
+        result = float(amount)
+        # Reject inf and nan as they're not valid amounts
+        if result == float("inf") or result == float("-inf") or result != result:  # nan != nan
+            return None
+        return round(result, 2)
     except (ValueError, TypeError):
         return None
 

--- a/tests/unit/test_kimi_credit_checker.py
+++ b/tests/unit/test_kimi_credit_checker.py
@@ -334,3 +334,57 @@ class TestParseAmountEdgeCases:
         assert result.balance is None
         assert result.total_used is None
         assert result.valid is True
+
+    @respx.mock
+    def test_parse_amount_inf_returns_none(self):
+        """_parse_amount handles inf values by returning None."""
+        respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"available_balance": "inf", "total_usage": "Infinity"}},
+            )
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test")
+
+        # inf values should be rejected as invalid amounts
+        assert result.balance is None
+        assert result.total_used is None
+        assert result.valid is True
+
+    @respx.mock
+    def test_parse_amount_negative_inf_returns_none(self):
+        """_parse_amount handles -inf values by returning None."""
+        respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"available_balance": "-inf", "total_usage": 0}},
+            )
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test")
+
+        # -inf values should be rejected as invalid amounts
+        assert result.balance is None
+        assert result.total_used == 0.0
+        assert result.valid is True
+
+    @respx.mock
+    def test_parse_amount_nan_returns_none(self):
+        """_parse_amount handles nan values by returning None."""
+        respx.get("https://api.kimi.com/v1/users/me/balance").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"available_balance": "nan", "total_usage": "NaN"}},
+            )
+        )
+
+        checker = CreditChecker()
+        result = checker.check_key("sk-test")
+
+        # nan values should be rejected as invalid amounts
+        assert result.balance is None
+        assert result.total_used is None
+        assert result.valid is True


### PR DESCRIPTION
## Summary

Reject inf, -inf, and nan values in credit amount parsing that could be returned by malformed API responses. These special float values are not valid credit amounts and could cause issues in downstream calculations or JSON serialization.

## Changes

- Add validation to return None for inf/-inf/nan values in `_parse_amount()`
- Add 3 new tests covering these edge cases
- Update test count from 510 to 513 in documentation

## Test plan

- [x] All 513 unit tests pass
- [x] 100% coverage maintained
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)