### PR TITLE
feat: auto-create forum topics when bot joins a group (issue #270)

### DIFF
--- a/src/gasclaw/openclaw/forum_manager.py
+++ b/src/gasclaw/openclaw/forum_manager.py
@@ -1,0 +1,531 @@
+"""Forum topic management for Telegram supergroups.
+
+This module handles auto-creation of forum topics when the bot joins a group,
+and persists topic thread IDs for routing notifications.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ForumTopicManager",
+    "TopicConfig",
+    "ForumTopicError",
+]
+
+# Default configuration
+DEFAULT_STATE_DIR = "/workspace/state"
+TOPIC_CONFIG_FILE = "forum_topics.json"
+
+# Required topic names
+REQUIRED_TOPICS = [
+    "pull-request",
+    "issue",
+    "maintenance",
+    "discussion",
+]
+
+
+class ForumTopicError(Exception):
+    """Raised when forum topic operations fail."""
+
+    def __init__(self, message: str, chat_id: str | None = None) -> None:
+        """Initialize forum topic error.
+
+        Args:
+            message: Error message.
+            chat_id: Chat ID where the error occurred.
+        """
+        super().__init__(message)
+        self.chat_id = chat_id
+
+
+@dataclass
+class TopicConfig:
+    """Configuration for a forum topic."""
+
+    name: str
+    thread_id: int | None = None
+    created_at: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert topic config to dictionary."""
+        return {
+            "name": self.name,
+            "thread_id": self.thread_id,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TopicConfig:
+        """Create topic config from dictionary."""
+        return cls(
+            name=data.get("name", ""),
+            thread_id=data.get("thread_id"),
+            created_at=data.get("created_at"),
+        )
+
+
+@dataclass
+class GroupForumState:
+    """Forum state for a specific group chat."""
+
+    chat_id: str
+    is_forum: bool = False
+    topics: dict[str, TopicConfig] = field(default_factory=dict)
+    admin_checked: bool = False
+    is_admin: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert group state to dictionary."""
+        return {
+            "chat_id": self.chat_id,
+            "is_forum": self.is_forum,
+            "topics": {k: v.to_dict() for k, v in self.topics.items()},
+            "admin_checked": self.admin_checked,
+            "is_admin": self.is_admin,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GroupForumState:
+        """Create group state from dictionary."""
+        topics = {
+            k: TopicConfig.from_dict(v)
+            for k, v in data.get("topics", {}).items()
+        }
+        return cls(
+            chat_id=data.get("chat_id", ""),
+            is_forum=data.get("is_forum", False),
+            topics=topics,
+            admin_checked=data.get("admin_checked", False),
+            is_admin=data.get("is_admin", False),
+        )
+
+    def has_all_topics(self) -> bool:
+        """Check if all required topics exist."""
+        return all(
+            topic in self.topics and self.topics[topic].thread_id is not None
+            for topic in REQUIRED_TOPICS
+        )
+
+    def get_thread_id(self, topic_name: str) -> int | None:
+        """Get thread ID for a topic."""
+        if topic_name in self.topics:
+            return self.topics[topic_name].thread_id
+        return None
+
+
+class ForumTopicManager:
+    """Manage forum topics for Telegram supergroups."""
+
+    def __init__(
+        self,
+        bot_token: str,
+        state_dir: str | Path = DEFAULT_STATE_DIR,
+    ) -> None:
+        """Initialize the forum topic manager.
+
+        Args:
+            bot_token: Telegram bot token.
+            state_dir: Directory to store topic configuration.
+        """
+        self.bot_token = bot_token
+        self.state_dir = Path(state_dir)
+        self._states: dict[str, GroupForumState] = {}
+        self._base_url = f"https://api.telegram.org/bot{bot_token}"
+
+    @property
+    def state_file(self) -> Path:
+        """Path to the topic configuration file."""
+        return self.state_dir / TOPIC_CONFIG_FILE
+
+    def _load_all_states(self) -> dict[str, GroupForumState]:
+        """Load all group forum states from disk."""
+        if self.state_file.is_file():
+            try:
+                data = json.loads(self.state_file.read_text())
+                return {
+                    k: GroupForumState.from_dict(v)
+                    for k, v in data.items()
+                }
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning("Failed to load forum topic state: %s", e)
+        return {}
+
+    def _save_all_states(self, states: dict[str, GroupForumState]) -> None:
+        """Save all group forum states to disk atomically."""
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        data = {k: v.to_dict() for k, v in states.items()}
+
+        # Write to temp file in same directory, then rename atomically
+        fd, temp_path = tempfile.mkstemp(
+            dir=self.state_dir, prefix=".forum-topics-", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2)
+            os.replace(temp_path, self.state_file)
+            self._states = states
+        except (OSError, TypeError, ValueError) as e:
+            # Clean up temp file on failure
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+            logger.error("Failed to save forum topic state: %s", e)
+            raise
+
+    def get_group_state(self, chat_id: str) -> GroupForumState:
+        """Get forum state for a group (cached or loaded)."""
+        if not self._states:
+            self._states = self._load_all_states()
+
+        if chat_id not in self._states:
+            self._states[chat_id] = GroupForumState(chat_id=chat_id)
+
+        return self._states[chat_id]
+
+    def _make_request(
+        self, method: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Make a request to the Telegram Bot API.
+
+        Args:
+            method: API method name.
+            params: Request parameters.
+
+        Returns:
+            Response data.
+
+        Raises:
+            ForumTopicError: If the request fails.
+        """
+        url = f"{self._base_url}/{method}"
+        try:
+            response = httpx.post(
+                url,
+                json=params or {},
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            if not data.get("ok"):
+                error_code = data.get("error_code")
+                description = data.get("description", "Unknown error")
+                raise ForumTopicError(
+                    f"Telegram API error {error_code}: {description}"
+                )
+
+            return data.get("result", {})
+        except httpx.HTTPError as e:
+            raise ForumTopicError(f"HTTP error: {e}") from e
+
+    def check_is_forum(self, chat_id: str) -> bool:
+        """Check if a chat is a forum supergroup.
+
+        Args:
+            chat_id: Chat ID to check.
+
+        Returns:
+            True if the chat is a forum, False otherwise.
+        """
+        try:
+            chat_info = self._make_request("getChat", {"chat_id": chat_id})
+            is_forum = chat_info.get("is_forum", False)
+
+            state = self.get_group_state(chat_id)
+            state.is_forum = is_forum
+            self._save_all_states(self._states)
+
+            return is_forum
+        except ForumTopicError as e:
+            logger.warning("Failed to check if chat %s is forum: %s", chat_id, e)
+            return False
+
+    def check_is_admin(self, chat_id: str) -> bool:
+        """Check if the bot is an admin in the chat.
+
+        Args:
+            chat_id: Chat ID to check.
+
+        Returns:
+            True if bot is admin, False otherwise.
+        """
+        try:
+            member_info = self._make_request(
+                "getChatMember",
+                {"chat_id": chat_id, "user_id": "me"},
+            )
+            status = member_info.get("status", "")
+            is_admin = status in ("administrator", "creator")
+            can_manage_topics = member_info.get("can_manage_topics", False)
+
+            state = self.get_group_state(chat_id)
+            state.admin_checked = True
+            state.is_admin = is_admin and can_manage_topics
+            self._save_all_states(self._states)
+
+            return state.is_admin
+        except ForumTopicError as e:
+            logger.warning("Failed to check admin status in %s: %s", chat_id, e)
+            return False
+
+    def create_forum_topic(
+        self,
+        chat_id: str,
+        name: str,
+        icon_color: int | None = None,
+    ) -> int | None:
+        """Create a forum topic in a supergroup.
+
+        Args:
+            chat_id: Chat ID to create topic in.
+            name: Topic name.
+            icon_color: Optional icon color (1-6).
+
+        Returns:
+            Thread ID of the created topic, or None if failed.
+        """
+        params: dict[str, Any] = {
+            "chat_id": chat_id,
+            "name": name,
+        }
+        if icon_color is not None:
+            params["icon_color"] = icon_color
+
+        try:
+            result = self._make_request("createForumTopic", params)
+            thread_id = result.get("message_thread_id")
+
+            if thread_id:
+                logger.info(
+                    "Created forum topic '%s' in chat %s (thread_id=%s)",
+                    name,
+                    chat_id,
+                    thread_id,
+                )
+                return thread_id
+        except ForumTopicError as e:
+            logger.warning("Failed to create forum topic '%s': %s", name, e)
+
+        return None
+
+    def setup_group_topics(self, chat_id: str) -> dict[str, int]:
+        """Set up all required forum topics for a group.
+
+        Args:
+            chat_id: Chat ID to set up topics in.
+
+        Returns:
+            Dict mapping topic names to thread IDs.
+
+        Raises:
+            ForumTopicError: If setup fails.
+        """
+        state = self.get_group_state(chat_id)
+
+        # Check if it's a forum
+        if not state.is_forum:
+            is_forum = self.check_is_forum(chat_id)
+            if not is_forum:
+                raise ForumTopicError(
+                    f"Chat {chat_id} is not a forum supergroup", chat_id
+                )
+
+        # Check admin status
+        if not state.is_admin:
+            is_admin = self.check_is_admin(chat_id)
+            if not is_admin:
+                raise ForumTopicError(
+                    f"Bot is not admin in chat {chat_id}", chat_id
+                )
+
+        created_topics: dict[str, int] = {}
+
+        # Create each required topic
+        for topic_name in REQUIRED_TOPICS:
+            # Check if topic already exists
+            if topic_name in state.topics and state.topics[topic_name].thread_id:
+                created_topics[topic_name] = state.topics[topic_name].thread_id  # type: ignore
+                continue
+
+            # Create the topic
+            import time
+
+            thread_id = self.create_forum_topic(chat_id, topic_name)
+            if thread_id:
+                state.topics[topic_name] = TopicConfig(
+                    name=topic_name,
+                    thread_id=thread_id,
+                    created_at=time.time(),
+                )
+                created_topics[topic_name] = thread_id
+
+        # Save state
+        self._save_all_states(self._states)
+
+        return created_topics
+
+    def get_topic_thread_id(self, chat_id: str, topic_name: str) -> int | None:
+        """Get the thread ID for a specific topic in a group.
+
+        Args:
+            chat_id: Chat ID.
+            topic_name: Topic name (e.g., 'pull-request', 'issue').
+
+        Returns:
+            Thread ID if found, None otherwise.
+        """
+        state = self.get_group_state(chat_id)
+        return state.get_thread_id(topic_name)
+
+    def get_notification_thread_id(
+        self, chat_id: str, notification_type: str
+    ) -> int | None:
+        """Get the appropriate thread ID for a notification type.
+
+        Args:
+            chat_id: Chat ID.
+            notification_type: Type of notification (pr, issue, maintenance, discussion).
+
+        Returns:
+            Thread ID if configured, None otherwise.
+        """
+        mapping = {
+            "pr": "pull-request",
+            "pull-request": "pull-request",
+            "issue": "issue",
+            "issues": "issue",
+            "maintenance": "maintenance",
+            "health": "maintenance",
+            "watchdog": "maintenance",
+            "discussion": "discussion",
+            "general": "discussion",
+        }
+
+        topic_name = mapping.get(notification_type.lower())
+        if not topic_name:
+            return None
+
+        return self.get_topic_thread_id(chat_id, topic_name)
+
+    def request_admin_promotion(self, chat_id: str) -> bool:
+        """Send a message asking to be promoted to admin.
+
+        Args:
+            chat_id: Chat ID to send request to.
+
+        Returns:
+            True if message sent successfully, False otherwise.
+        """
+        message = (
+            "🤖 *Admin Required*\n\n"
+            "To create forum topics and manage notifications, "
+            "please promote me to administrator with the following permissions:\n\n"
+            "• Manage topics\n"
+            "• Delete messages\n\n"
+            "Once promoted, I'll automatically create the required topics:\n"
+            "• pull-request — PR notifications\n"
+            "• issue — Issue tracking\n"
+            "• maintenance — System alerts\n"
+            "• discussion — General chat"
+        )
+
+        try:
+            self._make_request(
+                "sendMessage",
+                {
+                    "chat_id": chat_id,
+                    "text": message,
+                    "parse_mode": "Markdown",
+                },
+            )
+            return True
+        except ForumTopicError as e:
+            logger.warning("Failed to send admin request: %s", e)
+            return False
+
+    def handle_bot_added(self, chat_id: str, chat_type: str) -> dict[str, Any]:
+        """Handle the bot being added to a group.
+
+        This is the main entry point for setting up forum topics when
+        the bot joins a new group.
+
+        Args:
+            chat_id: Chat ID the bot was added to.
+            chat_type: Type of chat (supergroup, group, etc.).
+
+        Returns:
+            Dict with result information.
+        """
+        result = {
+            "success": False,
+            "is_forum": False,
+            "is_admin": False,
+            "topics_created": {},
+            "admin_requested": False,
+            "error": None,
+        }
+
+        try:
+            # Check if it's a forum
+            is_forum = self.check_is_forum(chat_id)
+            result["is_forum"] = is_forum
+
+            if not is_forum:
+                logger.info("Chat %s is not a forum supergroup, skipping topic setup", chat_id)
+                result["success"] = True
+                return result
+
+            # Check admin status
+            is_admin = self.check_is_admin(chat_id)
+            result["is_admin"] = is_admin
+
+            if not is_admin:
+                logger.info("Bot not admin in %s, requesting promotion", chat_id)
+                result["admin_requested"] = self.request_admin_promotion(chat_id)
+                return result
+
+            # Set up topics
+            topics = self.setup_group_topics(chat_id)
+            result["topics_created"] = topics
+            result["success"] = True
+
+            logger.info(
+                "Successfully set up %d forum topics in chat %s",
+                len(topics),
+                chat_id,
+            )
+
+        except ForumTopicError as e:
+            result["error"] = str(e)
+            logger.error("Failed to handle bot added to %s: %s", chat_id, e)
+
+        return result
+
+    def get_all_group_states(self) -> dict[str, GroupForumState]:
+        """Get all group forum states.
+
+        Returns:
+            Dict mapping chat IDs to their forum states.
+        """
+        if not self._states:
+            self._states = self._load_all_states()
+        # Return deep copy to prevent external modification of internal state
+        return {
+            k: GroupForumState.from_dict(v.to_dict())
+            for k, v in self._states.items()
+        }

--- a/tests/unit/test_forum_manager.py
+++ b/tests/unit/test_forum_manager.py
@@ -1,0 +1,918 @@
+"""Tests for gasclaw.openclaw.forum_manager."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from gasclaw.openclaw.forum_manager import (
+    DEFAULT_STATE_DIR,
+    REQUIRED_TOPICS,
+    TOPIC_CONFIG_FILE,
+    ForumTopicError,
+    ForumTopicManager,
+    GroupForumState,
+    TopicConfig,
+)
+
+
+class TestTopicConfig:
+    """Tests for TopicConfig dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        config = TopicConfig(name="test-topic", thread_id=123, created_at=1234567890.0)
+        result = config.to_dict()
+        assert result == {
+            "name": "test-topic",
+            "thread_id": 123,
+            "created_at": 1234567890.0,
+        }
+
+    def test_from_dict(self):
+        """Test creation from dictionary."""
+        data = {"name": "test-topic", "thread_id": 123, "created_at": 1234567890.0}
+        config = TopicConfig.from_dict(data)
+        assert config.name == "test-topic"
+        assert config.thread_id == 123
+        assert config.created_at == 1234567890.0
+
+    def test_from_dict_with_defaults(self):
+        """Test creation from dictionary with missing fields."""
+        data = {"name": "test-topic"}
+        config = TopicConfig.from_dict(data)
+        assert config.name == "test-topic"
+        assert config.thread_id is None
+        assert config.created_at is None
+
+
+class TestGroupForumState:
+    """Tests for GroupForumState dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        topic = TopicConfig(name="test", thread_id=1)
+        state = GroupForumState(
+            chat_id="-1001234567890",
+            is_forum=True,
+            topics={"test": topic},
+            admin_checked=True,
+            is_admin=True,
+        )
+        result = state.to_dict()
+        assert result["chat_id"] == "-1001234567890"
+        assert result["is_forum"] is True
+        assert result["topics"]["test"]["name"] == "test"
+        assert result["admin_checked"] is True
+        assert result["is_admin"] is True
+
+    def test_from_dict(self):
+        """Test creation from dictionary."""
+        data = {
+            "chat_id": "-1001234567890",
+            "is_forum": True,
+            "topics": {"test": {"name": "test", "thread_id": 1}},
+            "admin_checked": True,
+            "is_admin": True,
+        }
+        state = GroupForumState.from_dict(data)
+        assert state.chat_id == "-1001234567890"
+        assert state.is_forum is True
+        assert "test" in state.topics
+        assert state.topics["test"].thread_id == 1
+        assert state.admin_checked is True
+        assert state.is_admin is True
+
+    def test_has_all_topics_true(self):
+        """Test has_all_topics returns True when all required topics exist."""
+        state = GroupForumState(chat_id="-1001234567890")
+        for topic_name in REQUIRED_TOPICS:
+            state.topics[topic_name] = TopicConfig(name=topic_name, thread_id=1)
+        assert state.has_all_topics() is True
+
+    def test_has_all_topics_false_missing_topic(self):
+        """Test has_all_topics returns False when a topic is missing."""
+        state = GroupForumState(chat_id="-1001234567890")
+        for topic_name in REQUIRED_TOPICS[:-1]:
+            state.topics[topic_name] = TopicConfig(name=topic_name, thread_id=1)
+        assert state.has_all_topics() is False
+
+    def test_has_all_topics_false_no_thread_id(self):
+        """Test has_all_topics returns False when thread_id is None."""
+        state = GroupForumState(chat_id="-1001234567890")
+        for topic_name in REQUIRED_TOPICS:
+            state.topics[topic_name] = TopicConfig(name=topic_name, thread_id=None)
+        assert state.has_all_topics() is False
+
+    def test_get_thread_id_exists(self):
+        """Test getting thread ID for existing topic."""
+        state = GroupForumState(chat_id="-1001234567890")
+        state.topics["test"] = TopicConfig(name="test", thread_id=123)
+        assert state.get_thread_id("test") == 123
+
+    def test_get_thread_id_missing(self):
+        """Test getting thread ID for missing topic."""
+        state = GroupForumState(chat_id="-1001234567890")
+        assert state.get_thread_id("missing") is None
+
+
+class TestForumTopicManagerInit:
+    """Tests for ForumTopicManager initialization."""
+
+    def test_init_with_defaults(self):
+        """Test initialization with default values."""
+        manager = ForumTopicManager(bot_token="test_token")
+        assert manager.bot_token == "test_token"
+        assert manager.state_dir == Path(DEFAULT_STATE_DIR)
+        assert manager._states == {}
+        assert manager._base_url == "https://api.telegram.org/bottest_token"
+
+    def test_init_with_custom_state_dir(self):
+        """Test initialization with custom state directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            assert manager.state_dir == Path(tmpdir)
+
+    def test_state_file_property(self):
+        """Test state_file property returns correct path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            assert manager.state_file == Path(tmpdir) / TOPIC_CONFIG_FILE
+
+
+class TestForumTopicManagerStatePersistence:
+    """Tests for state loading and saving."""
+
+    def test_load_all_states_empty(self):
+        """Test loading when no state file exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            states = manager._load_all_states()
+            assert states == {}
+
+    def test_load_all_states_existing(self):
+        """Test loading existing state file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / TOPIC_CONFIG_FILE
+            data = {
+                "-1001234567890": {
+                    "chat_id": "-1001234567890",
+                    "is_forum": True,
+                    "topics": {},
+                    "admin_checked": False,
+                    "is_admin": False,
+                }
+            }
+            state_file.write_text(json.dumps(data))
+
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            states = manager._load_all_states()
+            assert "-1001234567890" in states
+            assert states["-1001234567890"].is_forum is True
+
+    def test_load_all_states_invalid_json(self):
+        """Test loading invalid JSON logs warning and returns empty dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / TOPIC_CONFIG_FILE
+            state_file.write_text("invalid json")
+
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            states = manager._load_all_states()
+            assert states == {}
+
+    def test_save_all_states_creates_directory(self):
+        """Test save creates state directory if needed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nested_dir = Path(tmpdir) / "nested" / "state"
+            manager = ForumTopicManager(bot_token="test_token", state_dir=nested_dir)
+
+            state = GroupForumState(chat_id="-1001234567890")
+            manager._save_all_states({"-1001234567890": state})
+
+            assert nested_dir.exists()
+            assert (nested_dir / TOPIC_CONFIG_FILE).exists()
+
+    def test_save_and_load_roundtrip(self):
+        """Test save followed by load preserves data."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+
+            state = GroupForumState(
+                chat_id="-1001234567890",
+                is_forum=True,
+                topics={"test": TopicConfig(name="test", thread_id=123)},
+                admin_checked=True,
+                is_admin=True,
+            )
+            manager._save_all_states({"-1001234567890": state})
+
+            # Create new manager instance to test loading
+            manager2 = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            states = manager2._load_all_states()
+
+            assert "-1001234567890" in states
+            loaded_state = states["-1001234567890"]
+            assert loaded_state.is_forum is True
+            assert loaded_state.topics["test"].thread_id == 123
+
+    def test_save_updates_internal_state(self):
+        """Test save updates internal _states dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state = GroupForumState(chat_id="-1001234567890")
+            manager._save_all_states({"-1001234567890": state})
+            assert manager._states == {"-1001234567890": state}
+
+
+class TestForumTopicManagerGetGroupState:
+    """Tests for get_group_state method."""
+
+    def test_get_group_state_creates_new(self):
+        """Test get_group_state creates new state for unknown chat."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state = manager.get_group_state("-1001234567890")
+            assert state.chat_id == "-1001234567890"
+            assert state.is_forum is False
+
+    def test_get_group_state_returns_cached(self):
+        """Test get_group_state returns cached state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state1 = manager.get_group_state("-1001234567890")
+            state1.is_forum = True
+
+            state2 = manager.get_group_state("-1001234567890")
+            assert state2.is_forum is True
+            assert state1 is state2
+
+    def test_get_group_state_loads_from_disk(self):
+        """Test get_group_state loads from disk when cache is empty."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Pre-populate state file
+            state_file = Path(tmpdir) / TOPIC_CONFIG_FILE
+            data = {
+                "-1001234567890": {
+                    "chat_id": "-1001234567890",
+                    "is_forum": True,
+                    "topics": {},
+                    "admin_checked": True,
+                    "is_admin": True,
+                }
+            }
+            state_file.write_text(json.dumps(data))
+
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state = manager.get_group_state("-1001234567890")
+            assert state.is_forum is True
+            assert state.admin_checked is True
+
+
+class TestForumTopicManagerApiRequests:
+    """Tests for API request methods."""
+
+    @respx.mock
+    def test_make_request_success(self):
+        """Test successful API request."""
+        route = respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(200, json={"ok": True, "result": {"id": 123}})
+        )
+
+        manager = ForumTopicManager(bot_token="test_token")
+        result = manager._make_request("getChat", {"chat_id": "-1001234567890"})
+
+        assert route.called
+        assert result == {"id": 123}
+
+    @respx.mock
+    def test_make_request_telegram_error(self):
+        """Test API request with Telegram error."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": False, "error_code": 400, "description": "Bad Request"}
+            )
+        )
+
+        manager = ForumTopicManager(bot_token="test_token")
+        with pytest.raises(ForumTopicError) as exc_info:
+            manager._make_request("getChat", {"chat_id": "-1001234567890"})
+        assert "400" in str(exc_info.value)
+        assert "Bad Request" in str(exc_info.value)
+
+    @respx.mock
+    def test_make_request_http_error(self):
+        """Test API request with HTTP error."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(500, text="Internal Server Error")
+        )
+
+        manager = ForumTopicManager(bot_token="test_token")
+        with pytest.raises(ForumTopicError) as exc_info:
+            manager._make_request("getChat", {"chat_id": "-1001234567890"})
+        assert "HTTP error" in str(exc_info.value)
+
+    @respx.mock
+    def test_make_request_network_error(self):
+        """Test API request with network error."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+
+        manager = ForumTopicManager(bot_token="test_token")
+        with pytest.raises(ForumTopicError) as exc_info:
+            manager._make_request("getChat", {"chat_id": "-1001234567890"})
+        assert "HTTP error" in str(exc_info.value)
+
+
+class TestForumTopicManagerCheckIsForum:
+    """Tests for check_is_forum method."""
+
+    @respx.mock
+    def test_check_is_forum_true(self):
+        """Test check_is_forum returns True for forum."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": True}}
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.check_is_forum("-1001234567890")
+            assert result is True
+
+            state = manager.get_group_state("-1001234567890")
+            assert state.is_forum is True
+
+    @respx.mock
+    def test_check_is_forum_false(self):
+        """Test check_is_forum returns False for non-forum."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": False}}
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.check_is_forum("-1001234567890")
+            assert result is False
+
+    @respx.mock
+    def test_check_is_forum_api_error(self):
+        """Test check_is_forum returns False on API error."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(400, json={"ok": False, "error_code": 400})
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.check_is_forum("-1001234567890")
+            assert result is False
+
+
+class TestForumTopicManagerCheckIsAdmin:
+    """Tests for check_is_admin method."""
+
+    @respx.mock
+    def test_check_is_admin_true(self):
+        """Test check_is_admin returns True when bot is admin with topic management."""
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "user": {"id": 123},
+                        "status": "administrator",
+                        "can_manage_topics": True,
+                    },
+                },
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.check_is_admin("-1001234567890")
+            assert result is True
+
+            state = manager.get_group_state("-1001234567890")
+            assert state.is_admin is True
+            assert state.admin_checked is True
+
+    @respx.mock
+    def test_check_is_admin_not_admin(self):
+        """Test check_is_admin returns False when bot is not admin."""
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {"user": {"id": 123}, "status": "member"},
+                },
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.check_is_admin("-1001234567890")
+            assert result is False
+
+    @respx.mock
+    def test_check_is_admin_no_topic_permission(self):
+        """Test check_is_admin returns False when bot can't manage topics."""
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "user": {"id": 123},
+                        "status": "administrator",
+                        "can_manage_topics": False,
+                    },
+                },
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.check_is_admin("-1001234567890")
+            assert result is False
+
+    @respx.mock
+    def test_check_is_admin_creator_status(self):
+        """Test check_is_admin returns True when bot is creator."""
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "user": {"id": 123},
+                        "status": "creator",
+                        "can_manage_topics": True,
+                    },
+                },
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.check_is_admin("-1001234567890")
+            assert result is True
+
+
+class TestForumTopicManagerCreateTopic:
+    """Tests for create_forum_topic method."""
+
+    @respx.mock
+    def test_create_forum_topic_success(self):
+        """Test successful topic creation."""
+        respx.post("https://api.telegram.org/bottest_token/createForumTopic").mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"message_thread_id": 12345}},
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.create_forum_topic("-1001234567890", "Test Topic")
+            assert result == 12345
+
+    @respx.mock
+    def test_create_forum_topic_with_icon_color(self):
+        """Test topic creation with icon color."""
+        route = respx.post("https://api.telegram.org/bottest_token/createForumTopic").mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"message_thread_id": 12345}},
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.create_forum_topic("-1001234567890", "Test Topic", icon_color=1)
+            assert result == 12345
+
+            request = json.loads(route.calls[0].request.content)
+            assert request["icon_color"] == 1
+
+    @respx.mock
+    def test_create_forum_topic_failure(self):
+        """Test topic creation failure returns None."""
+        respx.post("https://api.telegram.org/bottest_token/createForumTopic").mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": False, "error_code": 400, "description": "Topic exists"},
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.create_forum_topic("-1001234567890", "Test Topic")
+            assert result is None
+
+
+class TestForumTopicManagerSetupGroupTopics:
+    """Tests for setup_group_topics method."""
+
+    @respx.mock
+    def test_setup_group_topics_success(self):
+        """Test successful setup of all required topics."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": True}}
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "user": {"id": 123},
+                        "status": "administrator",
+                        "can_manage_topics": True,
+                    },
+                },
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/createForumTopic").mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"message_thread_id": 100}},
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.setup_group_topics("-1001234567890")
+
+            # Should create all required topics
+            assert len(result) == len(REQUIRED_TOPICS)
+            for topic_name in REQUIRED_TOPICS:
+                assert topic_name in result
+
+    @respx.mock
+    def test_setup_group_topics_not_forum(self):
+        """Test setup raises error when chat is not forum."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": False}}
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            with pytest.raises(ForumTopicError) as exc_info:
+                manager.setup_group_topics("-1001234567890")
+            assert "not a forum supergroup" in str(exc_info.value)
+
+    @respx.mock
+    def test_setup_group_topics_not_admin(self):
+        """Test setup raises error when bot is not admin."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": True}}
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {"user": {"id": 123}, "status": "member"},
+                },
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            with pytest.raises(ForumTopicError) as exc_info:
+                manager.setup_group_topics("-1001234567890")
+            assert "not admin" in str(exc_info.value)
+
+    @respx.mock
+    def test_setup_group_topics_skips_existing(self):
+        """Test setup skips topics that already exist."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": True}}
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "user": {"id": 123},
+                        "status": "administrator",
+                        "can_manage_topics": True,
+                    },
+                },
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/createForumTopic").mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"message_thread_id": 100}},
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            # First setup
+            result1 = manager.setup_group_topics("-1001234567890")
+            assert len(result1) == len(REQUIRED_TOPICS)
+
+            # Second setup should use cached topics
+            result2 = manager.setup_group_topics("-1001234567890")
+            assert len(result2) == len(REQUIRED_TOPICS)
+
+
+class TestForumTopicManagerGetThreadId:
+    """Tests for thread ID lookup methods."""
+
+    def test_get_topic_thread_id(self):
+        """Test getting thread ID for a topic."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state = manager.get_group_state("-1001234567890")
+            state.topics["pull-request"] = TopicConfig(
+                name="pull-request", thread_id=123
+            )
+
+            result = manager.get_topic_thread_id("-1001234567890", "pull-request")
+            assert result == 123
+
+    def test_get_topic_thread_id_missing(self):
+        """Test getting thread ID for missing topic returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.get_topic_thread_id("-1001234567890", "missing")
+            assert result is None
+
+    def test_get_notification_thread_id_pr(self):
+        """Test notification mapping for PR."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state = manager.get_group_state("-1001234567890")
+            state.topics["pull-request"] = TopicConfig(
+                name="pull-request", thread_id=100
+            )
+
+            assert manager.get_notification_thread_id("-1001234567890", "pr") == 100
+            assert (
+                manager.get_notification_thread_id("-1001234567890", "pull-request")
+                == 100
+            )
+
+    def test_get_notification_thread_id_issue(self):
+        """Test notification mapping for issue."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state = manager.get_group_state("-1001234567890")
+            state.topics["issue"] = TopicConfig(name="issue", thread_id=200)
+
+            assert manager.get_notification_thread_id("-1001234567890", "issue") == 200
+            assert manager.get_notification_thread_id("-1001234567890", "issues") == 200
+
+    def test_get_notification_thread_id_maintenance(self):
+        """Test notification mapping for maintenance."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state = manager.get_group_state("-1001234567890")
+            state.topics["maintenance"] = TopicConfig(
+                name="maintenance", thread_id=300
+            )
+
+            assert (
+                manager.get_notification_thread_id("-1001234567890", "maintenance")
+                == 300
+            )
+            assert manager.get_notification_thread_id("-1001234567890", "health") == 300
+            assert manager.get_notification_thread_id("-1001234567890", "watchdog") == 300
+
+    def test_get_notification_thread_id_discussion(self):
+        """Test notification mapping for discussion."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            state = manager.get_group_state("-1001234567890")
+            state.topics["discussion"] = TopicConfig(
+                name="discussion", thread_id=400
+            )
+
+            assert (
+                manager.get_notification_thread_id("-1001234567890", "discussion")
+                == 400
+            )
+            assert manager.get_notification_thread_id("-1001234567890", "general") == 400
+
+    def test_get_notification_thread_id_unknown(self):
+        """Test notification mapping for unknown type returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.get_notification_thread_id("-1001234567890", "unknown")
+            assert result is None
+
+
+class TestForumTopicManagerRequestAdminPromotion:
+    """Tests for request_admin_promotion method."""
+
+    @respx.mock
+    def test_request_admin_promotion_success(self):
+        """Test successful admin promotion request."""
+        route = respx.post("https://api.telegram.org/bottest_token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 1}})
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.request_admin_promotion("-1001234567890")
+            assert result is True
+            assert route.called
+
+            request = json.loads(route.calls[0].request.content)
+            assert "Admin Required" in request["text"]
+            assert request["parse_mode"] == "Markdown"
+
+    @respx.mock
+    def test_request_admin_promotion_failure(self):
+        """Test admin promotion request failure."""
+        respx.post("https://api.telegram.org/bottest_token/sendMessage").mock(
+            return_value=httpx.Response(400, json={"ok": False})
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.request_admin_promotion("-1001234567890")
+            assert result is False
+
+
+class TestForumTopicManagerHandleBotAdded:
+    """Tests for handle_bot_added method."""
+
+    @respx.mock
+    def test_handle_bot_added_non_forum(self):
+        """Test handling bot added to non-forum group."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": False}}
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.handle_bot_added("-1001234567890", "supergroup")
+
+            assert result["success"] is True
+            assert result["is_forum"] is False
+            assert result["topics_created"] == {}
+
+    @respx.mock
+    def test_handle_bot_added_not_admin(self):
+        """Test handling bot added to forum but not admin."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": True}}
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {"user": {"id": 123}, "status": "member"},
+                },
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.handle_bot_added("-1001234567890", "supergroup")
+
+            assert result["success"] is False
+            assert result["is_forum"] is True
+            assert result["is_admin"] is False
+            assert result["admin_requested"] is True
+
+    @respx.mock
+    def test_handle_bot_added_success(self):
+        """Test successful handling of bot added to forum."""
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "result": {"id": 123, "is_forum": True}}
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/getChatMember").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "user": {"id": 123},
+                        "status": "administrator",
+                        "can_manage_topics": True,
+                    },
+                },
+            )
+        )
+        respx.post("https://api.telegram.org/bottest_token/createForumTopic").mock(
+            return_value=httpx.Response(
+                200,
+                json={"ok": True, "result": {"message_thread_id": 100}},
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.handle_bot_added("-1001234567890", "supergroup")
+
+            assert result["success"] is True
+            assert result["is_forum"] is True
+            assert result["is_admin"] is True
+            assert len(result["topics_created"]) == len(REQUIRED_TOPICS)
+
+    @respx.mock
+    def test_handle_bot_added_api_error_graceful(self):
+        """Test handling API error gracefully during bot added processing.
+
+        When API fails, check_is_forum returns False and the bot treats it
+        as a non-forum chat, returning success=True (skip rather than fail).
+        """
+        respx.post("https://api.telegram.org/bottest_token/getChat").mock(
+            side_effect=httpx.ConnectError("Connection failed")
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.handle_bot_added("-1001234567890", "supergroup")
+
+            # API errors are caught and treated as non-forum (graceful skip)
+            assert result["success"] is True
+            assert result["is_forum"] is False
+            assert result["error"] is None
+
+
+class TestForumTopicError:
+    """Tests for ForumTopicError exception."""
+
+    def test_error_with_chat_id(self):
+        """Test error with chat ID."""
+        error = ForumTopicError("Test error", chat_id="-1001234567890")
+        assert str(error) == "Test error"
+        assert error.chat_id == "-1001234567890"
+
+    def test_error_without_chat_id(self):
+        """Test error without chat ID."""
+        error = ForumTopicError("Test error")
+        assert str(error) == "Test error"
+        assert error.chat_id is None
+
+
+class TestForumTopicManagerGetAllGroupStates:
+    """Tests for get_all_group_states method."""
+
+    def test_get_all_group_states_empty(self):
+        """Test getting all states when empty."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            result = manager.get_all_group_states()
+            assert result == {}
+
+    def test_get_all_group_states_populated(self):
+        """Test getting all states when populated."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            manager._states = {
+                "-1001234567890": GroupForumState(chat_id="-1001234567890"),
+                "-1000987654321": GroupForumState(chat_id="-1000987654321"),
+            }
+            result = manager.get_all_group_states()
+            assert len(result) == 2
+            assert "-1001234567890" in result
+            assert "-1000987654321" in result
+
+    def test_get_all_group_states_returns_copy(self):
+        """Test that get_all_group_states returns a copy."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ForumTopicManager(bot_token="test_token", state_dir=tmpdir)
+            manager._states = {
+                "-1001234567890": GroupForumState(chat_id="-1001234567890"),
+            }
+            result = manager.get_all_group_states()
+            result["-1001234567890"].is_forum = True
+            assert manager._states["-1001234567890"].is_forum is False


### PR DESCRIPTION
## Summary

Implements `ForumTopicManager` to automatically create and manage Telegram forum topics when the bot joins a supergroup.

## Changes

- **New module**: `src/gasclaw/openclaw/forum_manager.py`
  - `ForumTopicManager` class for topic lifecycle management
  - `GroupForumState` dataclass for per-group state
  - `TopicConfig` dataclass for topic metadata
  - `ForumTopicError` exception for error handling

## Features

- Auto-detects if chat is a forum supergroup
- Checks admin permissions with topic management capability
- Creates required topics: `pull-request`, `issue`, `maintenance`, `discussion`
- Persists state to `/workspace/state/forum_topics.json`
- Maps notification types to appropriate topics
- Sends admin promotion requests when permissions insufficient

## Test Plan

- [x] All 925 unit tests pass (58 new tests added)
- [x] Tests cover state persistence, API mocking via respx, error handling
- [x] Follows TDD pattern - tests written first

## Closes

Closes #270