### PR TITLE
Fix test isolation for containerized environments

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -77,6 +77,13 @@ class TestLoadConfig:
         """Optional fields use defaults."""
         for k, v in env_vars().items():
             monkeypatch.setenv(k, v)
+        # Ensure optional env vars are unset to test defaults
+        monkeypatch.delenv("GT_AGENT_COUNT", raising=False)
+        monkeypatch.delenv("GT_RIG_URL", raising=False)
+        monkeypatch.delenv("PROJECT_DIR", raising=False)
+        monkeypatch.delenv("MONITOR_INTERVAL", raising=False)
+        monkeypatch.delenv("ACTIVITY_DEADLINE", raising=False)
+        monkeypatch.delenv("DOLT_PORT", raising=False)
         cfg = load_config()
         assert cfg.gt_rig_url == "/project"
         assert cfg.project_dir == "/project"

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from gasclaw.migration import (
     MigrationResult,
@@ -91,6 +94,10 @@ class TestDetectGastownSetup:
 
     def test_handles_config_file_permission_error(self, tmp_path, monkeypatch):
         """Handles permission errors when reading config file."""
+        # Skip when running as root - root bypasses permission checks
+        if os.getuid() == 0:
+            pytest.skip("Permission tests don't work when running as root")
+        
         monkeypatch.delenv("KIMI_API_KEY", raising=False)
         monkeypatch.delenv("GASTOWN_KIMI_KEYS", raising=False)
 

--- a/tests/unit/test_yaml_config.py
+++ b/tests/unit/test_yaml_config.py
@@ -65,6 +65,8 @@ gastown:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123456:ABC")
         monkeypatch.setenv("TELEGRAM_OWNER_ID", "123456")
         monkeypatch.setenv("GASCLAW_CONFIG", str(config_file))
+        # Clear env vars to test YAML override of defaults
+        monkeypatch.delenv("GT_AGENT_COUNT", raising=False)
 
         cfg = load_config()
         assert cfg.gt_agent_count == 10
@@ -99,6 +101,8 @@ gastown:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123456:ABC")
         monkeypatch.setenv("TELEGRAM_OWNER_ID", "123456")
         monkeypatch.setenv("GASCLAW_CONFIG", str(config_file))
+        # Clear env vars to test YAML override of defaults
+        monkeypatch.delenv("GT_AGENT_COUNT", raising=False)
 
         cfg = load_config()
         assert cfg.gt_agent_count == 8  # from YAML
@@ -118,6 +122,9 @@ maintenance:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123456:ABC")
         monkeypatch.setenv("TELEGRAM_OWNER_ID", "123456")
         monkeypatch.setenv("GASCLAW_CONFIG", str(config_file))
+        # Clear env vars to test YAML values
+        monkeypatch.delenv("MONITOR_INTERVAL", raising=False)
+        monkeypatch.delenv("ACTIVITY_DEADLINE", raising=False)
 
         cfg = load_config()
         assert cfg.monitor_interval == 600
@@ -136,6 +143,9 @@ services:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123456:ABC")
         monkeypatch.setenv("TELEGRAM_OWNER_ID", "123456")
         monkeypatch.setenv("GASCLAW_CONFIG", str(config_file))
+        # Clear env vars to test YAML values
+        monkeypatch.delenv("DOLT_PORT", raising=False)
+        monkeypatch.delenv("GATEWAY_PORT", raising=False)
 
         cfg = load_config()
         assert cfg.dolt_port == 3308
@@ -221,6 +231,9 @@ class TestEmptyYamlConfig:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123456:ABC")
         monkeypatch.setenv("TELEGRAM_OWNER_ID", "123456")
         monkeypatch.setenv("GASCLAW_CONFIG", str(config_file))
+        # Clear optional env vars to test defaults
+        monkeypatch.delenv("GT_AGENT_COUNT", raising=False)
+        monkeypatch.delenv("MONITOR_INTERVAL", raising=False)
 
         cfg = load_config()
         assert cfg.gt_agent_count == 6  # default
@@ -233,6 +246,9 @@ class TestEmptyYamlConfig:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123456:ABC")
         monkeypatch.setenv("TELEGRAM_OWNER_ID", "123456")
         monkeypatch.setenv("GASCLAW_CONFIG", str(tmp_path / "nonexistent.yaml"))
+        # Clear optional env vars to test defaults
+        monkeypatch.delenv("GT_AGENT_COUNT", raising=False)
+        monkeypatch.delenv("MONITOR_INTERVAL", raising=False)
 
         cfg = load_config()
         assert cfg.gt_agent_count == 6  # default
@@ -253,6 +269,8 @@ services:
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123456:ABC")
         monkeypatch.setenv("TELEGRAM_OWNER_ID", "123456")
         monkeypatch.setenv("GASCLAW_CONFIG", str(config_file))
+        # Clear env var to test YAML validation
+        monkeypatch.delenv("DOLT_PORT", raising=False)
 
         import logging
         with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
Several unit tests were failing when environment variables (GT_AGENT_COUNT, MONITOR_INTERVAL, etc.) are pre-set in the container environment. This is common in CI/CD and development containers.

## Changes

- **test_config.py**: Unset optional env vars before testing defaults
- **test_migration.py**: Skip permission error test when running as root (root bypasses permission checks)
- **test_yaml_config.py**: Unset env vars before testing YAML override behavior

## Test Results

All 955 tests now pass (1 skipped due to root permission test):
```
955 passed, 1 skipped
```

These changes ensure tests properly isolate themselves from the host environment and test the intended behavior.