### PR TITLE
docs: update test count in CLAUDE.md from 600 to 606

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 600 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 606 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 


### PR DESCRIPTION
## Summary
Update the test count in CLAUDE.md from 600 to 606 (current count after recent PRs).

## Test plan
- [x] Verified 606 tests pass
- [x] Documentation change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)