### PR TITLE
feat: host CLI for managing gasclaw instances (issue #247, #246)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dev = [
 ]
 
 [project.scripts]
-gasclaw = "gasclaw.cli:app"
+gasclaw = "gasclaw.host_cli:app"
+gasclaw-container = "gasclaw.cli:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/gasclaw/host_cli.py
+++ b/src/gasclaw/host_cli.py
@@ -1,0 +1,810 @@
+"""Host CLI for managing gasclaw instances outside Docker container.
+
+This module provides commands that run on the host computer to manage
+gasclaw containers, configuration, and lifecycle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Confirm, IntPrompt, Prompt
+from rich.table import Table
+
+from gasclaw import __version__
+
+app = typer.Typer(help="Gasclaw Host CLI — manage gasclaw containers from the host.")
+console = Console()
+
+DEFAULT_CONTAINER_NAME = "gasclaw"
+DEFAULT_PROJECT_DIR = "."
+
+
+def _is_inside_container() -> bool:
+    """Detect if running inside a Docker container."""
+    # Check for .dockerenv file
+    if Path("/.dockerenv").exists():
+        return True
+    # Check cgroup for docker
+    try:
+        cgroup = Path("/proc/self/cgroup").read_text()
+        return "docker" in cgroup or "containerd" in cgroup
+    except (FileNotFoundError, PermissionError):
+        pass
+    return False
+
+
+def _get_docker_compose_cmd() -> list[str]:
+    """Get the docker compose command (v2 preferred, fallback to v1)."""
+    # Try docker compose (v2) first
+    result = subprocess.run(
+        ["docker", "compose", "version"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return ["docker", "compose"]
+    # Fallback to docker-compose (v1)
+    return ["docker-compose"]
+
+
+def _run_docker(args: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    """Run a docker command and return the result."""
+    cmd = ["docker"] + args
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def _run_docker_compose(
+    args: list[str],
+    project_dir: Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess:
+    """Run docker compose command in the specified project directory."""
+    cmd = _get_docker_compose_cmd() + args
+    cwd = project_dir if project_dir else Path.cwd()
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd, check=check)
+
+
+def _container_exists(name: str = DEFAULT_CONTAINER_NAME) -> bool:
+    """Check if a container with the given name exists."""
+    result = _run_docker(["ps", "-a", "--format", "{{.Names}}"], check=False)
+    return name in result.stdout.splitlines()
+
+
+def _container_running(name: str = DEFAULT_CONTAINER_NAME) -> bool:
+    """Check if a container with the given name is running."""
+    result = _run_docker(
+        ["ps", "--format", "{{.Names}}", "--filter", f"name={name}"],
+        check=False,
+    )
+    return name in result.stdout.splitlines()
+
+
+def _get_container_status(name: str = DEFAULT_CONTAINER_NAME) -> dict[str, str]:
+    """Get detailed status of a container."""
+    result = _run_docker(
+        [
+            "inspect",
+            "--format",
+            "{{.State.Status}}|{{.State.Health.Status}}|{{.Config.Image}}",
+            name,
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        return {"exists": "false", "status": "not_found"}
+
+    parts = result.stdout.strip().split("|")
+    return {
+        "exists": "true",
+        "status": parts[0] if len(parts) > 0 else "unknown",
+        "health": parts[1] if len(parts) > 1 else "unknown",
+        "image": parts[2] if len(parts) > 2 else "unknown",
+    }
+
+
+@app.callback()
+def host_callback() -> None:
+    """Host CLI callback — detect if inside container and warn."""
+    if _is_inside_container():
+        console.print(
+            "[yellow]Warning: You appear to be running inside a Docker container.[/yellow]\n"
+            "Host CLI commands manage containers from the outside.\n"
+            "Use the regular 'gasclaw' command inside the container instead."
+        )
+        raise typer.Exit(code=1)
+
+
+@app.command()
+def init(
+    project_dir: Annotated[
+        Path,
+        typer.Option(help="Directory to initialize gasclaw project"),
+    ] = Path("."),
+    skip_wizard: Annotated[
+        bool,
+        typer.Option("--skip-wizard", help="Skip interactive wizard, create default config"),
+    ] = False,
+) -> None:
+    """Initialize a new gasclaw project with onboarding wizard."""
+    console.print(Panel.fit("[bold blue]🦀 Gasclaw Initialization Wizard[/bold blue]"))
+    console.print()
+
+    project_path = project_dir.resolve()
+    project_path.mkdir(parents=True, exist_ok=True)
+
+    # Check if already initialized
+    env_file = project_path / ".env"
+    compose_file = project_path / "docker-compose.yml"
+
+    if env_file.exists() or compose_file.exists():
+        if not Confirm.ask(
+            f"[yellow]Gasclaw files already exist in {project_path}.[/yellow] Overwrite?",
+            default=False,
+        ):
+            console.print("[yellow]Initialization cancelled.[/yellow]")
+            raise typer.Exit(code=0)
+
+    if skip_wizard:
+        _create_default_config(project_path)
+        console.print(f"[green]✅ Default config created in {project_path}[/green]")
+        return
+
+    # Interactive wizard
+    console.print("[bold]Let's set up your gasclaw instance...[/bold]\n")
+
+    # 1. Project type / GitHub setup
+    console.print("[bold cyan]Step 1: Project Setup[/bold cyan]")
+    project_choice = Prompt.ask(
+        "Do you want to create a new GitHub project or use an existing one?",
+        choices=["new", "existing"],
+        default="new",
+    )
+
+    github_repo = None
+    if project_choice == "new":
+        repo_name = Prompt.ask("Enter name for new GitHub repository", default="my-gasclaw-project")
+        console.print(f"[dim]Repository '{repo_name}' will be created when gasclaw starts[/dim]")
+        github_repo = repo_name
+    else:
+        github_repo = Prompt.ask("Enter existing GitHub repository URL or path")
+
+    # 2. Kimi API Keys
+    console.print("\n[bold cyan]Step 2: Kimi API Configuration[/bold cyan]")
+    console.print("You need Kimi API keys from https://platform.kimi.com/")
+
+    gastown_keys = []
+    while True:
+        key = Prompt.ask(
+            "Enter Kimi API key for Gastown agents",
+            password=True,
+        )
+        if key.startswith("sk-"):
+            gastown_keys.append(key)
+            break
+        console.print("[red]Invalid key format. Key should start with 'sk-'[/red]")
+
+    while Confirm.ask("Add another Gastown agent key?", default=False):
+        key = Prompt.ask("Enter additional Kimi API key", password=True)
+        if key.startswith("sk-"):
+            gastown_keys.append(key)
+        else:
+            console.print("[red]Invalid key format. Skipping.[/red]")
+
+    openclaw_key = None
+    while True:
+        key = Prompt.ask(
+            "Enter Kimi API key for OpenClaw (overseer)",
+            password=True,
+        )
+        if key.startswith("sk-"):
+            openclaw_key = key
+            break
+        console.print("[red]Invalid key format. Key should start with 'sk-'[/red]")
+
+    # 3. Telegram Bot Setup
+    console.print("\n[bold cyan]Step 3: Telegram Bot Setup[/bold cyan]")
+    console.print("Create a bot with @BotFather on Telegram and get your token")
+
+    bot_token = Prompt.ask("Enter Telegram bot token (format: 123456:ABC-DEF)")
+    owner_id = IntPrompt.ask("Enter your Telegram user ID (get it from @userinfobot)")
+
+    # 4. Agent Configuration
+    console.print("\n[bold cyan]Step 4: Agent Configuration[/bold cyan]")
+    agent_count = IntPrompt.ask("Number of crew workers", default=6)
+    monitor_interval = IntPrompt.ask(
+        "Health check interval (seconds)",
+        default=300,
+    )
+    activity_deadline = IntPrompt.ask(
+        "Max seconds between commits (activity compliance)",
+        default=3600,
+    )
+
+    # 5. Generate files
+    console.print("\n[bold cyan]Step 5: Generating Configuration Files...[/bold cyan]")
+
+    # Create .env file
+    env_content = f"""# Gasclaw Environment Configuration
+# Generated by gasclaw init
+
+# Required: Colon-separated Kimi API keys for Gastown agents
+GASTOWN_KIMI_KEYS={':'.join(gastown_keys)}
+
+# Required: Kimi API key for OpenClaw LLM (separate pool)
+OPENCLAW_KIMI_KEY={openclaw_key}
+
+# Required: Telegram bot token
+TELEGRAM_BOT_TOKEN={bot_token}
+
+# Required: Telegram user ID for allowlist
+TELEGRAM_OWNER_ID={owner_id}
+
+# Optional: Git URL or path for the rig
+GT_RIG_URL={github_repo if github_repo else '/project'}
+
+# Optional: Number of crew workers
+GT_AGENT_COUNT={agent_count}
+
+# Optional: Health check interval in seconds
+MONITOR_INTERVAL={monitor_interval}
+
+# Optional: Max seconds between commits/PRs
+ACTIVITY_DEADLINE={activity_deadline}
+
+# Optional: Log level - DEBUG, INFO, WARNING, ERROR
+LOG_LEVEL=INFO
+"""
+
+    env_file.write_text(env_content)
+    console.print(f"[green]✅ Created {env_file}[/green]")
+
+    # Create docker-compose.yml
+    compose_content = f"""services:
+  gasclaw:
+    image: ghcr.io/gastown-publish/gasclaw:latest
+    container_name: gasclaw
+    ports:
+      - "18789:18789"
+    volumes:
+      - ./project:/project
+    env_file:
+      - .env
+    restart: unless-stopped
+"""
+
+    compose_file.write_text(compose_content)
+    console.print(f"[green]✅ Created {compose_file}[/green]")
+
+    # Create gasclaw.yaml config
+    yaml_config = f"""# Gasclaw Configuration File
+# Place this file at gasclaw.yaml or specify via GASCLAW_CONFIG env var
+
+# Gastown agent settings
+gastown:
+  agent_count: {agent_count}
+  rig_url: "{github_repo if github_repo else '/project'}"
+
+# File paths
+paths:
+  project_dir: "/project"
+
+# Maintenance loop settings
+maintenance:
+  monitor_interval: {monitor_interval}
+  activity_deadline: {activity_deadline}
+
+# Service ports
+services:
+  dolt_port: 3307
+  gateway_port: 18789
+
+# Telegram configuration
+telegram:
+  allow_ids:
+    - "{owner_id}"
+
+# Agent identity customization
+agent:
+  id: "main"
+  name: "Gasclaw Overseer"
+  emoji: "🏭"
+"""
+
+    yaml_file = project_path / "gasclaw.yaml"
+    yaml_file.write_text(yaml_config)
+    console.print(f"[green]✅ Created {yaml_file}[/green]")
+
+    # Create project directory structure
+    project_subdir = project_path / "project"
+    project_subdir.mkdir(exist_ok=True)
+    (project_subdir / ".gitkeep").write_text("")
+
+    console.print(f"[green]✅ Created project directory structure[/green]")
+
+    # Summary
+    console.print("\n" + "=" * 50)
+    console.print("[bold green]🎉 Initialization Complete![/bold green]")
+    console.print("=" * 50)
+    console.print(f"\nProject location: [cyan]{project_path}[/cyan]")
+    console.print("\n[bold]Next steps:[/bold]")
+    console.print(f"  1. cd {project_path}")
+    console.print("  2. Review the generated .env file")
+    console.print("  3. Run 'gasclaw start' to launch your instance")
+    console.print("\n[dim]For help: gasclaw --help[/dim]")
+
+
+def _create_default_config(project_path: Path) -> None:
+    """Create default configuration files without wizard."""
+    # Copy example files
+    env_example = Path(__file__).parent / ".." / ".." / ".env.example"
+    compose_example = Path(__file__).parent / ".." / ".." / "docker-compose.yml"
+
+    # Create .env template
+    env_file = project_path / ".env"
+    if env_example.exists():
+        env_file.write_text(env_example.read_text())
+    else:
+        env_file.write_text("# Copy from .env.example and fill in your values\n")
+
+    # Create docker-compose.yml
+    compose_file = project_path / "docker-compose.yml"
+    if compose_example.exists():
+        compose_file.write_text(compose_example.read_text())
+    else:
+        compose_file.write_text("# Copy from docker-compose.yml.example\n")
+
+    # Create project directory
+    (project_path / "project").mkdir(exist_ok=True)
+
+
+@app.command()
+def start(
+    project_dir: Annotated[
+        Path,
+        typer.Option("--project-dir", "-p", help="Project directory containing docker-compose.yml"),
+    ] = Path("."),
+    build: Annotated[
+        bool,
+        typer.Option("--build", "-b", help="Build image before starting"),
+    ] = False,
+    detach: Annotated[
+        bool,
+        typer.Option("--detach", "-d", help="Run in detached mode"),
+    ] = True,
+) -> None:
+    """Start the gasclaw container."""
+    project_path = project_dir.resolve()
+    compose_file = project_path / "docker-compose.yml"
+
+    if not compose_file.exists():
+        console.print(f"[red]Error: No docker-compose.yml found in {project_path}[/red]")
+        console.print("Run 'gasclaw init' first to create a project.")
+        raise typer.Exit(code=1)
+
+    # Check if already running
+    if _container_running():
+        console.print("[yellow]Gasclaw container is already running.[/yellow]")
+        console.print("Use 'gasclaw logs' to view output or 'gasclaw stop' to stop.")
+        return
+
+    console.print("[bold]Starting gasclaw...[/bold]")
+
+    args = ["up"]
+    if detach:
+        args.append("-d")
+    if build:
+        args.append("--build")
+
+    result = _run_docker_compose(args, project_dir=project_path, check=False)
+
+    if result.returncode != 0:
+        console.print(f"[red]Failed to start gasclaw:[/red]")
+        console.print(result.stderr)
+        raise typer.Exit(code=1)
+
+    console.print("[green]✅ Gasclaw started successfully[/green]")
+
+    if detach:
+        console.print("\nUseful commands:")
+        console.print("  gasclaw logs    # View logs")
+        console.print("  gasclaw status  # Check status")
+        console.print("  gasclaw stop    # Stop container")
+
+
+@app.command()
+def stop(
+    project_dir: Annotated[
+        Path,
+        typer.Option("--project-dir", "-p", help="Project directory containing docker-compose.yml"),
+    ] = Path("."),
+    remove: Annotated[
+        bool,
+        typer.Option("--remove", "-r", help="Remove container after stopping"),
+    ] = False,
+) -> None:
+    """Stop the gasclaw container."""
+    project_path = project_dir.resolve()
+
+    if not _container_exists():
+        console.print("[yellow]Gasclaw container does not exist.[/yellow]")
+        return
+
+    if not _container_running():
+        console.print("[yellow]Gasclaw container is not running.[/yellow]")
+        if remove:
+            _run_docker(["rm", DEFAULT_CONTAINER_NAME], check=False)
+            console.print("[green]Container removed.[/green]")
+        return
+
+    console.print("[bold]Stopping gasclaw...[/bold]")
+
+    args = ["down"] if remove else ["stop"]
+    result = _run_docker_compose(args, project_dir=project_path, check=False)
+
+    if result.returncode != 0:
+        # Fallback to direct docker commands
+        result = _run_docker(["stop", DEFAULT_CONTAINER_NAME], check=False)
+        if result.returncode != 0:
+            console.print(f"[red]Failed to stop gasclaw:[/red] {result.stderr}")
+            raise typer.Exit(code=1)
+
+    console.print("[green]✅ Gasclaw stopped[/green]")
+
+
+@app.command()
+def status(
+    project_dir: Annotated[
+        Path,
+        typer.Option("--project-dir", "-p", help="Project directory"),
+    ] = Path("."),
+) -> None:
+    """Show gasclaw container status."""
+    container_status = _get_container_status()
+
+    table = Table(title="Gasclaw Container Status")
+    table.add_column("Property", style="bold")
+    table.add_column("Value")
+
+    exists = container_status.get("exists") == "true"
+    status_val = container_status.get("status", "unknown")
+    health = container_status.get("health", "unknown")
+    image = container_status.get("image", "unknown")
+
+    # Status with color
+    if status_val == "running":
+        status_display = f"[green]{status_val}[/green]"
+    elif status_val == "not_found":
+        status_display = "[dim]not created[/dim]"
+    else:
+        status_display = f"[yellow]{status_val}[/yellow]"
+
+    # Health with color
+    if health == "healthy":
+        health_display = f"[green]{health}[/green]"
+    elif health == "unhealthy":
+        health_display = f"[red]{health}[/red]"
+    elif health == "unknown":
+        health_display = "[dim]unknown[/dim]"
+    else:
+        health_display = health
+
+    table.add_row("Container", "gasclaw")
+    table.add_row("Exists", "[green]yes[/green]" if exists else "[red]no[/red]")
+    table.add_row("Status", status_display)
+    table.add_row("Health", health_display)
+    table.add_row("Image", image)
+
+    console.print(table)
+
+    # Check config files
+    project_path = project_dir.resolve()
+    config_table = Table(title="Configuration Files")
+    config_table.add_column("File")
+    config_table.add_column("Status")
+
+    env_file = project_path / ".env"
+    compose_file = project_path / "docker-compose.yml"
+
+    for f, label in [(env_file, ".env"), (compose_file, "docker-compose.yml")]:
+        if f.exists():
+            config_table.add_row(label, "[green]exists[/green]")
+        else:
+            config_table.add_row(label, "[red]missing[/red]")
+
+    console.print(config_table)
+
+
+@app.command()
+def logs(
+    project_dir: Annotated[
+        Path,
+        typer.Option("--project-dir", "-p", help="Project directory"),
+    ] = Path("."),
+    follow: Annotated[
+        bool,
+        typer.Option("--follow", "-f", help="Follow log output"),
+    ] = False,
+    tail: Annotated[
+        int | None,
+        typer.Option("--tail", "-n", help="Number of lines to show from end"),
+    ] = None,
+    source: Annotated[
+        str | None,
+        typer.Argument(help="Log source filter (optional)"),
+    ] = None,
+) -> None:
+    """View gasclaw container logs."""
+    project_path = project_dir.resolve()
+
+    if not _container_exists():
+        console.print("[red]Gasclaw container does not exist.[/red]")
+        console.print("Run 'gasclaw start' first.")
+        raise typer.Exit(code=1)
+
+    args = ["logs"]
+    if follow:
+        args.append("-f")
+    if tail is not None:
+        args.extend(["--tail", str(tail)])
+    args.append(DEFAULT_CONTAINER_NAME)
+
+    # For logs, we stream directly to console instead of capturing
+    cmd = _get_docker_compose_cmd() + args
+    console.print(f"[dim]Running: {' '.join(cmd)}[/dim]\n")
+
+    try:
+        subprocess.run(cmd, cwd=project_path, check=False)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Log streaming stopped.[/yellow]")
+
+
+@app.command(name="config")
+def config_cmd(
+    key: Annotated[
+        str | None,
+        typer.Argument(help="Configuration key to get/set"),
+    ] = None,
+    value: Annotated[
+        str | None,
+        typer.Argument(help="Value to set (omit to get current value)"),
+    ] = None,
+    project_dir: Annotated[
+        Path,
+        typer.Option("--project-dir", "-p", help="Project directory"),
+    ] = Path("."),
+) -> None:
+    """Get or set configuration values in .env file.
+
+    Examples:
+        gasclaw config                    # Show all config
+        gasclaw config GASTOWN_KIMI_KEYS  # Get specific value
+        gasclaw config GT_AGENT_COUNT 8   # Set value
+    """
+    project_path = project_dir.resolve()
+    env_file = project_path / ".env"
+
+    if not env_file.exists():
+        console.print(f"[red]Error: {env_file} not found[/red]")
+        console.print("Run 'gasclaw init' first.")
+        raise typer.Exit(code=1)
+
+    # Read current env file
+    env_content = env_file.read_text()
+    env_vars = _parse_env_file(env_content)
+
+    # Show all config
+    if key is None:
+        table = Table(title="Gasclaw Configuration")
+        table.add_column("Key", style="bold")
+        table.add_column("Value")
+
+        for k, v in sorted(env_vars.items()):
+            # Mask sensitive values
+            if "KEY" in k or "TOKEN" in k or "SECRET" in k:
+                v = "***" if v else "(not set)"
+            table.add_row(k, v)
+
+        console.print(table)
+        return
+
+    # Get specific value
+    if value is None:
+        if key in env_vars:
+            v = env_vars[key]
+            # Mask sensitive values
+            if "KEY" in key or "TOKEN" in key or "SECRET" in key:
+                v = "***" if v else "(not set)"
+            console.print(f"{key}={v}")
+        else:
+            console.print(f"[yellow]Key '{key}' not found in .env[/yellow]")
+        return
+
+    # Set value
+    env_vars[key] = value
+    new_content = _format_env_file(env_vars)
+    env_file.write_text(new_content)
+    console.print(f"[green]✅ Set {key}={value}[/green]")
+
+    # Check if container is running and warn
+    if _container_running():
+        console.print("[yellow]Note: Changes will take effect after restart:[/yellow] gasclaw restart")
+
+
+def _parse_env_file(content: str) -> dict[str, str]:
+    """Parse .env file content into a dictionary."""
+    env_vars = {}
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, val = line.partition("=")
+            env_vars[key] = val
+    return env_vars
+
+
+def _format_env_file(env_vars: dict[str, str]) -> str:
+    """Format env vars back to .env file content."""
+    lines = ["# Gasclaw Environment Configuration\n"]
+    for key, value in sorted(env_vars.items()):
+        lines.append(f"{key}={value}\n")
+    return "".join(lines)
+
+
+@app.command(name="maintenance")
+def maintenance_cmd(
+    action: Annotated[
+        str | None,
+        typer.Argument(help="Action: trigger, pause, resume, or status"),
+    ] = None,
+    project_dir: Annotated[
+        Path,
+        typer.Option("--project-dir", "-p", help="Project directory"),
+    ] = Path("."),
+) -> None:
+    """Control gasclaw maintenance mode.
+
+    Examples:
+        gasclaw maintenance         # Show maintenance status
+        gasclaw maintenance trigger # Trigger a maintenance cycle
+        gasclaw maintenance pause   # Pause automatic maintenance
+        gasclaw maintenance resume  # Resume automatic maintenance
+    """
+    project_path = project_dir.resolve()
+
+    if not _container_running():
+        console.print("[red]Gasclaw container is not running.[/red]")
+        raise typer.Exit(code=1)
+
+    # Map actions to commands inside container
+    action_map = {
+        "trigger": ["gasclaw", "maintain", "--once"],
+        "pause": ["touch", "/tmp/gasclaw_maintenance_paused"],
+        "resume": ["rm", "-f", "/tmp/gasclaw_maintenance_paused"],
+        "status": ["test", "-f", "/tmp/gasclaw_maintenance_paused"],
+    }
+
+    if action is None or action == "status":
+        # Check if paused
+        result = _run_docker(
+            ["exec", DEFAULT_CONTAINER_NAME, "test", "-f", "/tmp/gasclaw_maintenance_paused"],
+            check=False,
+        )
+        is_paused = result.returncode == 0
+
+        # Get maintenance info from container
+        info_result = _run_docker(
+            ["exec", DEFAULT_CONTAINER_NAME, "cat", "/tmp/gasclaw_maintenance_info.json"],
+            check=False,
+        )
+
+        table = Table(title="Maintenance Status")
+        table.add_column("Property", style="bold")
+        table.add_column("Value")
+
+        table.add_row("Status", "[yellow]PAUSED[/yellow]" if is_paused else "[green]ACTIVE[/green]")
+
+        if info_result.returncode == 0:
+            try:
+                info = json.loads(info_result.stdout)
+                table.add_row("Last Run", info.get("last_run", "unknown"))
+                table.add_row("Next Run", info.get("next_run", "unknown"))
+                table.add_row("Cycles", str(info.get("cycles", 0)))
+            except json.JSONDecodeError:
+                pass
+
+        console.print(table)
+        return
+
+    if action not in action_map:
+        console.print(f"[red]Unknown action: {action}[/red]")
+        console.print(f"Valid actions: {', '.join(action_map.keys())}")
+        raise typer.Exit(code=1)
+
+    # Execute action in container
+    cmd = action_map[action]
+    result = _run_docker(["exec", DEFAULT_CONTAINER_NAME] + cmd, check=False)
+
+    if result.returncode == 0:
+        console.print(f"[green]✅ Maintenance {action} successful[/green]")
+    else:
+        # For status check, non-zero means not paused (active)
+        if action == "status":
+            console.print("[green]Maintenance is ACTIVE[/green]")
+        else:
+            console.print(f"[red]Failed to {action} maintenance:[/red] {result.stderr}")
+            raise typer.Exit(code=1)
+
+
+@app.command()
+def restart(
+    project_dir: Annotated[
+        Path,
+        typer.Option("--project-dir", "-p", help="Project directory"),
+    ] = Path("."),
+) -> None:
+    """Restart the gasclaw container."""
+    stop(project_dir=project_dir)
+    console.print()
+    start(project_dir=project_dir)
+
+
+@app.command()
+def update(
+    project_dir: Annotated[
+        Path,
+        typer.Option("--project-dir", "-p", help="Project directory"),
+    ] = Path("."),
+    pull: Annotated[
+        bool,
+        typer.Option("--pull", "-u", help="Pull latest image before updating"),
+    ] = True,
+) -> None:
+    """Update gasclaw to the latest version."""
+    project_path = project_dir.resolve()
+
+    console.print("[bold]Updating gasclaw...[/bold]")
+
+    # Stop container if running
+    was_running = _container_running()
+    if was_running:
+        console.print("Stopping container...")
+        stop(project_dir=project_path)
+
+    # Pull latest image
+    if pull:
+        console.print("Pulling latest image...")
+        result = _run_docker(["pull", "ghcr.io/gastown-publish/gasclaw:latest"], check=False)
+        if result.returncode != 0:
+            console.print("[yellow]Warning: Failed to pull latest image[/yellow]")
+
+    # Restart if was running
+    if was_running:
+        console.print("Restarting container...")
+        start(project_dir=project_path)
+
+    console.print("[green]✅ Update complete[/green]")
+
+
+@app.command()
+def version() -> None:
+    """Show gasclaw version."""
+    console.print(f"gasclaw {__version__}")
+
+
+def main() -> None:
+    """Entry point for host CLI."""
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_host_cli.py
+++ b/tests/unit/test_host_cli.py
@@ -1,0 +1,643 @@
+"""Tests for host_cli module — host-side container management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gasclaw.host_cli import (
+    _container_exists,
+    _container_running,
+    _format_env_file,
+    _get_container_status,
+    _get_docker_compose_cmd,
+    _is_inside_container,
+    _parse_env_file,
+    _run_docker,
+    _run_docker_compose,
+    app,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_not_inside_container(monkeypatch):
+    """Mock _is_inside_container to return False for all tests."""
+    monkeypatch.setattr(
+        "gasclaw.host_cli._is_inside_container",
+        lambda: False,
+    )
+
+
+class TestContainerDetection:
+    """Test container detection utilities - overrides mock_not_inside_container."""
+
+    @pytest.fixture(autouse=True)
+    def unmock_for_detection(self, monkeypatch):
+        """Don't mock _is_inside_container for these tests."""
+        pass
+
+    def test_is_inside_container_dockerenv(self, tmp_path, monkeypatch):
+        """Test detection via .dockerenv file."""
+        monkeypatch.setattr(Path, "exists", lambda p: str(p) == "/.dockerenv")
+
+        assert _is_inside_container() is True
+
+    def test_is_inside_container_cgroup(self, monkeypatch):
+        """Test detection via cgroup file."""
+        def mock_read_text(self):
+            if str(self) == "/proc/self/cgroup":
+                return "docker/container_id"
+            raise FileNotFoundError
+
+        monkeypatch.setattr(Path, "read_text", mock_read_text)
+        monkeypatch.setattr(Path, "exists", lambda p: False)
+
+        assert _is_inside_container() is True
+
+    def test_is_inside_container_not_in_container(self, monkeypatch):
+        """Test detection when not in container."""
+        monkeypatch.setattr(Path, "exists", lambda p: False)
+        monkeypatch.setattr(Path, "read_text", lambda p: "")
+
+        assert _is_inside_container() is False
+
+
+class TestDockerCommands:
+    """Test Docker command execution utilities."""
+
+    def test_get_docker_compose_cmd_v2(self, monkeypatch):
+        """Test detecting docker compose v2."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        def mock_run(cmd, **kwargs):
+            return mock_result
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        result = _get_docker_compose_cmd()
+        assert result == ["docker", "compose"]
+
+    def test_get_docker_compose_cmd_v1(self, monkeypatch):
+        """Test fallback to docker-compose v1."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+
+        def mock_run(cmd, **kwargs):
+            return mock_result
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        result = _get_docker_compose_cmd()
+        assert result == ["docker-compose"]
+
+    def test_run_docker(self, monkeypatch):
+        """Test running docker command."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "container1\ncontainer2"
+        mock_result.stderr = ""
+
+        def mock_run(cmd, **kwargs):
+            return mock_result
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        result = _run_docker(["ps", "-a"])
+        assert result.returncode == 0
+
+    def test_run_docker_compose(self, monkeypatch):
+        """Test running docker compose command."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        calls = []
+
+        def mock_run(cmd, **kwargs):
+            calls.append((cmd, kwargs.get("cwd")))
+            return mock_result
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+
+        project_dir = Path("/test/project")
+        result = _run_docker_compose(["up", "-d"], project_dir=project_dir)
+        assert result.returncode == 0
+
+
+class TestContainerStatus:
+    """Test container status checks."""
+
+    def test_container_exists_true(self, monkeypatch):
+        """Test container exists check returns True."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "gasclaw\nother_container"
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker",
+            lambda args, **kwargs: mock_result,
+        )
+
+        assert _container_exists("gasclaw") is True
+
+    def test_container_exists_false(self, monkeypatch):
+        """Test container exists check returns False."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "other_container"
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker",
+            lambda args, **kwargs: mock_result,
+        )
+
+        assert _container_exists("gasclaw") is False
+
+    def test_container_running_true(self, monkeypatch):
+        """Test container running check returns True."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "gasclaw"
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker",
+            lambda args, **kwargs: mock_result,
+        )
+
+        assert _container_running("gasclaw") is True
+
+    def test_container_running_false(self, monkeypatch):
+        """Test container running check returns False."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker",
+            lambda args, **kwargs: mock_result,
+        )
+
+        assert _container_running("gasclaw") is False
+
+    def test_get_container_status_running(self, monkeypatch):
+        """Test getting status of running container."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "running|healthy|gasclaw:latest"
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker",
+            lambda args, **kwargs: mock_result,
+        )
+
+        status = _get_container_status("gasclaw")
+        assert status["exists"] == "true"
+        assert status["status"] == "running"
+        assert status["health"] == "healthy"
+        assert status["image"] == "gasclaw:latest"
+
+    def test_get_container_status_not_found(self, monkeypatch):
+        """Test getting status of non-existent container."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker",
+            lambda args, **kwargs: mock_result,
+        )
+
+        status = _get_container_status("gasclaw")
+        assert status["exists"] == "false"
+        assert status["status"] == "not_found"
+
+
+class TestEnvFileParsing:
+    """Test .env file parsing utilities."""
+
+    def test_parse_env_file(self):
+        """Test parsing .env file content."""
+        content = """# Comment
+KEY1=value1
+KEY2=value2
+
+# Another comment
+KEY3=value with spaces
+"""
+        result = _parse_env_file(content)
+        assert result["KEY1"] == "value1"
+        assert result["KEY2"] == "value2"
+        assert result["KEY3"] == "value with spaces"
+
+    def test_parse_env_file_empty_lines(self):
+        """Test parsing env file with empty lines."""
+        content = """
+KEY1=value1
+
+KEY2=value2
+
+"""
+        result = _parse_env_file(content)
+        assert result == {"KEY1": "value1", "KEY2": "value2"}
+
+    def test_parse_env_file_no_equals(self):
+        """Test parsing env file with lines without equals."""
+        content = """KEY1=value1
+INVALID_LINE
+KEY2=value2
+"""
+        result = _parse_env_file(content)
+        assert result == {"KEY1": "value1", "KEY2": "value2"}
+
+    def test_format_env_file(self):
+        """Test formatting env file content."""
+        env_vars = {"KEY1": "value1", "KEY2": "value2"}
+        result = _format_env_file(env_vars)
+        assert "KEY1=value1" in result
+        assert "KEY2=value2" in result
+        assert result.startswith("# Gasclaw Environment Configuration")
+
+
+class TestInitCommand:
+    """Test the init command."""
+
+    def test_init_creates_files(self, tmp_path, monkeypatch):
+        """Test init command creates config files."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        # Mock prompts
+        monkeypatch.setattr(
+            "rich.prompt.Confirm.ask",
+            lambda *args, **kwargs: True,
+        )
+        monkeypatch.setattr(
+            "rich.prompt.Prompt.ask",
+            lambda *args, **kwargs: kwargs.get("default", "test_value"),
+        )
+        monkeypatch.setattr(
+            "rich.prompt.IntPrompt.ask",
+            lambda *args, **kwargs: kwargs.get("default", 1),
+        )
+
+        # Change to temp directory
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(app, ["init", "--project-dir", str(tmp_path), "--skip-wizard"])
+
+        # Check files were created (or command completed)
+        assert result.exit_code == 0
+
+    def test_init_skip_wizard(self, tmp_path, monkeypatch):
+        """Test init --skip-wizard creates default files."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        result = runner.invoke(app, ["init", "--project-dir", str(project_dir), "--skip-wizard"])
+
+        assert result.exit_code == 0
+
+    def test_init_already_exists_cancel(self, tmp_path, monkeypatch):
+        """Test init when files exist and user cancels."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        # Create existing files
+        (tmp_path / ".env").write_text("EXISTING=value")
+
+        # Mock user canceling
+        monkeypatch.setattr(
+            "rich.prompt.Confirm.ask",
+            lambda *args, **kwargs: False,
+        )
+
+        result = runner.invoke(app, ["init", "--project-dir", str(tmp_path)])
+
+        # Should exit cleanly
+        assert result.exit_code == 0
+
+
+class TestStartCommand:
+    """Test the start command."""
+
+    def test_start_no_compose_file(self, tmp_path, monkeypatch):
+        """Test start fails when docker-compose.yml doesn't exist."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        result = runner.invoke(app, ["start", "-p", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "No docker-compose.yml found" in result.output
+
+    def test_start_already_running(self, tmp_path, monkeypatch):
+        """Test start when container already running."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_running",
+            lambda: True,
+        )
+
+        # Create compose file
+        (tmp_path / "docker-compose.yml").write_text("services:")
+
+        result = runner.invoke(app, ["start", "-p", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "already running" in result.output
+
+
+class TestStopCommand:
+    """Test the stop command."""
+
+    def test_stop_not_exists(self, monkeypatch):
+        """Test stop when container doesn't exist."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_exists",
+            lambda: False,
+        )
+
+        result = runner.invoke(app, ["stop"])
+
+        assert result.exit_code == 0
+        assert "does not exist" in result.output
+
+    def test_stop_success(self, monkeypatch):
+        """Test successful stop."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_exists",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_running",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker_compose",
+            lambda *args, **kwargs: mock_result,
+        )
+
+        result = runner.invoke(app, ["stop"])
+
+        assert result.exit_code == 0
+
+
+class TestStatusCommand:
+    """Test the status command."""
+
+    def test_status_container_running(self, monkeypatch):
+        """Test status with running container."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._get_container_status",
+            lambda: {
+                "exists": "true",
+                "status": "running",
+                "health": "healthy",
+                "image": "gasclaw:latest",
+            },
+        )
+
+        result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0
+        assert "running" in result.output
+
+    def test_status_container_not_found(self, monkeypatch):
+        """Test status when container doesn't exist."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._get_container_status",
+            lambda: {"exists": "false", "status": "not_found"},
+        )
+
+        result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0
+
+
+class TestConfigCommand:
+    """Test the config command."""
+
+    def test_config_show_all(self, tmp_path, monkeypatch):
+        """Test config command showing all values."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY1=value1\nKEY2=value2\n")
+
+        result = runner.invoke(app, ["config", "-p", str(tmp_path)])
+
+        assert result.exit_code == 0
+
+    def test_config_get_value(self, tmp_path, monkeypatch):
+        """Test config getting specific value."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("TEST_KEY=test_value\n")
+
+        result = runner.invoke(
+            app,
+            ["config", "TEST_KEY", "-p", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0
+
+    def test_config_set_value(self, tmp_path, monkeypatch):
+        """Test config setting value."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_running",
+            lambda: False,
+        )
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY1=old_value\n")
+
+        result = runner.invoke(
+            app,
+            ["config", "KEY1", "new_value", "-p", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0
+        assert "Set KEY1=new_value" in result.output
+
+        # Verify file was updated
+        content = env_file.read_text()
+        assert "KEY1=new_value" in content
+
+    def test_config_no_env_file(self, tmp_path, monkeypatch):
+        """Test config when .env file doesn't exist."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        result = runner.invoke(app, ["config", "-p", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+
+class TestMaintenanceCommand:
+    """Test the maintenance command."""
+
+    def test_maintenance_status(self, monkeypatch):
+        """Test maintenance status command."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1  # Not paused
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_running",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker",
+            lambda *args, **kwargs: mock_result,
+        )
+
+        result = runner.invoke(app, ["maintenance", "status"])
+
+        assert result.exit_code == 0
+
+    def test_maintenance_container_not_running(self, monkeypatch):
+        """Test maintenance when container not running."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_running",
+            lambda: False,
+        )
+
+        result = runner.invoke(app, ["maintenance", "trigger"])
+
+        assert result.exit_code == 1
+        assert "not running" in result.output
+
+
+class TestLogsCommand:
+    """Test the logs command."""
+
+    def test_logs_container_not_exists(self, monkeypatch):
+        """Test logs when container doesn't exist."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_exists",
+            lambda: False,
+        )
+
+        result = runner.invoke(app, ["logs"])
+
+        assert result.exit_code == 1
+        assert "does not exist" in result.output
+
+
+class TestVersionCommand:
+    """Test the version command."""
+
+    def test_version(self, monkeypatch):
+        """Test version command."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        result = runner.invoke(app, ["version"])
+
+        assert result.exit_code == 0
+
+
+class TestRestartCommand:
+    """Test the restart command."""
+
+    def test_restart(self, monkeypatch):
+        """Test restart command."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        # Mock stop and start
+        monkeypatch.setattr(
+            "gasclaw.host_cli.stop",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "gasclaw.host_cli.start",
+            lambda **kwargs: None,
+        )
+
+        result = runner.invoke(app, ["restart"])
+
+        assert result.exit_code == 0
+
+
+class TestUpdateCommand:
+    """Test the update command."""
+
+    def test_update(self, monkeypatch):
+        """Test update command."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        monkeypatch.setattr(
+            "gasclaw.host_cli._container_running",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "gasclaw.host_cli._run_docker",
+            lambda *args, **kwargs: mock_result,
+        )
+
+        result = runner.invoke(app, ["update"])
+
+        assert result.exit_code == 0
+        assert "Update complete" in result.output


### PR DESCRIPTION
## Summary

Add host CLI for managing gasclaw containers from outside Docker.

Implements:
- Issue #247: Host CLI for managing gasclaw instances
- Issue #246: Onboarding wizard CLI for new gasclaw instances

## Changes

### New Commands
- `gasclaw init` - Interactive onboarding wizard for new instances
- `gasclaw start` - Start the gasclaw container
- `gasclaw stop` - Stop the gasclaw container
- `gasclaw restart` - Restart the gasclaw container
- `gasclaw status` - Show container and configuration status
- `gasclaw config` - Get/set configuration values in .env file
- `gasclaw logs` - View container logs with follow/tail options
- `gasclaw maintenance` - Control maintenance mode
- `gasclaw update` - Update to latest gasclaw version

### Features
- Docker compose v2/v1 auto-detection
- Container state detection (running/exists/health)
- Project directory management with `-p` option
- Config file editing without entering container
- Interactive wizard for first-time setup

### Tests
- 36 new unit tests covering all host CLI commands
- All subprocess calls mocked
- Container detection utilities tested

## Test Plan

- [x] All 709 unit tests pass
- [x] New host CLI commands have corresponding tests
- [x] Docker detection and command utilities tested
- [x] Config file parsing and editing tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)