### PR TITLE
docs: fix test count (582 → 585)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ All 582 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 582 tests)
+- [ ] `make test` passes (all 585 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (582 tests)
+make test          # Unit tests only (585 tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary

Update test count documentation to reflect current test suite size (585 tests).

## Changes

- README.md: 582 → 585
- CLAUDE.md: 582 → 585

## Test plan

- [x] `python -m pytest tests/unit` passes (585 tests)
- [x] `ruff check src tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)