### PR TITLE
fix: use Python 3.13 in docs workflow for consistency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
Update the docs GitHub workflow to use Python 3.13 instead of 3.12.

## Changes
- .github/workflows/docs.yml: Update python-version from 3.12 to 3.13

## Why
The project requires Python >=3.13 (as specified in pyproject.toml).
Using the same version in all workflows ensures consistency.

## Test Plan
- [x] Workflow syntax validated
- [x] Python 3.13 is the project minimum version

🤖 Generated with [Claude Code](https://claude.com/claude-code)