### PR TITLE
test: add explicit _validate_key tests for key_pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 594 unit tests — all mocked, no API keys needed
+tests/unit/             # 598 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 594 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 598 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 594 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 589 tests)
+- [ ] `make test` passes (all 598 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/tests/unit/test_kimigas_key_pool.py
+++ b/tests/unit/test_kimigas_key_pool.py
@@ -317,3 +317,47 @@ class TestKeyPoolEdgeCases:
         assert "rate_limited" in state
         assert isinstance(state["last_used"], dict)
         assert isinstance(state["rate_limited"], dict)
+
+
+class TestKeyPoolValidateKey:
+    """Direct tests for the _validate_key helper method."""
+
+    def test_validate_key_succeeds_for_valid_key(self, tmp_path):
+        """_validate_key succeeds silently for keys in the pool."""
+        pool = KeyPool(["k1", "k2", "k3"], state_dir=tmp_path)
+        # Should not raise for keys in the pool
+        pool._validate_key("k1")
+        pool._validate_key("k2")
+        pool._validate_key("k3")
+
+    def test_validate_key_raises_for_key_not_in_pool(self, tmp_path):
+        """_validate_key raises ValueError with key hash for invalid keys."""
+        pool = KeyPool(["k1", "k2"], state_dir=tmp_path)
+        expected_hash = pool._key_hash("k3")
+
+        with pytest.raises(ValueError, match=f"Key {expected_hash} does not belong"):
+            pool._validate_key("k3")
+
+    def test_validate_key_raises_for_empty_string_when_not_in_pool(self, tmp_path):
+        """_validate_key raises ValueError for empty string if not in pool."""
+        pool = KeyPool(["k1"], state_dir=tmp_path)
+        expected_hash = pool._key_hash("")
+
+        with pytest.raises(ValueError, match=f"Key {expected_hash} does not belong"):
+            pool._validate_key("")
+
+    def test_validate_key_error_includes_partial_hash(self, tmp_path):
+        """Error message includes truncated SHA-256 hash for security."""
+        pool = KeyPool(["valid-key"], state_dir=tmp_path)
+        foreign_key = "foreign-key-not-in-pool"
+        expected_hash = pool._key_hash(foreign_key)
+
+        # Verify hash is truncated to 12 chars (SHA-256[:12])
+        assert len(expected_hash) == 12
+
+        with pytest.raises(ValueError) as exc_info:
+            pool._validate_key(foreign_key)
+
+        assert expected_hash in str(exc_info.value)
+        # Full key should NOT be in error message (security)
+        assert foreign_key not in str(exc_info.value)


### PR DESCRIPTION
## Summary

Add direct test coverage for the `_validate_key` helper method in `key_pool.py`.

## Changes

- Added 4 new tests in `TestKeyPoolValidateKey` class:
  - `test_validate_key_succeeds_for_valid_key`: verifies no exception for valid keys
  - `test_validate_key_raises_for_key_not_in_pool`: verifies ValueError includes key hash
  - `test_validate_key_raises_for_empty_string_when_not_in_pool`: edge case coverage
  - `test_validate_key_error_includes_partial_hash`: verifies security (full key not leaked in error)

- Updated test count from 594 to 598 in CLAUDE.md

## Test Plan

- [x] All 598 unit tests pass
- [x] New tests cover _validate_key method directly
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)