### PR TITLE
test: add coverage for RuntimeError handling in update_test_counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 567 unit tests — all mocked, no API keys needed
+tests/unit/             # 568 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 567 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 568 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 567 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 567 tests)
+- [ ] `make test` passes (all 568 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/tests/unit/test_update_test_counts.py
+++ b/tests/unit/test_update_test_counts.py
@@ -186,6 +186,16 @@ class TestMain:
 
         assert result == 1
 
+    def test_exits_one_on_runtime_error(self):
+        """Test exit code 1 when RuntimeError occurs during test counting."""
+        with patch(
+            "scripts.update_test_counts.count_tests",
+            side_effect=RuntimeError("Could not parse test count"),
+        ):
+            result = main([])
+
+        assert result == 1
+
     def test_skips_update_when_count_unchanged(self):
         """Test no updates when test count hasn't changed."""
         with (


### PR DESCRIPTION
## Summary

Add test coverage for RuntimeError handling in scripts/update_test_counts.py.

## Changes

- Add test for main() exit code 1 when RuntimeError occurs during test counting
- Covers lines 122-124 in update_test_counts.py
- Update CLAUDE.md test count: 567 → 568

## Coverage Improvement

| File | Before | After |
|------|--------|-------|
| update_test_counts.py | 94% | 97% |

## Test Plan

- [x] All 568 unit tests pass
- [x] New test covers RuntimeError handling in main()

🤖 Generated with [Claude Code](https://claude.com/claude-code)