### PR TITLE
style: fix ruff formatting in 4 test files

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -211,6 +211,7 @@ class TestStatusCommand:
             "gasclaw.cli.check_agent_activity",
             lambda **kw: {"compliant": True, "last_commit_age": 300},
         )
+
         def mock_status():
             return {"total": 2, "available": 2, "rate_limited": 0}
 
@@ -375,6 +376,7 @@ class TestCLIEdgeCases:
             "gasclaw.cli.check_agent_activity",
             lambda **kw: {"compliant": True, "last_commit_age": 300},
         )
+
         def mock_status_rl():
             return {"total": 5, "available": 3, "rate_limited": 2}
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -625,12 +625,15 @@ class TestConfigValidationNew:
         with pytest.raises(ValueError, match="must start with 'sk-'"):
             load_config()
 
-    @pytest.mark.parametrize("invalid_port,expected_default", [
-        ("0", 3307),
-        ("65536", 3307),
-        ("100000", 3307),
-        ("-1", 3307),
-    ])
+    @pytest.mark.parametrize(
+        "invalid_port,expected_default",
+        [
+            ("0", 3307),
+            ("65536", 3307),
+            ("100000", 3307),
+            ("-1", 3307),
+        ],
+    )
     def test_dolt_port_out_of_range_defaults(
         self, monkeypatch, caplog, invalid_port, expected_default
     ):

--- a/tests/unit/test_gt_feed.py
+++ b/tests/unit/test_gt_feed.py
@@ -333,8 +333,7 @@ class TestGastownFeed:
                 returncode = 0
                 # First line malformed (only 2 parts), second valid
                 stdout = (
-                    "hash1|timestamp1\n"
-                    "abc123|2026-03-02 10:00:00 +0000|Test User|Merge PR #123"
+                    "hash1|timestamp1\nabc123|2026-03-02 10:00:00 +0000|Test User|Merge PR #123"
                 )
                 stderr = ""
 

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -130,7 +130,6 @@ class TestMigrateConfig:
         assert result["gastown_kimi_keys"] == "sk-migrate-key"
         assert "KIMI_API_KEY" in result["migrated_keys"]
 
-
     def test_migrates_multiple_keys(self, tmp_path, monkeypatch):
         """Handles multiple keys in KIMI_API_KEY."""
         monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
@@ -544,8 +543,10 @@ class TestMigrate:
         env_file = tmp_path / ".env"
 
         # Mock detection to return non-existent config_dir
-        with patch("gasclaw.migration.detect_gastown_setup") as m_detect, \
-             patch("gasclaw.migration.migrate_config") as m_migrate:
+        with (
+            patch("gasclaw.migration.detect_gastown_setup") as m_detect,
+            patch("gasclaw.migration.migrate_config") as m_migrate,
+        ):
             m_detect.return_value = {
                 "detected": True,
                 "source": "config_file",


### PR DESCRIPTION
## Summary
Apply ruff format to 4 test files that had formatting issues.

## Files Changed
- tests/unit/test_cli.py
- tests/unit/test_config.py  
- tests/unit/test_gt_feed.py
- tests/unit/test_migration.py

## Test Plan
- [x] All 588 unit tests pass
- [x] Ruff formatting check passes
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)