### PR TITLE
docs: update test count from 598 to 600

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (4: health, keys, update, agents)
-tests/unit/             # 598 unit tests — all mocked, no API keys needed
+tests/unit/             # 600 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 598 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 600 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -98,7 +98,7 @@ All 598 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 598 tests)
+- [ ] `make test` passes (all 600 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python -m venv .venv && source .venv/bin/activate
 make dev
 
 # Test
-make test          # Unit tests only (598 tests)
+make test          # Unit tests only (600 tests)
 make test-all      # Include integration tests
 
 # Lint


### PR DESCRIPTION
## Summary

Update test count references from 598 to 600 in documentation files.

## Changes

- CLAUDE.md: Updated 3 references (test directory comment, testing section, PR checklist)
- README.md: Updated 1 reference (testing section)

## Context

Test count increased from 598 to 600 after PR #219 added 2 new tests for debug logging in `_check_service`.

## Test Plan

- [x] Verified all 600 tests pass
- [x] Updated all documentation references

🤖 Generated with [Claude Code](https://claude.com/claude-code)