### PR TITLE
fix: Remove silent failure patterns in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,13 @@ RUN case "${TARGETARCH}" in \
 RUN npm install -g @anthropic-ai/claude-code
 
 # OpenClaw
-RUN npm install -g openclaw || true
+RUN npm install -g openclaw
 
 # KimiGas (kimi-cli)
-RUN pip install --no-cache-dir kimi-cli || true
+RUN pip install --no-cache-dir kimi-cli
 
 # Gastown (gt)
-RUN pip install --no-cache-dir gastown || true
+RUN pip install --no-cache-dir gastown
 
 # Install gasclaw
 WORKDIR /opt/gasclaw


### PR DESCRIPTION
## Summary

This PR removes the `|| true` patterns from Dockerfile installation commands that were silently hiding installation failures.

## Problem

The Dockerfile contained `|| true` patterns after three installation commands:
- openclaw installation
- kimi-cli installation
- gastown installation

These patterns caused the build to continue even when package installations failed, making it difficult to detect and debug issues early.

## Changes Made

Removed `|| true` from 3 lines in the Dockerfile:
1. openclaw installation - now fails on error
2. kimi-cli installation - now fails on error
3. gastown installation - now fails on error

## Why This Matters

Following the **fail-fast principle**, Docker builds should fail immediately when a critical installation step fails. This ensures:
- Faster detection of issues
- Clearer error messages
- No silent propagation of broken dependencies

## Related Issues

Fixes #233

## Test Plan

- [ ] Dockerfile builds successfully with the changes
- [ ] Intentionally failing installation causes build to stop
- [ ] CI/CD pipeline properly reports build failures