### PR TITLE
docs: update test count in README from 589 to 598

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (589 tests)
+make test          # Unit tests only (598 tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary

Update test count in README.md from 589 to 598 to reflect the current test suite size.

## Changes

- README.md: Updated test count from 589 to 598

## Test Plan

- [x] Documentation change only
- [x] All 598 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)