### PR TITLE
fix: lint line length and update test count in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 561 unit tests — all mocked, no API keys needed
+tests/unit/             # 563 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -98,7 +98,7 @@ All 561 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 513 tests)
+- [ ] `make test` passes (all 563 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -588,7 +588,9 @@ class TestConfigValidationNew:
         ("100000", 3307),
         ("-1", 3307),
     ])
-    def test_dolt_port_out_of_range_defaults(self, monkeypatch, caplog, invalid_port, expected_default):
+    def test_dolt_port_out_of_range_defaults(
+        self, monkeypatch, caplog, invalid_port, expected_default
+    ):
         """DOLT_PORT outside 1-65535 range logs warning and uses default."""
         monkeypatch.setenv("GASTOWN_KIMI_KEYS", "sk-key1")
         monkeypatch.setenv("OPENCLAW_KIMI_KEY", "sk-key2")


### PR DESCRIPTION
## Summary

Fixes E501 lint error and updates test count documentation.

## Changes

- Fix E501 line too long in `test_config.py` (line 591)
- Update test count from 561 to 563 in project structure docs
- Update PR checklist test count from 513 to 563

## Test Plan

- [x] `python -m ruff check src tests` passes
- [x] `python -m pytest tests/unit -v` passes (563 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)