### PR TITLE
docs: update test count from 513 to 561

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 513 unit tests — all mocked, no API keys needed
+tests/unit/             # 561 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 513 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 561 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 


### PR DESCRIPTION
## Summary

Update CLAUDE.md test count references from 513 to 561 to reflect
the current state of the test suite.

## Test Count History

- 513: Original baseline
- 558: After previous PRs
- 561: After adding config validation and debug logging tests

🤖 Generated with Claude Code