### PR TITLE
docs: fix test count in README.md (578 → 582)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (578 tests)
+make test          # Unit tests only (582 tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary
Update unit test count in README.md from 578 to 582 to reflect current test suite.

## Changes
- Updated test count in README.md

## Test plan
- [x] Verified `make test` runs 582 tests