### PR TITLE
test: Fix monkeypatch path in bootstrap integration tests

### DIFF
--- a/tests/integration/test_bootstrap_integration.py
+++ b/tests/integration/test_bootstrap_integration.py
@@ -229,7 +229,7 @@ class TestMonitorLoopIntegration:
             activity_calls.append(kw)
             return {"compliant": True, "last_commit_age": 300}
 
-        monkeypatch.setattr("gasclaw.bootstrap.check_health", mock_check_health)
+        monkeypatch.setattr("gasclaw.health.check_health", mock_check_health)
         monkeypatch.setattr("gasclaw.bootstrap.check_agent_activity", mock_check_activity)
         monkeypatch.setattr("gasclaw.bootstrap.notify_telegram", lambda msg: None)
         monkeypatch.setattr("time.sleep", lambda x: None)
@@ -258,7 +258,7 @@ class TestMonitorLoopIntegration:
                 agents=[],
             )
 
-        monkeypatch.setattr("gasclaw.bootstrap.check_health", mock_check_health)
+        monkeypatch.setattr("gasclaw.health.check_health", mock_check_health)
         monkeypatch.setattr(
             "gasclaw.bootstrap.check_agent_activity",
             lambda **kw: {"compliant": True, "last_commit_age": 300},
@@ -294,7 +294,7 @@ class TestMonitorLoopIntegration:
                 agents=["mayor"],
             )
 
-        monkeypatch.setattr("gasclaw.bootstrap.check_health", mock_check_health)
+        monkeypatch.setattr("gasclaw.health.check_health", mock_check_health)
         monkeypatch.setattr(
             "gasclaw.bootstrap.check_agent_activity",
             lambda **kw: {"compliant": False, "last_commit_age": 5000},  # Not compliant
@@ -333,7 +333,7 @@ class TestMonitorLoopIntegration:
                 agents=["mayor"],
             )
 
-        monkeypatch.setattr("gasclaw.bootstrap.check_health", mock_check_health)
+        monkeypatch.setattr("gasclaw.health.check_health", mock_check_health)
         monkeypatch.setattr(
             "gasclaw.bootstrap.check_agent_activity",
             lambda **kw: {"compliant": True, "last_commit_age": 300},
@@ -355,7 +355,7 @@ class TestMonitorLoopIntegration:
                 raise KeyboardInterrupt
 
         monkeypatch.setattr(
-            "gasclaw.bootstrap.check_health",
+            "gasclaw.health.check_health",
             lambda **kw: type(
                 "R",
                 (),
@@ -379,3 +379,4 @@ class TestMonitorLoopIntegration:
         monitor_loop(config, interval=custom_interval)
 
         assert all(s == custom_interval for s in sleep_calls)
+


### PR DESCRIPTION
## Summary

This PR fixes the monkeypatch path in 5 integration tests that were causing CI failures.

## Changes Made

- Fixed monkeypatch path from `gasclaw.bootstrap.check_health` to `gasclaw.health.check_health` in the following test functions:
  1. `test_monitor_loop_health_check_cycle`
  2. `test_monitor_loop_notifies_on_unhealthy_service`
  3. `test_monitor_loop_notifies_on_activity_violation`
  4. `test_monitor_loop_with_http_notification`
  5. `test_monitor_loop_uses_config_interval`

## Root Cause

The `check_health` function was moved from `gasclaw.bootstrap` to `gasclaw.health` module, but the integration tests were not updated to reflect this change. This caused `AttributeError` when the tests tried to monkeypatch the old path.

## Test Plan

- [x] Fixed monkeypatch paths updated
- [x] All 5 affected tests now use correct module path
- [x] Fixes CI failure reported in #230

## Related Issues

Fixes #230