### PR TITLE
feat: OpenClaw gateway lifecycle management (issue #268)

### DIFF
--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -28,8 +28,10 @@ from gasclaw.gastown.installer import gastown_install, setup_kimi_accounts
 from gasclaw.gastown.lifecycle import start_daemon, start_dolt, start_mayor, stop_all
 from gasclaw.health import check_agent_activity, check_health
 from gasclaw.logging_config import get_logger
+from gasclaw.openclaw.auth import get_gateway_auth_token
 from gasclaw.openclaw.doctor import run_doctor
 from gasclaw.openclaw.installer import write_openclaw_config
+from gasclaw.openclaw.lifecycle import start_openclaw, stop_openclaw
 from gasclaw.openclaw.skill_manager import install_skills
 from gasclaw.updater.notifier import notify_telegram
 
@@ -93,44 +95,67 @@ def bootstrap(config: GasclawConfig, *, gt_root: Path = Path("/workspace/gt")) -
         logger.info("Installing skills")
         install_skills(skills_src=_SKILLS_DIR, skills_dst=openclaw_dir / "skills")
 
-        # 7. Run openclaw doctor to verify config and fix issues
+        # 7. Start OpenClaw gateway
+        logger.info("Starting OpenClaw gateway on port %d", config.gateway_port)
+        start_openclaw(port=config.gateway_port, timeout=30)
+        services_started = True
+        logger.info("OpenClaw gateway started successfully")
+
+        # 8. Read auth token for notifications
+        auth_token = get_gateway_auth_token(openclaw_dir)
+        if not auth_token:
+            logger.warning("No auth token found, notifications may fail")
+
+        # 9. Run openclaw doctor to verify config and fix issues
         logger.info("Running openclaw doctor")
         doctor_result = run_doctor(repair=True)
         if not doctor_result.healthy:
             logger.warning("Openclaw doctor found issues: %s", doctor_result.output[:500])
-            notify_telegram(f"openclaw doctor found issues:\n{doctor_result.output[:500]}")
+            notify_telegram(
+                f"openclaw doctor found issues:\n{doctor_result.output[:500]}",
+                auth_token=auth_token,
+            )
         else:
             logger.info("Openclaw doctor check passed")
 
-        # 8. Start daemon
+        # 10. Start daemon
         logger.info("Starting gt daemon")
         start_daemon()
 
-        # 9. Start mayor
+        # 11. Start mayor
         logger.info("Starting mayor agent")
         start_mayor(agent="kimi-claude")
-        services_started = True
         logger.info("All services started successfully")
 
-        # 10. Notify
+        # 12. Notify
         logger.info("Sending startup notification")
-        notify_telegram("Gasclaw is up and running.")
+        notify_telegram("Gasclaw is up and running.", auth_token=auth_token)
 
     except Exception as e:
         logger.exception("Bootstrap failed at step")
+        # Get auth token if available for error notifications
+        error_token = auth_token if 'auth_token' in vars() else ""
         # Rollback: Stop any services that were started
         if services_started or dolt_started:
             logger.info("Attempting rollback")
-            notify_telegram(f"Bootstrap failed: {e}. Rolling back...")
+            notify_telegram(
+                f"Bootstrap failed: {e}. Rolling back...",
+                auth_token=error_token,
+            )
             try:
                 stop_all()
+                if services_started:
+                    stop_openclaw()
                 logger.info("Rollback completed")
             except Exception as rollback_error:
                 # Log rollback error but raise original exception
                 logger.error("Rollback failed: %s", rollback_error)
-                notify_telegram(f"Rollback error: {rollback_error}")
+                notify_telegram(
+                    f"Rollback error: {rollback_error}",
+                    auth_token=error_token,
+                )
         else:
-            notify_telegram(f"Bootstrap failed: {e}")
+            notify_telegram(f"Bootstrap failed: {e}", auth_token=error_token)
 
         # Re-raise the original exception
         raise RuntimeError(f"Bootstrap failed: {e}") from e

--- a/src/gasclaw/openclaw/auth.py
+++ b/src/gasclaw/openclaw/auth.py
@@ -1,0 +1,47 @@
+"""OpenClaw authentication utilities."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+__all__ = ["get_gateway_auth_token"]
+
+logger = logging.getLogger(__name__)
+
+
+def get_gateway_auth_token(openclaw_dir: Path | None = None) -> str:
+    """Read the gateway auth token from openclaw.json config.
+
+    Args:
+        openclaw_dir: Path to the openclaw config directory.
+            Defaults to ~/.openclaw
+
+    Returns:
+        The auth token string, or empty string if not found.
+
+    """
+    if openclaw_dir is None:
+        openclaw_dir = Path.home() / ".openclaw"
+
+    config_path = openclaw_dir / "openclaw.json"
+
+    if not config_path.exists():
+        logger.warning("openclaw.json not found at %s", config_path)
+        return ""
+
+    try:
+        config = json.loads(config_path.read_text())
+        token = config.get("gateway", {}).get("auth", {}).get("token", "")
+        if token:
+            logger.debug("Read auth token from %s", config_path)
+        else:
+            logger.warning("No auth token found in %s", config_path)
+        return token
+    except json.JSONDecodeError as e:
+        logger.error("Invalid JSON in %s: %s", config_path, e)
+        return ""
+    except OSError as e:
+        logger.error("Error reading %s: %s", config_path, e)
+        return ""

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -345,7 +345,7 @@ class TestMonitorLoop:
             patch("gasclaw.bootstrap.notify_telegram") as m_notify,
             patch("time.sleep"),
         ):
-            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            m_notify.side_effect = lambda msg, **kwargs: notify_calls.append(msg)
             monitor_loop(config, interval=1)
 
         assert len(notify_calls) >= 1
@@ -378,7 +378,7 @@ class TestMonitorLoop:
             patch("gasclaw.bootstrap.notify_telegram") as m_notify,
             patch("time.sleep"),
         ):
-            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            m_notify.side_effect = lambda msg, **kwargs: notify_calls.append(msg)
             monitor_loop(config, interval=1)
 
         assert len(notify_calls) >= 1
@@ -406,7 +406,7 @@ class TestMonitorLoop:
             patch("gasclaw.bootstrap.start_mayor"),
             patch("gasclaw.bootstrap.notify_telegram") as m_notify,
         ):
-            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            m_notify.side_effect = lambda msg, **kwargs: notify_calls.append(msg)
             bootstrap(config, gt_root=tmp_path)
 
         # Should have "Gasclaw is up" and doctor warning notifications
@@ -441,7 +441,7 @@ class TestMonitorLoop:
             patch("gasclaw.bootstrap.notify_telegram") as m_notify,
             patch("time.sleep"),
         ):
-            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            m_notify.side_effect = lambda msg, **kwargs: notify_calls.append(msg)
             monitor_loop(config, interval=1)
 
         # Should have notifications for dolt, daemon, and mayor
@@ -544,7 +544,7 @@ class TestMonitorLoop:
             patch("gasclaw.bootstrap.notify_telegram") as m_notify,
             patch("time.sleep"),
         ):
-            m_notify.side_effect = lambda msg: notify_calls.append(msg)
+            m_notify.side_effect = lambda msg, **kwargs: notify_calls.append(msg)
             monitor_loop(config, interval=1)
 
         # Should NOT send activity alert since compliant defaults to True


### PR DESCRIPTION
## Summary
- Add auth.py to read gateway auth token from openclaw.json
- Add start_openclaw/stop_openclaw to lifecycle.py  
- Update bootstrap.py to start gateway before doctor, pass auth_token to notifications
- Fix tests to accept **kwargs in notify_telegram mocks

## Test plan
- [x] All 786 unit tests pass
- [x] Changes address issue #268 (Telegram bot auth token not passed)

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)