### PR TITLE
feat: add key validation and clear_cooldown to KeyPool

### DIFF
--- a/src/gasclaw/kimigas/key_pool.py
+++ b/src/gasclaw/kimigas/key_pool.py
@@ -105,12 +105,49 @@ class KeyPool:
         self._save_state(state)
 
     def mark_rate_limited(self, key: str) -> None:
-        """Mark a key as rate-limited (enters cooldown)."""
+        """Mark a key as rate-limited (enters cooldown).
+
+        Args:
+            key: The API key to mark as rate-limited.
+
+        Raises:
+            ValueError: If the key does not belong to this pool.
+        """
+        if key not in self._keys:
+            raise ValueError("Key does not belong to this pool")
+
         state = self._load_state()
         rate_limited = state.get("rate_limited", {})
         rate_limited[self._key_hash(key)] = time.time()
         state["rate_limited"] = rate_limited
         self._save_state(state)
+
+    def clear_cooldown(self, key: str) -> bool:
+        """Clear rate-limited status for a key.
+
+        Args:
+            key: The API key to clear cooldown for.
+
+        Returns:
+            True if the key was rate-limited and is now cleared,
+            False if the key was not rate-limited.
+
+        Raises:
+            ValueError: If the key does not belong to this pool.
+        """
+        if key not in self._keys:
+            raise ValueError("Key does not belong to this pool")
+
+        state = self._load_state()
+        rate_limited = state.get("rate_limited", {})
+        key_hash = self._key_hash(key)
+
+        if key_hash in rate_limited:
+            del rate_limited[key_hash]
+            state["rate_limited"] = rate_limited
+            self._save_state(state)
+            return True
+        return False
 
     def status(self) -> dict[str, Any]:
         """Return pool status report."""

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -265,12 +265,40 @@ class TestKeyPoolEdgeCases:
         assert pool1._key_hash("k1") == pool2._key_hash("k1")
 
     def test_mark_nonexistent_key_rate_limited(self, tmp_path):
-        """Marking a key not in pool as rate-limited is handled gracefully."""
+        """Marking a key not in pool raises ValueError."""
         pool = KeyPool(["k1"], state_dir=tmp_path)
-        # This should not raise an error
-        pool.mark_rate_limited("nonexistent-key")
-        # k1 should still be available
+        with pytest.raises(ValueError, match="Key does not belong"):
+            pool.mark_rate_limited("nonexistent-key")
+
+    def test_clear_cooldown_removes_rate_limit(self, tmp_path):
+        """clear_cooldown removes rate-limited status and returns True."""
+        pool = KeyPool(["k1", "k2"], state_dir=tmp_path)
+        pool.mark_rate_limited("k1")
+
+        # k1 is rate-limited, so k2 is selected
+        assert pool.get_key() == "k2"
+
+        # Clear cooldown for k1
+        result = pool.clear_cooldown("k1")
+        assert result is True
+
+        # k1 is now available again (it's LRU)
         assert pool.get_key() == "k1"
+
+    def test_clear_cooldown_returns_false_if_not_rate_limited(self, tmp_path):
+        """clear_cooldown returns False if key was not rate-limited."""
+        pool = KeyPool(["k1", "k2"], state_dir=tmp_path)
+
+        # k1 was never rate-limited
+        result = pool.clear_cooldown("k1")
+        assert result is False
+
+    def test_clear_cooldown_raises_for_invalid_key(self, tmp_path):
+        """clear_cooldown raises ValueError for key not in pool."""
+        pool = KeyPool(["k1"], state_dir=tmp_path)
+
+        with pytest.raises(ValueError, match="Key does not belong"):
+            pool.clear_cooldown("nonexistent-key")
 
     def test_state_file_is_json(self, tmp_path):
         """State file contains valid JSON with expected structure."""


### PR DESCRIPTION
## Summary
Improves KeyPool API with validation and manual cooldown management.

## Changes
- **mark_rate_limited()** now validates that the key belongs to the pool and raises `ValueError` if not
- **clear_cooldown(key)** method added to manually clear rate-limited status for a key
- Updated tests to match new behavior and cover new functionality

## Test plan
- [x] All 588 tests pass
- [x] Lint passes
- [x] New tests added for clear_cooldown and validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)