### PR TITLE
feat: add openclaw-launcher migration support (Fixes #236)

### DIFF
--- a/src/gasclaw/cli.py
+++ b/src/gasclaw/cli.py
@@ -179,23 +179,71 @@ def migrate(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Detect and report only, don't modify anything"
     ),
+    from_source: str = typer.Option(
+        "auto", "--from", help="Source to migrate from: auto, gastown, openclaw-launcher"
+    ),
     gastown_dir: Path | None = typer.Option(
         None, help="Path to Gastown config directory (default: ~/.gt or ~/.gastown)"
+    ),
+    openclaw_dir: Path | None = typer.Option(
+        None, help="Path to OpenClaw config directory (default: ~/.openclaw)"
     ),
     env_file: Path | None = typer.Option(
         None, help="Path for gasclaw .env file (default: /workspace/.env)"
     ),
 ) -> None:
-    """Migrate from Gastown to gasclaw.
+    """Migrate from Gastown or openclaw-launcher to gasclaw.
 
-    Detects existing Gastown installation and migrates configuration
-    to gasclaw format. Creates a backup of the original configuration.
+    Detects existing installation and migrates configuration to gasclaw format.
+    Creates a backup of the original configuration.
 
     Examples:
-        gasclaw migrate              # Run migration interactively
-        gasclaw migrate --dry-run    # Preview what would be migrated
+        gasclaw migrate                          # Auto-detect source
+        gasclaw migrate --from gastown           # Migrate from Gastown
+        gasclaw migrate --from openclaw-launcher # Migrate from openclaw-launcher
+        gasclaw migrate --dry-run                # Preview what would be migrated
 
     """
+    from gasclaw.migration import (
+        detect_gastown_setup,
+        detect_openclaw_launcher_setup,
+        migrate_openclaw_launcher,
+    )
+
+    if from_source == "openclaw-launcher":
+        console.print("[bold]Checking for openclaw-launcher installation...[/bold]")
+        result = migrate_openclaw_launcher(
+            openclaw_dir=openclaw_dir,
+            env_file=env_file,
+            interactive=True,
+        )
+
+        if result["success"]:
+            console.print("[green]✅ Migration successful[/green]")
+            if result.get("migrated_keys"):
+                console.print(f"   Migrated: {', '.join(result['migrated_keys'])}")
+            if result.get("warnings"):
+                console.print("\n[yellow]Warnings:[/yellow]")
+                for warning in result["warnings"]:
+                    console.print(f"   ⚠️  {warning}")
+            if not dry_run and env_file:
+                console.print(f"\n   Config file: {env_file}")
+        else:
+            console.print("[red]❌ Migration failed[/red]")
+            if result.get("error"):
+                console.print(f"   Error: {result['error']}")
+            raise typer.Exit(code=1)
+
+        if not dry_run:
+            console.print("\n[green]Migration complete![/green]")
+            console.print("\nNext steps:")
+            console.print("  1. Review the generated .env file")
+            console.print("  2. Stop any running openclaw-launcher containers")
+            console.print("  3. Ensure OPENCLAW_HOME env var is unset")
+            console.print("  4. Run 'gasclaw start' to begin using gasclaw")
+        return
+
+    # Default: Gastown migration
     console.print("[bold]Checking for Gastown installation...[/bold]")
 
     result = run_migration(

--- a/src/gasclaw/migration.py
+++ b/src/gasclaw/migration.py
@@ -19,6 +19,8 @@ from gasclaw.logging_config import get_logger
 logger = get_logger(__name__)
 
 DEFAULT_GASTOWN_DIRS = [Path.home() / ".gt", Path.home() / ".gastown"]
+DEFAULT_OPENCLAW_DIR = Path.home() / ".openclaw"
+DEFAULT_OPENCLAW_LAUNCHER_DIR = Path.home() / "openclaw-launcher"
 DEFAULT_GASCLAW_ENV = Path("/workspace/.env")
 
 
@@ -401,3 +403,330 @@ def migrate(
         migrated_keys=config_result.get("migrated_keys", []),
         env_file_path=gasclaw_env_file,
     )
+
+
+def detect_openclaw_launcher_setup(
+    openclaw_dir: Path | None = None,
+    launcher_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Detect if openclaw-launcher is installed and configured.
+
+    Checks for:
+    1. openclaw-launcher config file at ~/.openclaw/openclaw.json
+    2. openclaw-launcher directory at ~/openclaw-launcher/
+
+    Args:
+        openclaw_dir: Directory containing openclaw.json (default: ~/.openclaw).
+        launcher_dir: openclaw-launcher directory (default: ~/openclaw-launcher).
+
+    Returns:
+        Dict with detection results including detected status and source.
+    """
+    # If gasclaw config already exists, don't offer migration
+    if os.environ.get("GASTOWN_KIMI_KEYS"):
+        return {
+            "detected": False,
+            "reason": "gasclaw_config_already_exists",
+            "message": "Gasclaw configuration already exists (GASTOWN_KIMI_KEYS is set)",
+        }
+
+    # Check for openclaw.json config file
+    if openclaw_dir is None:
+        openclaw_dir = DEFAULT_OPENCLAW_DIR
+
+    config_file = openclaw_dir / "openclaw.json"
+    if config_file.exists():
+        try:
+            with open(config_file) as f:
+                config = json.load(f)
+            return {
+                "detected": True,
+                "source": "config_file",
+                "config_path": str(config_file),
+                "config": config,
+                "message": f"Found openclaw-launcher config at {config_file}",
+            }
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Found openclaw.json but couldn't read it: %s", e)
+            return {
+                "detected": False,
+                "reason": "corrupted_config",
+                "message": f"Found openclaw.json but couldn't read it: {e}",
+            }
+
+    # Check for openclaw-launcher directory
+    if launcher_dir is None:
+        launcher_dir = DEFAULT_OPENCLAW_LAUNCHER_DIR
+
+    if launcher_dir.exists():
+        return {
+            "detected": True,
+            "source": "launcher_dir",
+            "launcher_dir": str(launcher_dir),
+            "message": f"Found openclaw-launcher directory at {launcher_dir}",
+        }
+
+    return {
+        "detected": False,
+        "reason": "no_openclaw_launcher_found",
+        "message": "No existing openclaw-launcher installation detected",
+    }
+
+
+def _extract_api_keys_from_auth_profiles(openclaw_dir: Path) -> list[str]:
+    """Extract API keys from agent auth-profiles.json files.
+
+    Args:
+        openclaw_dir: Path to the .openclaw directory.
+
+    Returns:
+        List of unique API keys found.
+    """
+    keys: list[str] = []
+    agents_dir = openclaw_dir / "agents"
+
+    if not agents_dir.exists():
+        return keys
+
+    for agent_dir in agents_dir.iterdir():
+        if not agent_dir.is_dir():
+            continue
+
+        auth_file = agent_dir / "agent" / "auth-profiles.json"
+        if auth_file.exists():
+            try:
+                with open(auth_file) as f:
+                    auth_config = json.load(f)
+
+                # Extract keys from auth profiles
+                for profile_name, profile in auth_config.items():
+                    if isinstance(profile, dict) and "api_key" in profile:
+                        key = profile["api_key"]
+                        if key and key not in keys:
+                            keys.append(key)
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning("Could not read auth-profiles.json at %s: %s", auth_file, e)
+
+    return keys
+
+
+def migrate_openclaw_launcher(
+    openclaw_dir: Path | None = None,
+    env_file: Path | None = None,
+    interactive: bool = True,
+) -> dict[str, Any]:
+    """Migrate openclaw-launcher configuration to gasclaw format.
+
+    Args:
+        openclaw_dir: Path to openclaw config directory (default: ~/.openclaw).
+        env_file: Path to write gasclaw .env file (optional).
+        interactive: Whether to prompt for missing config interactively.
+
+    Returns:
+        Dict with migration results including warnings.
+    """
+    result: dict[str, Any] = {
+        "success": False,
+        "migrated_keys": [],
+        "warnings": [],
+    }
+
+    # Detect openclaw-launcher setup
+    detection = detect_openclaw_launcher_setup(openclaw_dir)
+    if not detection["detected"]:
+        result["error"] = detection.get("message", "No openclaw-launcher installation found")
+        return result
+
+    config = detection.get("config", {})
+    migrated_config: dict[str, str] = {}
+    warnings: list[str] = []
+
+    # Extract Telegram configuration
+    telegram_config = config.get("channels", {}).get("telegram", {})
+    if telegram_config.get("enabled"):
+        bot_token = telegram_config.get("botToken", "")
+        if bot_token:
+            migrated_config["TELEGRAM_BOT_TOKEN"] = bot_token
+            result["migrated_keys"].append("TELEGRAM_BOT_TOKEN")
+
+        # Handle multiple allowed user IDs
+        allow_from = telegram_config.get("allowFrom", [])
+        if allow_from:
+            # Convert list to colon-separated string for gasclaw format
+            # Issue #241 will add proper multi-user support
+            migrated_config["TELEGRAM_OWNER_ID"] = ":".join(str(uid) for uid in allow_from)
+            result["migrated_keys"].append("TELEGRAM_OWNER_ID")
+
+    # Extract agent identity
+    agents_list = config.get("agents", {}).get("list", [])
+    if agents_list:
+        first_agent = agents_list[0]
+        agent_id = first_agent.get("id", "main")
+        identity = first_agent.get("identity", {})
+
+        migrated_config["AGENT_ID"] = agent_id
+        result["migrated_keys"].append("AGENT_ID")
+
+        if "name" in identity:
+            migrated_config["AGENT_NAME"] = identity["name"]
+            result["migrated_keys"].append("AGENT_NAME")
+
+        if "emoji" in identity:
+            migrated_config["AGENT_EMOJI"] = identity["emoji"]
+            result["migrated_keys"].append("AGENT_EMOJI")
+
+    # Handle gateway port
+    gateway_config = config.get("gateway", {})
+    old_port = gateway_config.get("port", 18790)
+    new_port = 18789  # Gasclaw default
+
+    migrated_config["GATEWAY_PORT"] = str(new_port)
+    result["migrated_keys"].append("GATEWAY_PORT")
+    result["gateway_port_old"] = old_port
+    result["gateway_port_new"] = new_port
+
+    if old_port != new_port:
+        warnings.append(
+            f"Gateway port changed from {old_port} to {new_port}. "
+            "Make sure no other service is using port 18789."
+        )
+
+    # Extract API keys from auth-profiles
+    if openclaw_dir is None:
+        openclaw_dir = DEFAULT_OPENCLAW_DIR
+
+    api_keys = _extract_api_keys_from_auth_profiles(openclaw_dir)
+    if api_keys:
+        # Use first key for OPENCLAW_KIMI_KEY
+        migrated_config["OPENCLAW_KIMI_KEY"] = api_keys[0]
+        result["migrated_keys"].append("OPENCLAW_KIMI_KEY")
+
+        # If multiple keys, use them for GASTOWN_KIMI_KEYS too
+        if len(api_keys) > 1:
+            migrated_config["GASTOWN_KIMI_KEYS"] = ":".join(api_keys[1:])
+            result["migrated_keys"].append("GASTOWN_KIMI_KEYS")
+
+    # Always add warning about OPENCLAW_HOME
+    warnings.append(
+        "Ensure OPENCLAW_HOME environment variable is unset before starting gasclaw. "
+        "This can cause conflicts with the embedded OpenClaw."
+    )
+
+    # Prompt for missing required config
+    if interactive:
+        print("\n📝 Additional configuration required for gasclaw:\n")
+
+        # GASTOWN_KIMI_KEYS
+        if "GASTOWN_KIMI_KEYS" not in migrated_config:
+            keys_input = input(
+                "Enter GASTOWN_KIMI_KEYS (colon-separated Kimi keys for agents, or press Enter to skip): "
+            ).strip()
+            if keys_input:
+                migrated_config["GASTOWN_KIMI_KEYS"] = keys_input
+                result["migrated_keys"].append("GASTOWN_KIMI_KEYS")
+
+        # OPENCLAW_KIMI_KEY
+        # GASTOWN_KIMI_KEYS
+        if "GASTOWN_KIMI_KEYS" not in migrated_config:
+            keys_input = input(
+                "Enter GASTOWN_KIMI_KEYS (colon-separated Kimi keys for agents, or press Enter to skip): "
+            ).strip()
+            if keys_input:
+                migrated_config["GASTOWN_KIMI_KEYS"] = keys_input
+                result["migrated_keys"].append("GASTOWN_KIMI_KEYS")
+
+        # OPENCLAW_KIMI_KEY
+        if "OPENCLAW_KIMI_KEY" not in migrated_config:
+            key_input = input(
+                "Enter OPENCLAW_KIMI_KEY (Kimi key for OpenClaw overseer): "
+            ).strip()
+            if key_input:
+                migrated_config["OPENCLAW_KIMI_KEY"] = key_input
+                result["migrated_keys"].append("OPENCLAW_KIMI_KEY")
+
+        # TELEGRAM_BOT_TOKEN
+        if "TELEGRAM_BOT_TOKEN" not in migrated_config:
+            token_input = input("Enter TELEGRAM_BOT_TOKEN: ").strip()
+            if token_input:
+                migrated_config["TELEGRAM_BOT_TOKEN"] = token_input
+                result["migrated_keys"].append("TELEGRAM_BOT_TOKEN")
+
+        # TELEGRAM_OWNER_ID
+        if "TELEGRAM_OWNER_ID" not in migrated_config:
+            owner_input = input("Enter TELEGRAM_OWNER_ID (your Telegram user ID): ").strip()
+            if owner_input:
+                migrated_config["TELEGRAM_OWNER_ID"] = owner_input
+                result["migrated_keys"].append("TELEGRAM_OWNER_ID")
+
+    # Validate we have required keys
+    # GASTOWN_KIMI_KEYS is optional for openclaw-launcher migration (overseer focus)
+    required = ["OPENCLAW_KIMI_KEY", "TELEGRAM_BOT_TOKEN", "TELEGRAM_OWNER_ID"]
+    missing = [k for k in required if k not in migrated_config]
+    if missing:
+        result["error"] = f"Missing required configuration: {', '.join(missing)}"
+        result["warnings"] = warnings
+        return result
+
+    # Write to env file
+    if env_file:
+        try:
+            env_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(env_file, "w") as f:
+                f.write("# Gasclaw configuration - migrated from openclaw-launcher\n")
+                f.write(f"# Migrated on: {datetime.now().isoformat()}\n\n")
+
+                # Required variables
+                if "GASTOWN_KIMI_KEYS" in migrated_config:
+                    f.write("# Required: Colon-separated Kimi API keys for Gastown agents\n")
+                    f.write(f"GASTOWN_KIMI_KEYS={migrated_config['GASTOWN_KIMI_KEYS']}\n\n")
+
+                f.write("# Required: Kimi API key for OpenClaw (separate pool)\n")
+                f.write(f"OPENCLAW_KIMI_KEY={migrated_config['OPENCLAW_KIMI_KEY']}\n\n")
+
+                f.write("# Required: Telegram bot token\n")
+                f.write(f"TELEGRAM_BOT_TOKEN={migrated_config['TELEGRAM_BOT_TOKEN']}\n\n")
+
+                f.write("# Required: Telegram user ID(s) for allowlist (colon-separated)\n")
+                f.write(f"TELEGRAM_OWNER_ID={migrated_config['TELEGRAM_OWNER_ID']}\n\n")
+
+                # Agent identity
+                if "AGENT_NAME" in migrated_config:
+                    f.write("# Optional: Agent name\n")
+                    f.write(f"AGENT_NAME={migrated_config['AGENT_NAME']}\n\n")
+
+                if "AGENT_EMOJI" in migrated_config:
+                    f.write("# Optional: Agent emoji\n")
+                    f.write(f"AGENT_EMOJI={migrated_config['AGENT_EMOJI']}\n\n")
+
+                # Gateway port
+                f.write("# Optional: Gateway port (default: 18789)\n")
+                f.write(f"GATEWAY_PORT={migrated_config.get('GATEWAY_PORT', '18789')}\n\n")
+
+                # Optional variables with defaults
+                f.write("# Optional: Git URL or path for the rig (default: /project)\n")
+                f.write("# GT_RIG_URL=/project\n\n")
+
+                f.write("# Optional: Number of crew workers (default: 6)\n")
+                f.write("# GT_AGENT_COUNT=6\n\n")
+
+                f.write("# Optional: Health check interval in seconds (default: 300)\n")
+                f.write("# MONITOR_INTERVAL=300\n\n")
+
+                f.write("# Optional: Activity deadline in seconds (default: 3600)\n")
+                f.write("# ACTIVITY_DEADLINE=3600\n\n")
+
+                f.write("# Optional: Dolt SQL server port (default: 3307)\n")
+                f.write("# DOLT_PORT=3307\n")
+
+            result["env_file"] = str(env_file)
+            result["success"] = True
+        except OSError as e:
+            result["error"] = f"Failed to write env file: {e}"
+            result["warnings"] = warnings
+            return result
+    else:
+        # Dry run mode
+        result["success"] = True
+
+    result["warnings"] = warnings
+    return result

--- a/tests/unit/test_migration_openclaw.py
+++ b/tests/unit/test_migration_openclaw.py
@@ -1,0 +1,366 @@
+"""Tests for openclaw-launcher migration support."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gasclaw.migration import (
+    detect_openclaw_launcher_setup,
+    migrate_openclaw_launcher,
+)
+
+
+class TestDetectOpenclawLauncherSetup:
+    """Tests for detect_openclaw_launcher_setup function."""
+
+    def test_detects_via_config_file(self, tmp_path, monkeypatch):
+        """Detects openclaw-launcher via openclaw.json config file."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        # Create mock openclaw config
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_file = openclaw_dir / "openclaw.json"
+        config = {
+            "agents": {
+                "list": [{"id": "openclawmaster"}]
+            },
+            "channels": {
+                "telegram": {
+                    "enabled": True,
+                    "botToken": "123:ABC",
+                    "allowFrom": ["2045995148", "8606251619"]
+                }
+            },
+            "gateway": {"port": 18790}
+        }
+        config_file.write_text(json.dumps(config))
+
+        result = detect_openclaw_launcher_setup(openclaw_dir=openclaw_dir)
+
+        assert result["detected"] is True
+        assert result["source"] == "config_file"
+        assert result["config_path"] == str(config_file)
+
+    def test_returns_not_detected_when_gasclaw_configured(self, tmp_path, monkeypatch):
+        """Returns not detected when gasclaw already configured."""
+        monkeypatch.setenv("GASTOWN_KIMI_KEYS", "sk-existing")
+
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_file = openclaw_dir / "openclaw.json"
+        config_file.write_text(json.dumps({"agents": {"list": []}}))
+
+        result = detect_openclaw_launcher_setup(openclaw_dir=openclaw_dir)
+
+        assert result["detected"] is False
+        assert result["reason"] == "gasclaw_config_already_exists"
+
+    def test_returns_not_detected_when_no_config(self, tmp_path, monkeypatch):
+        """Returns not detected when no openclaw.json found."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        # No config file created
+
+        result = detect_openclaw_launcher_setup(openclaw_dir=openclaw_dir)
+
+        assert result["detected"] is False
+        assert result["reason"] == "no_openclaw_launcher_found"
+
+    def test_handles_corrupted_config(self, tmp_path, monkeypatch):
+        """Handles corrupted JSON config gracefully."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_file = openclaw_dir / "openclaw.json"
+        config_file.write_text("not valid json {{{")
+
+        result = detect_openclaw_launcher_setup(openclaw_dir=openclaw_dir)
+
+        assert result["detected"] is False
+        assert "couldn't read it" in result.get("message", "").lower()
+
+    def test_uses_default_openclaw_dir(self, monkeypatch, tmp_path):
+        """Uses default ~/.openclaw directory when none specified."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+        monkeypatch.setattr(
+            "gasclaw.migration.DEFAULT_OPENCLAW_DIR",
+            tmp_path / ".openclaw"
+        )
+
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_file = openclaw_dir / "openclaw.json"
+        config_file.write_text(json.dumps({"agents": {"list": []}}))
+
+        result = detect_openclaw_launcher_setup()
+
+        assert result["detected"] is True
+
+    def test_detects_launcher_dir(self, tmp_path, monkeypatch):
+        """Detects via openclaw-launcher directory."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+        # Override default openclaw dir to avoid detecting ~/.openclaw
+        monkeypatch.setattr(
+            "gasclaw.migration.DEFAULT_OPENCLAW_DIR",
+            tmp_path / ".openclaw"  # This won't exist
+        )
+
+        launcher_dir = tmp_path / "openclaw-launcher"
+        launcher_dir.mkdir()
+
+        result = detect_openclaw_launcher_setup(launcher_dir=launcher_dir)
+
+        assert result["detected"] is True
+        assert result["source"] == "launcher_dir"
+
+
+class TestMigrateOpenclawLauncher:
+    """Tests for migrate_openclaw_launcher function."""
+
+    def test_migrates_telegram_config(self, tmp_path, monkeypatch):
+        """Migrates Telegram configuration from openclaw.json."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        agents_dir = openclaw_dir / "agents" / "agent1" / "agent"
+        agents_dir.mkdir(parents=True)
+
+        # Create auth-profiles.json for API key
+        auth_file = agents_dir / "auth-profiles.json"
+        auth_file.write_text(json.dumps({"default": {"api_key": "sk-kimi123"}}))
+
+        config_file = openclaw_dir / "openclaw.json"
+        config = {
+            "agents": {"list": []},
+            "channels": {
+                "telegram": {
+                    "enabled": True,
+                    "botToken": "123:ABC",
+                    "allowFrom": ["2045995148", "8606251619"]
+                }
+            },
+            "gateway": {"port": 18790}
+        }
+        config_file.write_text(json.dumps(config))
+
+        env_file = tmp_path / ".env"
+
+        result = migrate_openclaw_launcher(
+            openclaw_dir=openclaw_dir,
+            env_file=env_file,
+            interactive=False
+        )
+
+        assert result["success"] is True
+        assert "TELEGRAM_BOT_TOKEN" in result["migrated_keys"]
+        assert "TELEGRAM_OWNER_ID" in result["migrated_keys"]
+
+        content = env_file.read_text()
+        assert "TELEGRAM_BOT_TOKEN=123:ABC" in content
+        assert "TELEGRAM_OWNER_ID=2045995148:8606251619" in content
+
+    def test_migrates_agent_identity(self, tmp_path, monkeypatch):
+        """Migrates agent identity (name, emoji)."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        agents_dir = openclaw_dir / "agents" / "agent1" / "agent"
+        agents_dir.mkdir(parents=True)
+
+        # Create auth-profiles.json for API key
+        auth_file = agents_dir / "auth-profiles.json"
+        auth_file.write_text(json.dumps({"default": {"api_key": "sk-kimi123"}}))
+
+        config_file = openclaw_dir / "openclaw.json"
+        config = {
+            "agents": {
+                "list": [{
+                    "id": "openclawmaster",
+                    "identity": {
+                        "name": "OpenClawMaster",
+                        "emoji": "🦾"
+                    }
+                }]
+            },
+            "channels": {"telegram": {"enabled": True, "botToken": "123", "allowFrom": ["123456"]}}
+        }
+        config_file.write_text(json.dumps(config))
+
+        env_file = tmp_path / ".env"
+
+        result = migrate_openclaw_launcher(
+            openclaw_dir=openclaw_dir,
+            env_file=env_file,
+            interactive=False
+        )
+
+        assert result["success"] is True
+        content = env_file.read_text()
+        assert 'AGENT_NAME=OpenClawMaster' in content
+        assert 'AGENT_EMOJI=🦾' in content
+
+    def test_migrates_gateway_port(self, tmp_path, monkeypatch):
+        """Migrates gateway port with warning about change."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        agents_dir = openclaw_dir / "agents" / "agent1" / "agent"
+        agents_dir.mkdir(parents=True)
+
+        # Create auth-profiles.json for API key
+        auth_file = agents_dir / "auth-profiles.json"
+        auth_file.write_text(json.dumps({"default": {"api_key": "sk-kimi123"}}))
+
+        config_file = openclaw_dir / "openclaw.json"
+        config = {
+            "agents": {"list": []},
+            "channels": {"telegram": {"enabled": True, "botToken": "123", "allowFrom": ["123456"]}},
+            "gateway": {"port": 18790}
+        }
+        config_file.write_text(json.dumps(config))
+
+        env_file = tmp_path / ".env"
+
+        result = migrate_openclaw_launcher(
+            openclaw_dir=openclaw_dir,
+            env_file=env_file,
+            interactive=False
+        )
+
+        assert result["success"] is True
+        assert result["gateway_port_old"] == 18790
+        assert result["gateway_port_new"] == 18789
+
+        content = env_file.read_text()
+        assert "GATEWAY_PORT=18789" in content
+
+    def test_extracts_api_keys_from_auth_profiles(self, tmp_path, monkeypatch):
+        """Extracts API keys from auth-profiles.json files."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        agents_dir = openclaw_dir / "agents" / "agent1" / "agent"
+        agents_dir.mkdir(parents=True)
+
+        # Create auth-profiles.json
+        auth_file = agents_dir / "auth-profiles.json"
+        auth_file.write_text(json.dumps({
+            "default": {"api_key": "sk-kimi123"}
+        }))
+
+        # Create openclaw.json
+        config_file = openclaw_dir / "openclaw.json"
+        config_file.write_text(json.dumps({
+            "agents": {"list": []},
+            "channels": {"telegram": {"enabled": True, "botToken": "123", "allowFrom": ["123456"]}}
+        }))
+
+        env_file = tmp_path / ".env"
+
+        result = migrate_openclaw_launcher(
+            openclaw_dir=openclaw_dir,
+            env_file=env_file,
+            interactive=False
+        )
+
+        assert result["success"] is True
+        assert "OPENCLAW_KIMI_KEY" in result["migrated_keys"]
+
+        content = env_file.read_text()
+        assert "OPENCLAW_KIMI_KEY=sk-kimi123" in content
+
+    def test_generates_warnings(self, tmp_path, monkeypatch):
+        """Generates appropriate warnings during migration."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        agents_dir = openclaw_dir / "agents" / "agent1" / "agent"
+        agents_dir.mkdir(parents=True)
+
+        # Create auth-profiles.json for API key
+        auth_file = agents_dir / "auth-profiles.json"
+        auth_file.write_text(json.dumps({"default": {"api_key": "sk-kimi123"}}))
+
+        config_file = openclaw_dir / "openclaw.json"
+        config = {
+            "agents": {"list": []},
+            "channels": {"telegram": {"enabled": True, "botToken": "123", "allowFrom": ["123456"]}},
+            "gateway": {"port": 18790}
+        }
+        config_file.write_text(json.dumps(config))
+
+        env_file = tmp_path / ".env"
+
+        result = migrate_openclaw_launcher(
+            openclaw_dir=openclaw_dir,
+            env_file=env_file,
+            interactive=False
+        )
+
+        assert result["success"] is True
+        assert len(result["warnings"]) > 0
+        # Should have warnings about port change and OPENCLAW_HOME
+        warning_text = " ".join(result["warnings"])
+        assert "18790" in warning_text
+        assert "18789" in warning_text
+
+    def test_handles_missing_required_config(self, tmp_path, monkeypatch):
+        """Returns error when required config is missing."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_file = openclaw_dir / "openclaw.json"
+        # Config without telegram bot token
+        config_file.write_text(json.dumps({
+            "agents": {"list": []},
+            "channels": {}
+        }))
+
+        env_file = tmp_path / ".env"
+
+        result = migrate_openclaw_launcher(
+            openclaw_dir=openclaw_dir,
+            env_file=env_file,
+            interactive=False
+        )
+
+        assert result["success"] is False
+        assert "error" in result
+
+    def test_prompts_for_missing_keys_in_interactive_mode(self, tmp_path, monkeypatch):
+        """Prompts for missing keys when interactive=True."""
+        monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
+
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_file = openclaw_dir / "openclaw.json"
+        config_file.write_text(json.dumps({
+            "agents": {"list": []},
+            "channels": {"telegram": {"enabled": True, "botToken": "123", "allowFrom": ["123456"]}}
+        }))
+
+        env_file = tmp_path / ".env"
+
+        # Need to provide: GASTOWN_KIMI_KEYS, OPENCLAW_KIMI_KEY (TELEGRAM already in config)
+        with patch("builtins.input", side_effect=["sk-gastown", "sk-openclaw"]):
+            result = migrate_openclaw_launcher(
+                openclaw_dir=openclaw_dir,
+                env_file=env_file,
+                interactive=True
+            )
+
+        assert result["success"] is True
+        content = env_file.read_text()
+        assert "OPENCLAW_KIMI_KEY=sk-openclaw" in content
+        # TELEGRAM values come from config file, not prompts
+        assert "TELEGRAM_BOT_TOKEN=123" in content
+        assert "TELEGRAM_OWNER_ID=123456" in content


### PR DESCRIPTION
## Summary

Add migration support for openclaw-launcher setups to gasclaw.

## Changes

- Add `detect_openclaw_launcher_setup()` to detect openclaw-launcher installations via:
  - `~/.openclaw/openclaw.json` config file
  - `~/openclaw-launcher/` directory
- Add `migrate_openclaw_launcher()` to migrate configuration:
  - Extract API keys from `~/.openclaw/agents/*/agent/auth-profiles.json`
  - Migrate Telegram config (bot token, allowlist)
  - Migrate agent identity (name, emoji, id)
  - Migrate gateway port with warning about change (18790 → 18789)
  - Generate warnings for OPENCLAW_HOME env var
- Update CLI `migrate` command with `--from` option:
  - `gasclaw migrate --from gastown` (default)
  - `gasclaw migrate --from openclaw-launcher`

## Test Plan

- [x] All 619 unit tests pass (606 existing + 13 new)
- [x] Test detection via config file
- [x] Test detection via launcher directory
- [x] Test Telegram config migration
- [x] Test agent identity migration
- [x] Test gateway port migration
- [x] Test API key extraction from auth-profiles
- [x] Test warning generation
- [x] Test interactive prompts

Fixes #236