### PR TITLE
refactor: use math.isinf() and math.isnan() for clarity

### DIFF
--- a/src/gasclaw/kimigas/credit_checker.py
+++ b/src/gasclaw/kimigas/credit_checker.py
@@ -6,6 +6,7 @@ Queries Kimi API billing endpoints to check credit balance and usage per API key
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -176,7 +177,7 @@ def _parse_amount(amount: Any) -> float | None:
     try:
         result = float(amount)
         # Reject inf and nan as they're not valid amounts
-        if result == float("inf") or result == float("-inf") or result != result:  # nan != nan
+        if math.isinf(result) or math.isnan(result):
             return None
         return round(result, 2)
     except (ValueError, TypeError):


### PR DESCRIPTION
## Summary

Use `math.isinf()` and `math.isnan()` instead of manual checks for better code clarity and explicitness.

## Changes

- Import `math` module
- Replace `result == float("inf") or result == float("-inf")` with `math.isinf(result)`
- Replace `result != result` (NaN check) with `math.isnan(result)`

## Test plan

- [x] All 513 unit tests pass
- [x] No functional changes - existing tests cover inf/nan handling
- [x] 100% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)