### PR TITLE
docs: add API documentation for maintenance.py and migration.py (Fixes #235)

### DIFF
--- a/docs/api/maintenance.md
+++ b/docs/api/maintenance.md
@@ -1,0 +1,316 @@
+# maintenance.py
+
+Automated maintenance loop for the gasclaw repository.
+
+## Overview
+
+This module provides continuous maintenance capabilities for the gasclaw project:
+
+- Check and merge open PRs automatically
+- Fix open issues
+- Improve test coverage
+- Maintain code quality
+
+Can be run as a standalone script or imported as a module.
+
+## Classes
+
+### `CommandNotFoundError`
+
+Raised when a command binary is not found in PATH.
+
+```python
+class CommandNotFoundError(subprocess.CalledProcessError)
+```
+
+**Inheritance**: `subprocess.CalledProcessError`
+
+#### Constructor
+
+```python
+def __init__(cmd: list[str]) -> None
+```
+
+**Parameters**:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `cmd` | `list[str]` | The command that was not found |
+
+**Attributes**:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `binary` | `str` | The binary name that was not found |
+
+---
+
+## Functions
+
+### `run_command()`
+
+Run a shell command and return the result.
+
+```python
+def run_command(
+    cmd: list[str],
+    *,
+    check: bool = True,
+    timeout: int = 120
+) -> subprocess.CompletedProcess[str]
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `cmd` | `list[str]` | — | Command and arguments as a list |
+| `check` | `bool` | `True` | If True, raise CalledProcessError on non-zero exit |
+| `timeout` | `int` | `120` | Max seconds to wait for command |
+
+**Returns**: `CompletedProcess` with `returncode`, `stdout`, `stderr`
+
+**Raises**:
+
+- `CommandNotFoundError`: If `check=True` and command binary is not found
+- `subprocess.CalledProcessError`: If `check=True` and command fails
+- `subprocess.TimeoutExpired`: If command times out
+
+---
+
+### `get_open_prs()`
+
+Get list of open PRs from GitHub.
+
+```python
+def get_open_prs(timeout: int = 120) -> list[dict[str, Any]]
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `timeout` | `int` | `120` | Max seconds to wait for the command |
+
+**Returns**: List of PR dicts with `number`, `title`, `headRefName`, and `author`
+
+---
+
+### `get_open_issues()`
+
+Get list of open issues from GitHub.
+
+```python
+def get_open_issues(timeout: int = 120) -> list[dict[str, Any]]
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `timeout` | `int` | `120` | Max seconds to wait for the command |
+
+**Returns**: List of issue dicts with `number` and `title`
+
+---
+
+### `checkout_and_test_pr()`
+
+Checkout a PR branch and run tests.
+
+```python
+def checkout_and_test_pr(pr_number: int, branch: str) -> bool
+```
+
+**Parameters**:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `pr_number` | `int` | The PR number |
+| `branch` | `str` | The branch name to checkout |
+
+**Returns**: `True` if tests pass, `False` otherwise
+
+---
+
+### `merge_pr()`
+
+Merge a PR using squash merge.
+
+```python
+def merge_pr(pr_number: int) -> bool
+```
+
+**Parameters**:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `pr_number` | `int` | The PR number to merge |
+
+**Returns**: `True` if merge succeeded, `False` otherwise
+
+---
+
+### `process_open_prs()`
+
+Process all open PRs: test and merge if passing.
+
+```python
+def process_open_prs() -> dict[str, Any]
+```
+
+**Returns**: Dict with counts of `merged`, `failed`, and `fixed` PRs, plus `total`
+
+**Return Structure**:
+
+```python
+{
+    "merged": int,   # Number of PRs successfully merged
+    "failed": int,   # Number of PRs with failing tests
+    "fixed": int,    # Number of PRs auto-fixed (placeholder)
+    "total": int     # Total PRs processed
+}
+```
+
+---
+
+### `process_open_issues()`
+
+Process open issues by creating fix branches and PRs.
+
+```python
+def process_open_issues() -> dict[str, Any]
+```
+
+**Returns**: Dict with counts of issues processed
+
+**Return Structure**:
+
+```python
+{
+    "processed": int,  # Number of issues processed
+    "total": int       # Total open issues found
+}
+```
+
+---
+
+### `run_maintenance_cycle()`
+
+Run a single maintenance cycle.
+
+```python
+def run_maintenance_cycle() -> dict[str, Any]
+```
+
+**Returns**: Dict with summary of all actions taken
+
+**Return Structure**:
+
+```python
+{
+    "prs": {
+        "merged": int,
+        "failed": int,
+        "fixed": int,
+        "total": int
+    },
+    "issues": {
+        "processed": int,
+        "total": int
+    }
+}
+```
+
+---
+
+### `maintenance_loop()`
+
+Run continuous maintenance loop.
+
+```python
+def maintenance_loop(interval: int = 300) -> None
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `interval` | `int` | `300` | Seconds between maintenance cycles |
+
+**Behavior**:
+
+- Runs indefinitely until interrupted
+- Sends Telegram notifications for PR merges and errors
+- Catches exceptions and continues looping
+- Handles `KeyboardInterrupt` gracefully
+
+---
+
+### `main()`
+
+Run the maintenance script entry point.
+
+```python
+def main(args: list[str] | None = None) -> None
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `args` | `list[str] \| None` | `None` | Command line arguments (defaults to `sys.argv[1:]`)
+
+**Command Line Usage**:
+
+```bash
+# Run maintenance once
+python -m gasclaw.maintenance --once
+
+# Run continuous loop with custom interval
+python -m gasclaw.maintenance --interval 600
+```
+
+---
+
+## Usage Examples
+
+### Run a Single Maintenance Cycle
+
+```python
+from gasclaw.maintenance import run_maintenance_cycle
+
+results = run_maintenance_cycle()
+print(f"Merged: {results['prs']['merged']}")
+print(f"Failed: {results['prs']['failed']}")
+```
+
+### Get Open PRs
+
+```python
+from gasclaw.maintenance import get_open_prs
+
+prs = get_open_prs()
+for pr in prs:
+    print(f"#{pr['number']}: {pr['title']}")
+```
+
+### Run Continuous Loop
+
+```python
+from gasclaw.maintenance import maintenance_loop
+
+# Run every 5 minutes (default)
+maintenance_loop()
+
+# Run every 10 minutes
+maintenance_loop(interval=600)
+```
+
+---
+
+## Constants
+
+| Name | Value | Description |
+|------|-------|-------------|
+| `REPO` | `"gastown-publish/gasclaw"` | GitHub repository identifier |

--- a/docs/api/migration.md
+++ b/docs/api/migration.md
@@ -1,0 +1,314 @@
+# migration.py
+
+Migration utilities for transitioning from Gastown to gasclaw.
+
+## Overview
+
+This module provides functionality to detect existing Gastown installations and migrate their configuration to gasclaw format. It handles:
+
+- Detection of classic Gastown setups (environment variables or config files)
+- Backup creation before migration
+- Configuration format conversion
+- Interactive prompting for missing required values
+
+## Classes
+
+### `MigrationResult`
+
+Result of a migration attempt.
+
+```python
+@dataclass
+class MigrationResult
+```
+
+#### Attributes
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `success` | `bool` | — | Whether migration succeeded |
+| `dry_run` | `bool` | — | Whether this was a dry run |
+| `gastown_detected` | `bool` | — | Whether Gastown installation was detected |
+| `backup_path` | `Path \| None` | `None` | Path to backup directory |
+| `migrated_keys` | `list[str]` | `[]` | List of migrated configuration keys |
+| `env_file_path` | `Path \| None` | `None` | Path to created env file |
+| `error_message` | `str` | `""` | Error message if migration failed |
+
+#### Methods
+
+##### `summary()`
+
+Return a human-readable summary of the migration.
+
+```python
+def summary(self) -> str
+```
+
+**Returns**: Formatted string with migration status and details
+
+---
+
+## Functions
+
+### `detect_gastown_setup()`
+
+Detect if Gastown is installed and configured.
+
+Checks for:
+
+1. `KIMI_API_KEY` environment variable (classic Gastown)
+2. Gastown config files in `~/.gt` or `~/.gastown`
+
+```python
+def detect_gastown_setup(
+    search_dirs: list[Path] | Path | None = None,
+) -> dict[str, Any]
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `search_dirs` | `list[Path] \| Path \| None` | `None` | Directories to search for Gastown configs |
+
+**Returns**: Dict with detection results including:
+
+```python
+{
+    "detected": bool,           # Whether Gastown was found
+    "source": str,              # "env_var" or "config_file"
+    "message": str,             # Human-readable status message
+    # If detected from env_var:
+    "kimi_api_key": str,
+    # If detected from config_file:
+    "config_dir": str,
+    "config": dict,
+    # If not detected:
+    "reason": str,
+}
+```
+
+---
+
+### `create_backup()`
+
+Create a backup of the Gastown configuration.
+
+```python
+def create_backup(gastown_dir: Path) -> Path | None
+```
+
+**Parameters**:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `gastown_dir` | `Path` | Path to the Gastown configuration directory |
+
+**Returns**: Path to the backup directory, or `None` if backup failed
+
+**Backup Naming**: `backup-gastown-{YYYYMMDD-HHMMSS}`
+
+---
+
+### `migrate_config()`
+
+Migrate Gastown configuration to gasclaw format.
+
+```python
+def migrate_config(
+    gastown_dir: Path | None = None,
+    env_file: Path | None = None,
+    interactive: bool = True,
+) -> dict[str, Any]
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `gastown_dir` | `Path \| None` | `None` | Path to Gastown config directory |
+| `env_file` | `Path \| None` | `None` | Path to write gasclaw .env file |
+| `interactive` | `bool` | `True` | Whether to prompt for missing config |
+
+**Returns**: Dict with migration results:
+
+```python
+{
+    "success": bool,
+    "migrated_keys": list[str],
+    "env_file": str | None,        # Path to created env file
+    "gastown_kimi_keys": str,      # Migrated key string
+    "error": str | None,           # Error message if failed
+}
+```
+
+**Behavior**:
+
+1. Detects Gastown setup using `detect_gastown_setup()`
+2. Converts key format (comma-separated → colon-separated)
+3. Prompts for missing required configuration
+4. Writes complete `.env` file with all variables
+
+---
+
+### `migrate()`
+
+Migrate Gastown configuration to gasclaw.
+
+This is the high-level migration function that orchestrates the entire process.
+
+```python
+def migrate(
+    gastown_dir: Path | None = None,
+    gasclaw_env_file: Path | None = None,
+    dry_run: bool = False,
+    interactive: bool = True,
+) -> MigrationResult
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `gastown_dir` | `Path \| None` | `None` | Path to Gastown config directory |
+| `gasclaw_env_file` | `Path \| None` | `None` | Path to write gasclaw .env file |
+| `dry_run` | `bool` | `False` | If True, only detect and report, don't modify |
+| `interactive` | `bool` | `True` | Whether to prompt for missing configuration |
+
+**Returns**: `MigrationResult` with full details of the migration
+
+**Migration Process**:
+
+1. Detect Gastown installation
+2. Create backup of existing config (if not dry run)
+3. Migrate configuration
+4. Write new `.env` file (if not dry run)
+5. Return detailed results
+
+---
+
+## Internal Functions
+
+### `_parse_gastown_keys()`
+
+Convert Gastown key format to gasclaw format.
+
+```python
+def _parse_gastown_keys(key_value: str) -> str
+```
+
+Gastown used comma-separated keys, gasclaw uses colon-separated.
+
+**Parameters**:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `key_value` | `str` | The key string from Gastown config |
+
+**Returns**: Colon-separated keys for gasclaw
+
+---
+
+### `_prompt_for_missing_config()`
+
+Prompt user for required gasclaw configuration.
+
+```python
+def _prompt_for_missing_config(interactive: bool = True) -> dict[str, str]
+```
+
+**Parameters**:
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `interactive` | `bool` | `True` | Whether to prompt interactively |
+
+**Returns**: Dict with configuration values
+
+**Prompts for**:
+
+- `OPENCLAW_KIMI_KEY` (if not in environment)
+- `TELEGRAM_BOT_TOKEN` (if not in environment)
+- `TELEGRAM_OWNER_ID` (if not in environment)
+
+---
+
+## Constants
+
+| Name | Value | Description |
+|------|-------|-------------|
+| `DEFAULT_GASTOWN_DIRS` | `[Path.home() / ".gt", Path.home() / ".gastown"]` | Default directories to search |
+| `DEFAULT_GASCLAW_ENV` | `Path("/workspace/.env")` | Default path for gasclaw env file |
+
+---
+
+## Usage Examples
+
+### Check if Gastown is Installed
+
+```python
+from gasclaw.migration import detect_gastown_setup
+
+result = detect_gastown_setup()
+if result["detected"]:
+    print(f"Found Gastown: {result['message']}")
+else:
+    print("No Gastown installation detected")
+```
+
+### Dry Run Migration
+
+```python
+from gasclaw.migration import migrate
+
+result = migrate(dry_run=True)
+print(result.summary())
+# Output: 🔄 DRY RUN - No changes were made
+```
+
+### Perform Migration
+
+```python
+from gasclaw.migration import migrate
+from pathlib import Path
+
+result = migrate(
+    gastown_dir=Path.home() / ".gt",
+    gasclaw_env_file=Path("/workspace/.env"),
+    interactive=True
+)
+
+if result.success:
+    print("Migration successful!")
+    print(f"Backup at: {result.backup_path}")
+    print(f"Config at: {result.env_file_path}")
+else:
+    print(f"Migration failed: {result.error_message}")
+```
+
+### Non-Interactive Migration
+
+```python
+from gasclaw.migration import migrate
+import os
+
+# Set required vars in environment
+os.environ["OPENCLAW_KIMI_KEY"] = "sk-openclaw-key"
+os.environ["TELEGRAM_BOT_TOKEN"] = "bot-token"
+os.environ["TELEGRAM_OWNER_ID"] = "12345"
+
+result = migrate(interactive=False)
+print(result.summary())
+```
+
+---
+
+## Migration Mapping
+
+| Gastown | Gasclaw | Notes |
+|---------|---------|-------|
+| `KIMI_API_KEY` | `GASTOWN_KIMI_KEYS` | Format: comma → colon separated |
+| — | `OPENCLAW_KIMI_KEY` | New required variable |
+| — | `TELEGRAM_BOT_TOKEN` | New required variable |
+| — | `TELEGRAM_OWNER_ID` | New required variable |
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,8 @@ nav:
     - Config: api/config.md
     - Health: api/health.md
     - Key Pool: api/key-pool.md
+    - Maintenance: api/maintenance.md
+    - Migration: api/migration.md
   - Troubleshooting: troubleshooting.md
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
## Summary

Adds comprehensive API documentation for `maintenance.py` and `migration.py` modules.

## Changes

- Created `docs/api/maintenance.md` documenting:
  - `CommandNotFoundError` exception class
  - All public functions with signatures and examples
  - Usage examples for single cycle and continuous loop
  
- Created `docs/api/migration.md` documenting:
  - `MigrationResult` dataclass
  - All migration functions with parameters and return values
  - Configuration mapping between Gastown and gasclaw
  - Usage examples for dry-run and full migration

- Updated `mkdocs.yml` navigation to include new API docs

## Test plan
- [x] Documentation renders correctly
- [x] All 606 unit tests pass

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)