### PR TITLE
test: add coverage configuration for 100% source coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,14 @@ check_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 show_error_codes = true
+
+[tool.coverage.run]
+source = ["src", "scripts"]
+omit = ["*/tests/*"]
+
+[tool.coverage.report]
+exclude_also = [
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "pragma: no cover",
+]


### PR DESCRIPTION
## Summary

Add `[tool.coverage]` configuration to pyproject.toml to:
- Track coverage for both `src/` and `scripts/` directories  
- Exclude test files from coverage analysis
- Exclude common boilerplate patterns:
  - `if __name__ == \"__main__\":` blocks
  - `if TYPE_CHECKING:` blocks
  - `pragma: no cover` annotations

## Result

Source code coverage is now 100% (1370 statements covered, 0 missing).

## Test Plan

- [x] `make test` passes (589 tests)
- [x] Coverage report shows 100% for all source files
- [x] Configuration follows Python community best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)