### PR TITLE
fix: improve dry run summary to show keys status

### DIFF
--- a/src/gasclaw/migration.py
+++ b/src/gasclaw/migration.py
@@ -49,6 +49,8 @@ class MigrationResult:
                 lines.append(f"   Backup created: {self.backup_path}")
             if self.migrated_keys:
                 lines.append(f"   Migrated keys: {', '.join(self.migrated_keys)}")
+            elif self.dry_run:
+                lines.append("   Migrated keys: (will be determined during actual migration)")
             if self.env_file_path:
                 lines.append(f"   Config file: {self.env_file_path}")
         else:

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -607,3 +607,18 @@ class TestMigrationResult:
         summary = result.summary()
 
         assert "DRY RUN" in summary
+        assert "KIMI_API_KEY" in summary
+
+    def test_summary_shows_dry_run_no_keys(self):
+        """Summary shows dry run message when migrated_keys is empty."""
+        result = MigrationResult(
+            success=True,
+            dry_run=True,
+            gastown_detected=True,
+            migrated_keys=[],
+        )
+
+        summary = result.summary()
+
+        assert "DRY RUN" in summary
+        assert "will be determined during actual migration" in summary


### PR DESCRIPTION
## Summary

Improves the `MigrationResult.summary()` method to show migrated keys during dry run mode. When keys are empty in dry run, it shows a helpful message indicating they will be determined during the actual migration.

## Changes

- Added elif branch in `summary()` to show placeholder when `dry_run=True` and `migrated_keys` is empty
- Updated existing test to verify keys are shown in dry run
- Added new test for empty keys case

## Test Plan

- [x] `make test` passes (579 tests)
- [x] New test covers dry run with empty keys case
- [x] Updated test verifies keys shown in dry run

🤖 Generated with [Claude Code](https://claude.com/claude-code)