### PR TITLE
refactor: add debug logging to _check_service using service_name

### DIFF
--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -56,11 +56,24 @@ class HealthReport:
 
 
 def _check_service(cmd: list[str], service_name: str) -> str:
-    """Run a health check command and return status."""
+    """Run a health check command and return status.
+
+    Args:
+        cmd: Command and arguments to run.
+        service_name: Name of the service being checked (for logging).
+
+    Returns:
+        "healthy" if command succeeds, "unhealthy" otherwise.
+
+    """
     try:
         result = subprocess.run(cmd, capture_output=True, timeout=10)
-        return "healthy" if result.returncode == 0 else "unhealthy"
+        if result.returncode == 0:
+            return "healthy"
+        logger.debug("Health check failed for %s: exit code %d", service_name, result.returncode)
+        return "unhealthy"
     except (OSError, subprocess.TimeoutExpired):
+        logger.debug("Health check error for %s: command failed or timed out", service_name)
         return "unhealthy"
 
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -247,6 +247,41 @@ class TestCheckServiceErrorHandling:
         result = _check_service(["gt", "daemon", "status"], "daemon")
         assert result == "unhealthy"
 
+    def test_check_service_logs_debug_on_failure(self, monkeypatch, caplog):
+        """Test _check_service logs debug message when service returns non-zero exit code."""
+        from gasclaw.health import _check_service
+        import logging
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 1, stderr=b"error"),
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            result = _check_service(["gt", "daemon", "status"], "daemon")
+
+        assert result == "unhealthy"
+        assert "daemon" in caplog.text
+        assert "exit code 1" in caplog.text
+
+    def test_check_service_logs_debug_on_exception(self, monkeypatch, caplog):
+        """Test _check_service logs debug message when command fails or times out."""
+        from gasclaw.health import _check_service
+        import logging
+
+        def _raise_timeout(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd=a[0] if a else "cmd", timeout=10)
+
+        monkeypatch.setattr(subprocess, "run", _raise_timeout)
+
+        with caplog.at_level(logging.DEBUG):
+            result = _check_service(["gt", "daemon", "status"], "daemon")
+
+        assert result == "unhealthy"
+        assert "daemon" in caplog.text
+        assert "timed out" in caplog.text.lower()
+
     def test_git_error_returns_non_compliant(self, monkeypatch, tmp_path):
         """Git command failure returns non-compliant activity."""
         git_dir = tmp_path / "git_repo"


### PR DESCRIPTION
## Summary

The `service_name` parameter in `_check_service` was previously unused. This PR adds debug logging that includes the service name for better troubleshooting.

## Changes

- Enhanced `_check_service` docstring with proper Args/Returns documentation
- Added debug logging when health check returns non-zero exit code
- Added debug logging when health check fails with exception
- Added 2 new tests to cover the new debug logging paths

## Test Plan

- [x] All 600 unit tests pass
- [x] 100% code coverage maintained
- [x] Lint checks pass
- [x] New tests verify debug logging behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)