### PR TITLE
test: add coverage for _parse_port exception handler

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -500,6 +500,28 @@ class TestParsePositiveIntEdgeCases:
         result = _parse_positive_int("invalid", default=99, name="")
         assert result == 99
 
+    def test_parse_port_non_integer_defaults(self, monkeypatch, caplog):
+        """Non-integer string for DOLT_PORT triggers exception handler and uses default."""
+        from gasclaw.config import _parse_port
+
+        with caplog.at_level(logging.WARNING):
+            result = _parse_port("not_a_number", default=3307, name="DOLT_PORT")
+
+        assert result == 3307
+        assert "DOLT_PORT" in caplog.text
+        assert "not a valid integer" in caplog.text.lower()
+
+    def test_parse_port_float_string_defaults(self, monkeypatch, caplog):
+        """Float string for DOLT_PORT triggers exception handler and uses default."""
+        from gasclaw.config import _parse_port
+
+        with caplog.at_level(logging.WARNING):
+            result = _parse_port("3.14", default=3307, name="DOLT_PORT")
+
+        assert result == 3307
+        assert "DOLT_PORT" in caplog.text
+        assert "not a valid integer" in caplog.text.lower()
+
     def test_valid_value_with_name(self):
         """Valid value returns correctly even with name provided."""
         from gasclaw.config import _parse_positive_int


### PR DESCRIPTION
## Summary

Adds two new tests to cover the `ValueError/TypeError` exception handler in the `_parse_port` function (lines 138-143 of config.py).

## Changes

- `test_parse_port_non_integer_defaults`: Tests non-integer string values
- `test_parse_port_float_string_defaults`: Tests float string values

## Coverage Impact

Brings `config.py` to 100% coverage (up from 94%). Total tests: 563.

## Test Plan

- [x] `python -m pytest tests/unit -v` passes (563 tests)
- [x] Coverage for `config.py` is now 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)