### PR TITLE
fix: improve error handling in key pool shell scripts

### DIFF
--- a/skills/gastown-keys/scripts/key-rotate.sh
+++ b/skills/gastown-keys/scripts/key-rotate.sh
@@ -11,9 +11,28 @@ if [ ! -f "$STATE_FILE" ]; then
     exit 0
 fi
 
+# Check if file is readable and writable
+if [ ! -r "$STATE_FILE" ]; then
+    echo "Error: Cannot read state file (permission denied)"
+    exit 1
+fi
+if [ ! -w "$STATE_FILE" ]; then
+    echo "Error: Cannot write state file (permission denied)"
+    exit 1
+fi
+
 python3 -c "
-import json, time
-state = json.load(open('$STATE_FILE'))
+import json, time, sys
+try:
+    with open('$STATE_FILE', 'r') as f:
+        state = json.load(f)
+except json.JSONDecodeError as e:
+    print(f'Error: Invalid JSON in state file: {e}', file=sys.stderr)
+    sys.exit(1)
+except OSError as e:
+    print(f'Error: Cannot read state file: {e}', file=sys.stderr)
+    sys.exit(1)
+
 last_used = state.get('last_used', {})
 rate_limited = state.get('rate_limited', {})
 now = time.time()
@@ -23,10 +42,14 @@ if last_used:
     mru = max(last_used, key=last_used.get)
     rate_limited[mru] = now
     state['rate_limited'] = rate_limited
-    with open('$STATE_FILE', 'w') as f:
-        json.dump(state, f, indent=2)
-    print(f'Marked key {mru} as rate-limited (5min cooldown)')
-    print('Next request will use a different key')
+    try:
+        with open('$STATE_FILE', 'w') as f:
+            json.dump(state, f, indent=2)
+        print(f'Marked key {mru} as rate-limited (5min cooldown)')
+        print('Next request will use a different key')
+    except OSError as e:
+        print(f'Error: Failed to write state file: {e}', file=sys.stderr)
+        sys.exit(1)
 else:
     print('No keys tracked yet')
-"
+" || exit 1

--- a/skills/gastown-keys/scripts/key-status.sh
+++ b/skills/gastown-keys/scripts/key-status.sh
@@ -11,10 +11,30 @@ if [ -f "$STATE_FILE" ]; then
     echo "State file: $STATE_FILE"
     echo ""
 
+    # Check if file is readable and non-empty
+    if [ ! -r "$STATE_FILE" ]; then
+        echo "Error: Cannot read state file (permission denied)"
+        exit 1
+    fi
+
+    if [ ! -s "$STATE_FILE" ]; then
+        echo "State file is empty — key pool not initialized yet"
+        exit 0
+    fi
+
     # Parse with python (always available)
     python3 -c "
-import json, time
-state = json.load(open('$STATE_FILE'))
+import json, time, sys
+try:
+    with open('$STATE_FILE', 'r') as f:
+        state = json.load(f)
+except json.JSONDecodeError as e:
+    print(f'Error: Invalid JSON in state file: {e}', file=sys.stderr)
+    sys.exit(1)
+except OSError as e:
+    print(f'Error: Cannot read state file: {e}', file=sys.stderr)
+    sys.exit(1)
+
 last_used = state.get('last_used', {})
 rate_limited = state.get('rate_limited', {})
 now = time.time()
@@ -35,7 +55,7 @@ for h, ts in rate_limited.items():
 print()
 print(f'Available: {len(last_used) - rl_count}')
 print(f'Rate-limited: {rl_count}')
-"
+" || exit 1
 else
     echo "No state file found — key pool not initialized yet"
 fi


### PR DESCRIPTION
## Summary

Improves error handling in the gastown-keys skill scripts (key-status.sh and key-rotate.sh).

## Changes

- Check file readability/writability before operations
- Handle empty state files gracefully  
- Catch JSON decode errors with descriptive messages
- Handle OS errors (permissions, I/O errors) explicitly
- Exit with proper error codes on failure

## Test Plan

- [x] All 600 unit tests pass
- [x] Shell scripts remain executable
- [x] Error messages are clear and actionable

## Motivation

Previously, if the key-rotation.json file was corrupted, empty, or had permission issues, the scripts would produce confusing Python tracebacks or silently fail. Now they provide clear error messages and proper exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)