### PR TITLE
fix: use stdout when stderr is empty on update failure

### DIFF
--- a/src/gasclaw/updater/applier.py
+++ b/src/gasclaw/updater/applier.py
@@ -32,7 +32,11 @@ def apply_updates() -> dict[str, str]:
                 results[name] = "updated"
                 logger.info("%s updated successfully", name)
             else:
-                stderr = result.stderr.decode().strip()[:200]
+                stderr = result.stderr.decode().strip()
+                # Some commands write errors to stdout; fallback if stderr is empty
+                if not stderr:
+                    stderr = result.stdout.decode().strip()
+                stderr = stderr[:200]
                 results[name] = f"failed: {stderr}"
                 logger.error("%s update failed: %s", name, stderr)
         except (OSError, subprocess.TimeoutExpired) as e:

--- a/tests/unit/test_updater_applier.py
+++ b/tests/unit/test_updater_applier.py
@@ -75,3 +75,17 @@ class TestApplyUpdates:
                 # The error portion after "failed: " should be truncated
                 error_part = v.split("failed: ", 1)[1]
                 assert len(error_part) <= 200
+
+    def test_uses_stdout_when_stderr_empty(self, monkeypatch):
+        """When stderr is empty, stdout is used for error message."""
+        stdout_error = b"error message in stdout"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                a[0], 1, stdout=stdout_error, stderr=b""
+            ),
+        )
+        results = apply_updates()
+        # Check that stdout error is captured when stderr is empty
+        assert any("error message in stdout" in v for v in results.values())


### PR DESCRIPTION
## Summary

Some update commands write error messages to stdout instead of stderr. When a command fails with non-zero exit code but empty stderr, the error message showed nothing useful.

## Changes

- Modified `updater/applier.py` to fall back to stdout if stderr is empty
- Added test case for stdout fallback behavior

## Test plan

- [x] All 589 unit tests pass
- [x] New test specifically covers stdout fallback case
- [x] Existing truncation test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)