### PR TITLE
fix: clarify KeyPool error messages

### DIFF
--- a/src/gasclaw/kimigas/key_pool.py
+++ b/src/gasclaw/kimigas/key_pool.py
@@ -114,7 +114,7 @@ class KeyPool:
             ValueError: If the key does not belong to this pool.
         """
         if key not in self._keys:
-            raise ValueError(f"Key {self._key_hash(key)} does not belong to this pool")
+            raise ValueError(f"Key hash {self._key_hash(key)} does not belong to this pool")
 
         state = self._load_state()
         rate_limited = state.get("rate_limited", {})
@@ -136,7 +136,7 @@ class KeyPool:
             ValueError: If the key does not belong to this pool.
         """
         if key not in self._keys:
-            raise ValueError(f"Key {self._key_hash(key)} does not belong to this pool")
+            raise ValueError(f"Key hash {self._key_hash(key)} does not belong to this pool")
 
         state = self._load_state()
         rate_limited = state.get("rate_limited", {})

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -268,7 +268,7 @@ class TestKeyPoolEdgeCases:
         """Marking a key not in pool raises ValueError with key hash."""
         pool = KeyPool(["k1"], state_dir=tmp_path)
         expected_hash = pool._key_hash("nonexistent-key")
-        with pytest.raises(ValueError, match=f"Key {expected_hash} does not belong"):
+        with pytest.raises(ValueError, match=f"Key hash {expected_hash} does not belong"):
             pool.mark_rate_limited("nonexistent-key")
 
     def test_clear_cooldown_removes_rate_limit(self, tmp_path):
@@ -299,7 +299,7 @@ class TestKeyPoolEdgeCases:
         pool = KeyPool(["k1"], state_dir=tmp_path)
         expected_hash = pool._key_hash("nonexistent-key")
 
-        with pytest.raises(ValueError, match=f"Key {expected_hash} does not belong"):
+        with pytest.raises(ValueError, match=f"Key hash {expected_hash} does not belong"):
             pool.clear_cooldown("nonexistent-key")
 
     def test_state_file_is_json(self, tmp_path):


### PR DESCRIPTION
## Summary

Clarify error messages in `KeyPool.mark_rate_limited()` and `KeyPool.clear_cooldown()` to indicate that the value shown is a **hash**, not a masked key.

## Changes

- Error messages now say `Key hash {hash}` instead of `Key {hash}`
- Updated corresponding tests to match new error format

## Rationale

The `_key_hash()` method returns a SHA256 hash (first 12 chars), which is different from a masked key format like `...last8chars`. Making this explicit in error messages improves clarity for developers debugging key pool issues.

## Test Plan

- [x] All 589 unit tests pass
- [x] Lint passes
- [x] Specific tests updated for new error message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)