### PR TITLE
docs: update test count from 588 to 589

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 588 unit tests — all mocked, no API keys needed
+tests/unit/             # 589 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 588 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 589 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 588 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 588 tests)
+- [ ] `make test` passes (all 589 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (588 tests)
+make test          # Unit tests only (589 tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary

Update test count references in documentation files to reflect the current count of 589 tests.

## Changes

- README.md: Updated unit test count (588 → 589)
- CLAUDE.md: Updated all test count references (588 → 589)

## Test plan

- [x] `python -m pytest tests/unit -q` passes (589 tests)
- [x] `python scripts/update_test_counts.py` reports no changes needed