### PR TITLE
fix: correct import order in test_health.py

### DIFF
--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -249,8 +249,9 @@ class TestCheckServiceErrorHandling:
 
     def test_check_service_logs_debug_on_failure(self, monkeypatch, caplog):
         """Test _check_service logs debug message when service returns non-zero exit code."""
-        from gasclaw.health import _check_service
         import logging
+
+        from gasclaw.health import _check_service
 
         monkeypatch.setattr(
             subprocess,
@@ -267,8 +268,9 @@ class TestCheckServiceErrorHandling:
 
     def test_check_service_logs_debug_on_exception(self, monkeypatch, caplog):
         """Test _check_service logs debug message when command fails or times out."""
-        from gasclaw.health import _check_service
         import logging
+
+        from gasclaw.health import _check_service
 
         def _raise_timeout(*a, **kw):
             raise subprocess.TimeoutExpired(cmd=a[0] if a else "cmd", timeout=10)


### PR DESCRIPTION
## Summary
Fix ruff I001 import sorting errors in test_health.py by placing standard library imports (logging) before local imports (gasclaw.health) with proper blank line separation.

## Changes
- Fixed import order in `test_check_service_logs_debug_on_failure`
- Fixed import order in `test_check_service_logs_debug_on_exception`

## Test plan
- [x] `ruff check tests/unit/test_health.py` passes
- [x] All 600 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)