### PR TITLE
refactor: use lazy logging format for better performance

### DIFF
--- a/src/gasclaw/gastown/gt_feed.py
+++ b/src/gasclaw/gastown/gt_feed.py
@@ -60,9 +60,9 @@ class GastownFeed:
             )
             if result.returncode == 0:
                 return result.stdout
-            logger.warning(f"gt command failed: {' '.join(args)} - {result.stderr}")
+            logger.warning("gt command failed: %s - %s", " ".join(args), result.stderr)
         except (OSError, subprocess.TimeoutExpired) as e:
-            logger.warning(f"Failed to run gt command: {e}")
+            logger.warning("Failed to run gt command: %s", e)
         return None
 
     def get_agent_status(self) -> list[dict[str, Any]]:
@@ -110,7 +110,7 @@ class GastownFeed:
                             )
                 return events
         except (OSError, subprocess.TimeoutExpired) as e:
-            logger.warning(f"Failed to get git log: {e}")
+            logger.warning("Failed to get git log: %s", e)
         return []
 
     def get_recent_prs(self, limit: int = 5) -> list[ActivityEvent]:
@@ -149,7 +149,7 @@ class GastownFeed:
                             )
                 return events
         except (OSError, subprocess.TimeoutExpired) as e:
-            logger.warning(f"Failed to get merge commits: {e}")
+            logger.warning("Failed to get merge commits: %s", e)
         return []
 
     def get_feed(self, limit: int = 10) -> list[ActivityEvent]:

--- a/src/gasclaw/kimigas/credit_checker.py
+++ b/src/gasclaw/kimigas/credit_checker.py
@@ -101,21 +101,21 @@ class CreditChecker:
                 )
 
         except httpx.HTTPStatusError as e:
-            logger.warning(f"HTTP error checking key {masked}: {e.response.status_code}")
+            logger.warning("HTTP error checking key %s: %s", masked, e.response.status_code)
             return CreditInfo(
                 key=masked,
                 valid=False,
                 error=f"HTTP {e.response.status_code}",
             )
         except httpx.RequestError as e:
-            logger.warning(f"Request error checking key {masked}: {e}")
+            logger.warning("Request error checking key %s: %s", masked, e)
             return CreditInfo(
                 key=masked,
                 valid=False,
                 error=f"Request failed: {e}",
             )
         except Exception as e:
-            logger.warning(f"Error checking key {masked}: {e}")
+            logger.warning("Error checking key %s: %s", masked, e)
             return CreditInfo(
                 key=masked,
                 valid=False,


### PR DESCRIPTION
## Summary
Convert f-string logging to lazy format (%s placeholders) for better performance.

## Changes
- gt_feed.py: 4 warning logs
- credit_checker.py: 3 warning logs

## Why
Lazy logging avoids string formatting when the log level is not enabled, providing a small performance improvement especially for frequently executed code paths.

## Test Plan
- [x] All 578 unit tests pass
- [x] No functional changes
- [x] Code quality improvement only

🤖 Generated with [Claude Code](https://claude.com/claude-code)