### PR TITLE
refactor: extract key validation into helper method

### DIFF
--- a/src/gasclaw/kimigas/key_pool.py
+++ b/src/gasclaw/kimigas/key_pool.py
@@ -104,6 +104,19 @@ class KeyPool:
         state["last_used"] = last_used
         self._save_state(state)
 
+    def _validate_key(self, key: str) -> None:
+        """Validate that a key belongs to this pool.
+
+        Args:
+            key: The API key to validate.
+
+        Raises:
+            ValueError: If the key does not belong to this pool.
+
+        """
+        if key not in self._keys:
+            raise ValueError(f"Key {self._key_hash(key)} does not belong to this pool")
+
     def mark_rate_limited(self, key: str) -> None:
         """Mark a key as rate-limited (enters cooldown).
 
@@ -114,8 +127,7 @@ class KeyPool:
             ValueError: If the key does not belong to this pool.
 
         """
-        if key not in self._keys:
-            raise ValueError(f"Key {self._key_hash(key)} does not belong to this pool")
+        self._validate_key(key)
 
         state = self._load_state()
         rate_limited = state.get("rate_limited", {})
@@ -137,8 +149,7 @@ class KeyPool:
             ValueError: If the key does not belong to this pool.
 
         """
-        if key not in self._keys:
-            raise ValueError(f"Key {self._key_hash(key)} does not belong to this pool")
+        self._validate_key(key)
 
         state = self._load_state()
         rate_limited = state.get("rate_limited", {})


### PR DESCRIPTION
## Summary
Extract duplicate key validation logic from `mark_rate_limited()` and `clear_cooldown()` into a private `_validate_key()` helper method in `KeyPool`.

## Changes
- Added `_validate_key()` private method to centralize key membership validation
- Refactored `mark_rate_limited()` to use the new helper
- Refactored `clear_cooldown()` to use the new helper

## Rationale
This reduces code duplication and improves maintainability. The validation logic was identical in both methods.

## Test plan
- [x] All 589 unit tests pass
- [x] 100% code coverage maintained
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)