### PR TITLE
refactor: include key hash in KeyPool error messages

### DIFF
--- a/src/gasclaw/kimigas/key_pool.py
+++ b/src/gasclaw/kimigas/key_pool.py
@@ -114,7 +114,7 @@ class KeyPool:
             ValueError: If the key does not belong to this pool.
         """
         if key not in self._keys:
-            raise ValueError("Key does not belong to this pool")
+            raise ValueError(f"Key {self._key_hash(key)} does not belong to this pool")
 
         state = self._load_state()
         rate_limited = state.get("rate_limited", {})
@@ -136,7 +136,7 @@ class KeyPool:
             ValueError: If the key does not belong to this pool.
         """
         if key not in self._keys:
-            raise ValueError("Key does not belong to this pool")
+            raise ValueError(f"Key {self._key_hash(key)} does not belong to this pool")
 
         state = self._load_state()
         rate_limited = state.get("rate_limited", {})

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -265,9 +265,10 @@ class TestKeyPoolEdgeCases:
         assert pool1._key_hash("k1") == pool2._key_hash("k1")
 
     def test_mark_nonexistent_key_rate_limited(self, tmp_path):
-        """Marking a key not in pool raises ValueError."""
+        """Marking a key not in pool raises ValueError with key hash."""
         pool = KeyPool(["k1"], state_dir=tmp_path)
-        with pytest.raises(ValueError, match="Key does not belong"):
+        expected_hash = pool._key_hash("nonexistent-key")
+        with pytest.raises(ValueError, match=f"Key {expected_hash} does not belong"):
             pool.mark_rate_limited("nonexistent-key")
 
     def test_clear_cooldown_removes_rate_limit(self, tmp_path):
@@ -294,10 +295,11 @@ class TestKeyPoolEdgeCases:
         assert result is False
 
     def test_clear_cooldown_raises_for_invalid_key(self, tmp_path):
-        """clear_cooldown raises ValueError for key not in pool."""
+        """clear_cooldown raises ValueError with key hash for key not in pool."""
         pool = KeyPool(["k1"], state_dir=tmp_path)
+        expected_hash = pool._key_hash("nonexistent-key")
 
-        with pytest.raises(ValueError, match="Key does not belong"):
+        with pytest.raises(ValueError, match=f"Key {expected_hash} does not belong"):
             pool.clear_cooldown("nonexistent-key")
 
     def test_state_file_is_json(self, tmp_path):


### PR DESCRIPTION
## Summary

Include the key hash in ValueError messages when a key doesn't belong to the pool. This makes debugging configuration issues easier by identifying which key (by hash) caused the error without exposing the full key in logs.

## Changes

- Update `mark_rate_limited()` error message to include key hash
- Update `clear_cooldown()` error message to include key hash  
- Update corresponding tests to verify hash inclusion

## Test Plan

- [x] All 589 unit tests pass
- [x] Ruff linting passes
- [x] 100% code coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)