### PR TITLE
docs: update test count from 589 to 594

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 589 unit tests — all mocked, no API keys needed
+tests/unit/             # 594 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 589 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 594 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 


### PR DESCRIPTION
## Summary
Update the documented test count in CLAUDE.md to match the actual test suite size (594 tests).

## Changes
- Updated test count from 589 to 594 in project structure section
- Updated test count from 589 to 594 in testing section

## Verification
- [x] `make test` passes (all 594 tests)
- [x] `make lint` passes
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)