### PR TITLE
build: lower Python requirement from 3.13 to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "gasclaw"
 version = "0.2.0"
 description = "Gastown + OpenClaw + KimiGas in one container"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = [
     "typer>=0.21.0,<0.25.0",
     "click>=8.0.0,<9.0.0",
@@ -33,7 +33,7 @@ build-backend = "hatchling.build"
 packages = ["src/gasclaw"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
@@ -41,7 +41,7 @@ select = ["E", "F", "I", "UP", "W", "B", "C4", "SIM", "PERF"]
 ignore = ["B008"]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
## Summary

This PR lowers the Python version requirement from 3.13 to 3.12 to improve compatibility with CI environments and systems that don't yet have Python 3.13 available.

## Changes

- `requires-python` in pyproject.toml: `>=3.13` → `>=3.12`
- `target-version` in ruff config: `py313` → `py312`
- `python_version` in mypy config: `3.13` → `3.12`

## Related Issues

Fixes #257

## Test Plan

- [x] All 606 unit tests pass with Python 3.12
- [x] Project installs successfully with Python 3.12
- [x] No code changes required - only version metadata updated

## Backward Compatibility

This change is backward compatible. Users with Python 3.13 can still use the project, and it now also supports Python 3.12.