### PR TITLE
style: add noqa comments to intentional broad exception handlers

### DIFF
--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -141,7 +141,7 @@ def bootstrap(config: GasclawConfig, *, gt_root: Path = Path("/workspace/gt")) -
         logger.info("Sending startup notification")
         notify_telegram("Gasclaw is up and running.", auth_token=auth_token)
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.exception("Bootstrap failed at step")
         # Get auth token if available for error notifications
         error_token = auth_token if 'auth_token' in vars() else ""
@@ -157,7 +157,7 @@ def bootstrap(config: GasclawConfig, *, gt_root: Path = Path("/workspace/gt")) -
                 if services_started:
                     stop_openclaw()
                 logger.info("Rollback completed")
-            except Exception as rollback_error:
+            except Exception as rollback_error:  # noqa: BLE001
                 # Log rollback error but raise original exception
                 logger.error("Rollback failed: %s", rollback_error)
                 notify_telegram(

--- a/src/gasclaw/gastown/lifecycle.py
+++ b/src/gasclaw/gastown/lifecycle.py
@@ -51,7 +51,7 @@ def start_dolt(
                 return
             time.sleep(1)
         raise TimeoutError(f"Dolt not ready after {timeout}s on port {port}")
-    except Exception:
+    except Exception:  # noqa: BLE001
         # Clean up subprocess on any failure
         proc.terminate()
         try:

--- a/src/gasclaw/openclaw/lifecycle.py
+++ b/src/gasclaw/openclaw/lifecycle.py
@@ -55,7 +55,7 @@ def start_openclaw(
             time.sleep(1)
 
         raise TimeoutError(f"OpenClaw not ready after {timeout}s on port {port}")
-    except Exception:
+    except Exception:  # noqa: BLE001
         # Clean up subprocess on any failure
         proc.terminate()
         try:


### PR DESCRIPTION
## Summary

Add `# noqa: BLE001` comments to cleanup/rollback exception handlers that intentionally catch all exceptions. This documents intent and makes the codebase consistent with other similar handlers that already have noqa comments.

## Changes

- `bootstrap.py`: Add noqa to bootstrap error handler and rollback error handler
- `gastown/lifecycle.py`: Add noqa to dolt startup cleanup handler  
- `openclaw/lifecycle.py`: Add noqa to openclaw startup cleanup handler

## Rationale

These exception handlers intentionally catch all exceptions during cleanup/rollback operations to ensure resources are properly released even when unexpected errors occur. The noqa comments document this intent and prevent false positives from linting tools.

## Testing

- [x] All 954 unit tests pass
- [x] Ruff linting passes
- [x] Changes are minimal (4 lines across 3 files)