### PR TITLE
feat(openclaw): add proper public API exports

### DIFF
--- a/src/gasclaw/openclaw/__init__.py
+++ b/src/gasclaw/openclaw/__init__.py
@@ -3,3 +3,33 @@
 Provides installation, configuration, and lifecycle management
 for the OpenClaw overseer service.
 """
+
+from gasclaw.openclaw.auth import get_gateway_auth_token
+from gasclaw.openclaw.doctor import DoctorResult, run_doctor
+from gasclaw.openclaw.forum_manager import (
+    ForumTopicError,
+    ForumTopicManager,
+    TopicConfig,
+)
+from gasclaw.openclaw.installer import write_openclaw_config
+from gasclaw.openclaw.lifecycle import start_openclaw, stop_openclaw
+from gasclaw.openclaw.skill_manager import install_skills
+
+__all__ = [
+    # Auth
+    "get_gateway_auth_token",
+    # Doctor
+    "DoctorResult",
+    "run_doctor",
+    # Forum
+    "ForumTopicError",
+    "ForumTopicManager",
+    "TopicConfig",
+    # Installer
+    "write_openclaw_config",
+    # Lifecycle
+    "start_openclaw",
+    "stop_openclaw",
+    # Skills
+    "install_skills",
+]

--- a/src/gasclaw/openclaw/doctor.py
+++ b/src/gasclaw/openclaw/doctor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 
+__all__ = ["DoctorResult", "run_doctor"]
+
 
 @dataclass
 class DoctorResult:


### PR DESCRIPTION
## Summary

Adds proper `__all__` declarations and public API exports to the `openclaw` module.

## Changes

- **doctor.py**: Add `__all__` to explicitly export `DoctorResult` and `run_doctor`
- **__init__.py**: Exports all public functions/classes from submodules

## Benefits

- Follows Python best practices for module exports
- Makes the API more discoverable and IDE-friendly
- Enables clean imports: `from gasclaw.openclaw import write_openclaw_config, start_openclaw`

## Testing

- All 954 existing tests pass
- Verified exports work correctly via import test

## Size

+32 lines (well under 200 line limit)
