### PR TITLE
docs: fix test count in CLAUDE.md (568 → 582)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 568 unit tests — all mocked, no API keys needed
+tests/unit/             # 582 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 568 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 582 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 568 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 568 tests)
+- [ ] `make test` passes (all 582 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format


### PR DESCRIPTION
## Summary
Update unit test count in CLAUDE.md from 568 to 582 to reflect current test suite.

## Changes
- Updated test count in 3 places in CLAUDE.md

## Test plan
- [x] Verified `make test` runs 582 tests