### PR TITLE
docs: fix test count (585/582 → 588)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 582 unit tests — all mocked, no API keys needed
+tests/unit/             # 588 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 582 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 588 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 582 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 585 tests)
+- [ ] `make test` passes (all 588 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (585 tests)
+make test          # Unit tests only (588 tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary
Update test count references to match actual count after PR #201.

## Changes
- README.md: 585 → 588
- CLAUDE.md: 582/585 → 588 (3 locations)

## Test plan
- [x] Verified test count: 588 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)