### PR TITLE
style: fix ruff formatting in test_updater_applier.py

### DIFF
--- a/tests/unit/test_updater_applier.py
+++ b/tests/unit/test_updater_applier.py
@@ -82,9 +82,7 @@ class TestApplyUpdates:
         monkeypatch.setattr(
             subprocess,
             "run",
-            lambda *a, **kw: subprocess.CompletedProcess(
-                a[0], 1, stdout=stdout_error, stderr=b""
-            ),
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stdout=stdout_error, stderr=b""),
         )
         results = apply_updates()
         # Check that stdout error is captured when stderr is empty


### PR DESCRIPTION
## Summary
Fix ruff formatting issue in `tests/unit/test_updater_applier.py` - single-line lambda formatting.

## Test plan
- [x] `make lint` passes
- [x] All 589 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)