### PR TITLE
feat: add CommandNotFoundError exception class

### DIFF
--- a/src/gasclaw/maintenance.py
+++ b/src/gasclaw/maintenance.py
@@ -26,6 +26,33 @@ logger = get_logger(__name__)
 # Repository configuration
 REPO = "gastown-publish/gasclaw"
 
+__all__ = [
+    "CommandNotFoundError",
+    "run_command",
+    "get_open_prs",
+    "get_open_issues",
+    "checkout_and_test_pr",
+    "merge_pr",
+    "process_open_prs",
+    "process_open_issues",
+    "run_maintenance_cycle",
+    "maintenance_loop",
+    "main",
+]
+
+
+class CommandNotFoundError(subprocess.CalledProcessError):
+    """Raised when a command binary is not found in PATH."""
+
+    def __init__(self, cmd: list[str]) -> None:
+        self.binary = cmd[0] if cmd else "unknown"
+        super().__init__(
+            returncode=-1,
+            cmd=cmd,
+            output="",
+            stderr=f"Command not found: {self.binary}",
+        )
+
 
 def run_command(
     cmd: list[str], *, check: bool = True, timeout: int = 120
@@ -41,25 +68,23 @@ def run_command(
         CompletedProcess with returncode, stdout, stderr.
 
     Raises:
-        subprocess.CalledProcessError: If check=True and command fails or binary not found.
+        CommandNotFoundError: If check=True and the command binary is not found.
+        subprocess.CalledProcessError: If check=True and command fails.
         subprocess.TimeoutExpired: If command times out.
 
     """
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except FileNotFoundError:
-        # Handle missing binary gracefully
-        binary = cmd[0] if cmd else "unknown"
-        result = subprocess.CompletedProcess(
+        if check:
+            raise CommandNotFoundError(cmd) from None
+        # Return a failed result when check=False
+        return subprocess.CompletedProcess(
             args=cmd,
             returncode=-1,
             stdout="",
-            stderr=f"Command not found: {binary}",
+            stderr=f"Command not found: {cmd[0] if cmd else 'unknown'}",
         )
-        if check:
-            raise subprocess.CalledProcessError(
-                result.returncode, cmd, result.stdout, result.stderr
-            ) from None
     if check and result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
     return result

--- a/tests/unit/test_maintenance.py
+++ b/tests/unit/test_maintenance.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gasclaw.maintenance import (
+    CommandNotFoundError,
     checkout_and_test_pr,
     fix_on_branch,
     get_open_issues,
@@ -20,6 +21,35 @@ from gasclaw.maintenance import (
     run_command,
     run_maintenance_cycle,
 )
+
+
+class TestCommandNotFoundError:
+    """Tests for CommandNotFoundError exception class."""
+
+    def test_is_subclass_of_called_process_error(self):
+        """CommandNotFoundError is a CalledProcessError subclass."""
+        assert issubclass(CommandNotFoundError, subprocess.CalledProcessError)
+
+    def test_stores_binary_name(self):
+        """Error stores the binary name that was not found."""
+        error = CommandNotFoundError(["nonexistent", "arg1", "arg2"])
+        assert error.binary == "nonexistent"
+
+    def test_stores_unknown_for_empty_cmd(self):
+        """Error stores 'unknown' for empty command list."""
+        error = CommandNotFoundError([])
+        assert error.binary == "unknown"
+
+    def test_has_correct_returncode(self):
+        """Error has returncode of -1."""
+        error = CommandNotFoundError(["cmd"])
+        assert error.returncode == -1
+
+    def test_has_informative_stderr(self):
+        """Error has informative stderr message."""
+        error = CommandNotFoundError(["mycommand"])
+        assert "not found" in error.stderr.lower()
+        assert "mycommand" in error.stderr
 
 
 class TestRunCommand:
@@ -41,11 +71,12 @@ class TestRunCommand:
             run_command(["sleep", "10"], timeout=1)
 
     def test_handles_file_not_found(self):
-        """FileNotFoundError is converted to CalledProcessError when check=True."""
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        """FileNotFoundError is converted to CommandNotFoundError when check=True."""
+        with pytest.raises(CommandNotFoundError) as exc_info:
             run_command(["nonexistent_binary_xyz"], check=True)
         assert exc_info.value.returncode == -1
         assert "not found" in exc_info.value.stderr.lower()
+        assert exc_info.value.binary == "nonexistent_binary_xyz"
 
     def test_returns_result_on_file_not_found_when_check_false(self):
         """FileNotFoundError returns result with returncode -1 when check=False."""


### PR DESCRIPTION
## Summary
Add a specific CommandNotFoundError exception class for clearer error handling when command binaries are not found in PATH.

## Changes
- Added CommandNotFoundError class extending CalledProcessError
- Refactored run_command() to use the new exception
- Added __all__ exports for cleaner module interface
- Added comprehensive tests for the new exception class

## Rationale
This provides clearer error semantics and makes it easier for calling code to handle the specific case of missing binaries.

## Test plan
- [x] All 594 unit tests pass (+5 new tests)
- [x] 100% code coverage maintained
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)