### PR TITLE
feat: auto-create issues from GitHub Actions failures (issue #248)

### DIFF
--- a/src/gasclaw/ci_monitor.py
+++ b/src/gasclaw/ci_monitor.py
@@ -1,0 +1,271 @@
+"""CI failure monitoring for GitHub Actions.
+
+Monitors GitHub Actions workflow runs and auto-creates issues for failures.
+State is persisted to avoid duplicate issues.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# State file location (persisted across restarts)
+DEFAULT_STATE_FILE = "/workspace/state/ci_failures.json"
+MAX_HISTORY_SIZE = 100  # Keep last 100 failure IDs to limit file size
+
+
+@dataclass
+class CIFailure:
+    """Represents a CI workflow failure."""
+
+    run_id: str
+    workflow_name: str
+    url: str
+    started_at: str
+
+    def unique_id(self) -> str:
+        """Generate unique identifier for deduplication."""
+        return f"{self.workflow_name}:{self.run_id}"
+
+
+def get_failed_workflows(repo: str) -> list[CIFailure]:
+    """Get list of failed workflow runs from GitHub CLI.
+
+    Args:
+        repo: Repository in format "owner/repo"
+
+    Returns:
+        List of CIFailure objects for failed runs
+    """
+    cmd = [
+        "gh", "run", "list",
+        "--repo", repo,
+        "--status", "failure",
+        "--json", "databaseId,name,status,conclusion,url,startedAt",
+        "--limit", "20"
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            logger.warning("gh run list failed: %s", result.stderr)
+            return []
+
+        runs = json.loads(result.stdout)
+        failures = []
+
+        for run in runs:
+            if run.get("conclusion") == "failure":
+                failures.append(CIFailure(
+                    run_id=str(run.get("databaseId", "")),
+                    workflow_name=run.get("name", "Unknown Workflow"),
+                    url=run.get("url", ""),
+                    started_at=run.get("startedAt", "")
+                ))
+
+        return failures
+
+    except json.JSONDecodeError as e:
+        logger.warning("Failed to parse gh output: %s", e)
+        return []
+    except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
+        logger.warning("Failed to get failed workflows: %s", e)
+        return []
+
+
+def load_seen_failures(state_file: str | None = None) -> set[str]:
+    """Load set of previously seen failure IDs.
+
+    Args:
+        state_file: Path to state file. Uses DEFAULT_STATE_FILE if not specified.
+
+    Returns:
+        Set of failure unique IDs that have been processed
+    """
+    path = Path(state_file or DEFAULT_STATE_FILE)
+
+    if not path.exists():
+        return set()
+
+    try:
+        with open(path) as f:
+            data = json.load(f)
+            return set(data.get("seen", []))
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning("Failed to load seen failures: %s", e)
+        return set()
+
+
+def save_seen_failures(seen: set[str], state_file: str | None = None) -> None:
+    """Save set of seen failure IDs to state file.
+
+    Args:
+        seen: Set of failure unique IDs
+        state_file: Path to state file. Uses DEFAULT_STATE_FILE if not specified.
+    """
+    path = Path(state_file or DEFAULT_STATE_FILE)
+
+    # Ensure directory exists
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with open(path, "w") as f:
+            json.dump({"seen": sorted(seen)}, f, indent=2)
+    except IOError as e:
+        logger.warning("Failed to save seen failures: %s", e)
+
+
+def is_duplicate_issue(failure_id: str, seen: set[str]) -> bool:
+    """Check if a failure has already been reported.
+
+    Args:
+        failure_id: Unique identifier for the failure
+        seen: Set of previously seen failure IDs
+
+    Returns:
+        True if failure was already reported
+    """
+    return failure_id in seen
+
+
+def create_failure_issue(repo: str, failure: CIFailure) -> bool:
+    """Create a GitHub issue for a CI failure.
+
+    Args:
+        repo: Repository in format "owner/repo"
+        failure: CIFailure to report
+
+    Returns:
+        True if issue was created successfully
+    """
+    title = f"CI Failure: {failure.workflow_name} (run #{failure.run_id})"
+
+    body = f"""## CI Workflow Failure
+
+**Workflow:** {failure.workflow_name}
+**Run ID:** {failure.run_id}
+**Started:** {failure.started_at}
+**URL:** {failure.url}
+
+This issue was automatically created by the Gasclaw maintainer bot when a GitHub Actions workflow failed.
+
+---
+*This is an automated message. Please investigate the failure and close this issue when resolved.*
+"""
+
+    cmd = [
+        "gh", "issue", "create",
+        "--repo", repo,
+        "--title", title,
+        "--body", body,
+        "--label", "ci-failure"
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode == 0:
+            logger.info("Created issue for %s run %s", failure.workflow_name, failure.run_id)
+            return True
+        else:
+            logger.warning("Failed to create issue: %s", result.stderr)
+            return False
+
+    except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
+        logger.warning("Failed to create issue: %s", e)
+        return False
+
+
+def format_failure_message(failure: CIFailure) -> str:
+    """Format a failure notification for Telegram.
+
+    Args:
+        failure: CIFailure to format
+
+    Returns:
+        Markdown-formatted message
+    """
+    return (
+        f"🔴 *CI Failure: {failure.workflow_name}*\n"
+        f"Run: #{failure.run_id}\n"
+        f"[View on GitHub]({failure.url})"
+    )
+
+
+def check_ci_failures(
+    repo: str,
+    state_file: str | None = None,
+    send_notification: callable | None = None
+) -> dict[str, int]:
+    """Check for CI failures and create issues for new ones.
+
+    Args:
+        repo: Repository in format "owner/repo"
+        state_file: Path to state file for persistence
+        send_notification: Optional callback for notifications (e.g., Telegram)
+
+    Returns:
+        Dict with counts: {"checked": N, "new": N, "duplicates": N}
+    """
+    result = {"checked": 0, "new": 0, "duplicates": 0}
+
+    # Get current failures
+    failures = get_failed_workflows(repo)
+    result["checked"] = len(failures)
+
+    if not failures:
+        logger.debug("No CI failures found")
+        return result
+
+    # Load previously seen failures
+    seen = load_seen_failures(state_file)
+    new_seen = seen.copy()
+
+    # Process each failure
+    for failure in failures:
+        failure_id = failure.run_id  # Use run_id for deduplication
+
+        if is_duplicate_issue(failure_id, seen):
+            result["duplicates"] += 1
+            logger.debug("Skipping duplicate failure: %s", failure_id)
+            new_seen.add(failure_id)  # Keep in history
+            continue
+
+        # Create issue for new failure
+        if create_failure_issue(repo, failure):
+            result["new"] += 1
+            new_seen.add(failure_id)
+
+            # Send notification if callback provided
+            if send_notification:
+                try:
+                    send_notification(format_failure_message(failure))
+                except Exception as e:
+                    logger.warning("Failed to send notification: %s", e)
+
+    # Limit history size
+    if len(new_seen) > MAX_HISTORY_SIZE:
+        # Keep most recent (sorted by ID which is roughly chronological)
+        new_seen = set(sorted(new_seen)[-MAX_HISTORY_SIZE:])
+
+    # Save updated history
+    save_seen_failures(new_seen, state_file)
+
+    return result

--- a/tests/unit/test_ci_monitor.py
+++ b/tests/unit/test_ci_monitor.py
@@ -1,0 +1,321 @@
+"""Tests for CI failure monitoring (issue #248)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gasclaw.ci_monitor import (
+    CIFailure,
+    check_ci_failures,
+    create_failure_issue,
+    format_failure_message,
+    get_failed_workflows,
+    is_duplicate_issue,
+    load_seen_failures,
+    save_seen_failures,
+)
+
+
+class TestGetFailedWorkflows:
+    """Tests for getting failed workflows from gh CLI."""
+
+    def test_get_failed_workflows_success(self):
+        """Successfully parse failed workflows from gh CLI output."""
+        mock_output = """
+        [
+          {
+            "databaseId": 12345,
+            "name": "Test Workflow",
+            "status": "completed",
+            "conclusion": "failure",
+            "url": "https://github.com/gastown-publish/gasclaw/actions/runs/12345",
+            "startedAt": "2026-03-03T10:00:00Z"
+          },
+          {
+            "databaseId": 12346,
+            "name": "Build Workflow",
+            "status": "completed",
+            "conclusion": "failure",
+            "url": "https://github.com/gastown-publish/gasclaw/actions/runs/12346",
+            "startedAt": "2026-03-03T11:00:00Z"
+          }
+        ]
+        """
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=mock_output,
+                stderr=""
+            )
+            failures = get_failed_workflows("gastown-publish/gasclaw")
+
+        assert len(failures) == 2
+        assert failures[0].run_id == "12345"
+        assert failures[0].workflow_name == "Test Workflow"
+        assert failures[0].url == "https://github.com/gastown-publish/gasclaw/actions/runs/12345"
+
+    def test_get_failed_workflows_empty(self):
+        """Handle empty list of failures."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
+            failures = get_failed_workflows("gastown-publish/gasclaw")
+
+        assert failures == []
+
+    def test_get_failed_workflows_command_failure(self):
+        """Handle gh CLI command failure."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="error"
+            )
+            failures = get_failed_workflows("gastown-publish/gasclaw")
+
+        assert failures == []
+
+    def test_get_failed_workflows_invalid_json(self):
+        """Handle invalid JSON output."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="invalid json",
+                stderr=""
+            )
+            failures = get_failed_workflows("gastown-publish/gasclaw")
+
+        assert failures == []
+
+    def test_get_failed_workflows_exception(self):
+        """Handle subprocess exception."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("gh not found")
+            failures = get_failed_workflows("gastown-publish/gasclaw")
+
+        assert failures == []
+
+
+class TestIsDuplicateIssue:
+    """Tests for duplicate issue detection."""
+
+    def test_is_duplicate_true(self):
+        """Returns True if run_id already seen."""
+        seen = {"12345", "12346"}
+        assert is_duplicate_issue("12345", seen) is True
+
+    def test_is_duplicate_false(self):
+        """Returns False if run_id not seen."""
+        seen = {"12345", "12346"}
+        assert is_duplicate_issue("99999", seen) is False
+
+    def test_is_duplicate_empty(self):
+        """Returns False for empty seen set."""
+        assert is_duplicate_issue("12345", set()) is False
+
+
+class TestCreateFailureIssue:
+    """Tests for creating GitHub issues."""
+
+    def test_create_issue_success(self):
+        """Successfully create an issue."""
+        failure = CIFailure(
+            run_id="12345",
+            workflow_name="Test Workflow",
+            url="https://github.com/org/repo/actions/runs/12345",
+            started_at="2026-03-03T10:00:00Z"
+        )
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = create_failure_issue("gastown-publish/gasclaw", failure)
+
+        assert result is True
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args[0][0]
+        assert "gh" in call_args
+        assert "issue" in call_args
+        assert "create" in call_args
+        assert "ci-failure" in call_args
+
+    def test_create_issue_failure(self):
+        """Handle issue creation failure."""
+        failure = CIFailure(
+            run_id="12345",
+            workflow_name="Test Workflow",
+            url="https://github.com/org/repo/actions/runs/12345",
+            started_at="2026-03-03T10:00:00Z"
+        )
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+            result = create_failure_issue("gastown-publish/gasclaw", failure)
+
+        assert result is False
+
+    def test_create_issue_exception(self):
+        """Handle exception during issue creation."""
+        failure = CIFailure(
+            run_id="12345",
+            workflow_name="Test Workflow",
+            url="https://github.com/org/repo/actions/runs/12345",
+            started_at="2026-03-03T10:00:00Z"
+        )
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = Exception("command failed")
+            result = create_failure_issue("gastown-publish/gasclaw", failure)
+
+        assert result is False
+
+
+class TestFormatFailureMessage:
+    """Tests for formatting failure notifications."""
+
+    def test_format_failure_message(self):
+        """Format a failure for Telegram notification."""
+        failure = CIFailure(
+            run_id="12345",
+            workflow_name="Test Workflow",
+            url="https://github.com/org/repo/actions/runs/12345",
+            started_at="2026-03-03T10:00:00Z"
+        )
+
+        message = format_failure_message(failure)
+
+        assert "Test Workflow" in message
+        assert "12345" in message
+        assert "https://github.com/org/repo/actions/runs/12345" in message
+        assert "CI Failure" in message
+
+
+class TestSeenFailuresPersistence:
+    """Tests for loading/saving seen failure IDs."""
+
+    def test_load_seen_failures_file_exists(self, tmp_path):
+        """Load seen failures from existing file."""
+        state_file = tmp_path / "ci_failures.json"
+        state_file.write_text(json.dumps({"seen": ["12345", "12346"]}))
+
+        seen = load_seen_failures(str(state_file))
+
+        assert seen == {"12345", "12346"}
+
+    def test_load_seen_failures_missing_file(self, tmp_path):
+        """Return empty set for missing file."""
+        seen = load_seen_failures(str(tmp_path / "nonexistent.json"))
+        assert seen == set()
+
+    def test_load_seen_failures_invalid_json(self, tmp_path):
+        """Return empty set for invalid JSON."""
+        state_file = tmp_path / "ci_failures.json"
+        state_file.write_text("invalid json")
+
+        seen = load_seen_failures(str(state_file))
+        assert seen == set()
+
+    def test_save_seen_failures(self, tmp_path):
+        """Save seen failures to file."""
+        state_file = tmp_path / "ci_failures.json"
+
+        save_seen_failures({"12345", "12346"}, str(state_file))
+
+        data = json.loads(state_file.read_text())
+        assert set(data["seen"]) == {"12345", "12346"}
+
+    def test_save_seen_failures_creates_dir(self, tmp_path):
+        """Create directory if needed when saving."""
+        state_file = tmp_path / "subdir" / "ci_failures.json"
+
+        save_seen_failures({"12345"}, str(state_file))
+
+        assert state_file.exists()
+
+
+class TestCheckCIFailures:
+    """Integration tests for the main check function."""
+
+    def test_check_ci_failures_creates_issues(self):
+        """Create issues for new failures."""
+        failures = [
+            CIFailure(
+                run_id="12345",
+                workflow_name="Test Workflow",
+                url="https://github.com/org/repo/actions/runs/12345",
+                started_at="2026-03-03T10:00:00Z"
+            )
+        ]
+
+        with patch("gasclaw.ci_monitor.get_failed_workflows", return_value=failures):
+            with patch("gasclaw.ci_monitor.load_seen_failures", return_value=set()):
+                with patch("gasclaw.ci_monitor.save_seen_failures") as mock_save:
+                    with patch("gasclaw.ci_monitor.create_failure_issue", return_value=True):
+                        result = check_ci_failures("gastown-publish/gasclaw")
+
+        assert result["checked"] == 1
+        assert result["new"] == 1
+        assert result["duplicates"] == 0
+        mock_save.assert_called_once()
+
+    def test_check_ci_failures_skips_duplicates(self):
+        """Skip duplicate failures but keep them in history."""
+        failures = [
+            CIFailure(
+                run_id="12345",
+                workflow_name="Test Workflow",
+                url="https://github.com/org/repo/actions/runs/12345",
+                started_at="2026-03-03T10:00:00Z"
+            )
+        ]
+
+        with patch("gasclaw.ci_monitor.get_failed_workflows", return_value=failures):
+            with patch("gasclaw.ci_monitor.load_seen_failures", return_value={"12345"}):
+                with patch("gasclaw.ci_monitor.save_seen_failures") as mock_save:
+                    with patch("gasclaw.ci_monitor.create_failure_issue") as mock_create:
+                        result = check_ci_failures("gastown-publish/gasclaw")
+
+        assert result["checked"] == 1
+        assert result["new"] == 0
+        assert result["duplicates"] == 1
+        mock_create.assert_not_called()
+        # History is saved even for duplicates (to keep them in history)
+        mock_save.assert_called_once()
+
+    def test_check_ci_failures_no_failures(self):
+        """Handle no failures case."""
+        with patch("gasclaw.ci_monitor.get_failed_workflows", return_value=[]):
+            with patch("gasclaw.ci_monitor.load_seen_failures", return_value=set()):
+                result = check_ci_failures("gastown-publish/gasclaw")
+
+        assert result["checked"] == 0
+        assert result["new"] == 0
+        assert result["duplicates"] == 0
+
+    def test_check_ci_failures_limits_history(self):
+        """Limit seen failures history to prevent unbounded growth."""
+        # Create many old failures plus one new one
+        old_ids = [str(i) for i in range(150)]
+        failures = [
+            CIFailure(
+                run_id="99999",  # New failure not in history
+                workflow_name="Test Workflow",
+                url="https://github.com/org/repo/actions/runs/99999",
+                started_at="2026-03-03T10:00:00Z"
+            )
+        ]
+
+        with patch("gasclaw.ci_monitor.get_failed_workflows", return_value=failures):
+            with patch("gasclaw.ci_monitor.load_seen_failures", return_value=set(old_ids)):
+                with patch("gasclaw.ci_monitor.save_seen_failures") as mock_save:
+                    with patch("gasclaw.ci_monitor.create_failure_issue", return_value=True):
+                        check_ci_failures("gastown-publish/gasclaw")
+
+        # Check that save was called with limited set
+        assert mock_save.called
+        saved = mock_save.call_args[0][0]
+        assert len(saved) == 100  # Max history size


### PR DESCRIPTION
## Summary

Implements CI failure monitoring that automatically creates GitHub issues when workflows fail (issue #248).

## Changes

- **ci_monitor.py**: New module for CI failure monitoring
- **check_ci_failures()**: Main entry point for checking and reporting
- **Duplicate detection**: Uses persisted state file to avoid duplicates
- **State persistence**: /workspace/state/ci_failures.json
- **History limiting**: Keeps last 100 failure IDs to prevent unbounded growth

## Workflow

1. Query `gh run list --status failure` for failed workflows
2. Check each failure against seen history
3. Create GitHub issue with `ci-failure` label for new failures
4. Send Telegram notification (via callback)
5. Update seen history

## Example usage

```python
from gasclaw.ci_monitor import check_ci_failures

# Check for failures and create issues
result = check_ci_failures("gastown-publish/gasclaw")
print(f"Checked: {result['checked']}, New: {result['new']}, Duplicates: {result['duplicates']}")
```

## State file format

```json
{
  "seen": ["12345", "12346", "12347"]
}
```

## Test Plan

- [x] All 657 unit tests pass
- [x] 21 new tests for CI monitor functionality
- [x] Tests cover: success, empty, failures, exceptions, duplicates, history limiting
- [x] All subprocess calls mocked for unit testing

## Related Issues

Closes #248