### PR TITLE
refactor: simplify redundant exception handling in ci_monitor.py

### DIFF
--- a/src/gasclaw/ci_monitor.py
+++ b/src/gasclaw/ci_monitor.py
@@ -77,7 +77,7 @@ def get_failed_workflows(repo: str) -> list[CIFailure]:
     except json.JSONDecodeError as e:
         logger.warning("Failed to parse gh output: %s", e)
         return []
-    except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
+    except Exception as e:  # noqa: BLE001
         logger.warning("Failed to get failed workflows: %s", e)
         return []
 
@@ -186,7 +186,7 @@ when a GitHub Actions workflow failed.
             logger.warning("Failed to create issue: %s", result.stderr)
             return False
 
-    except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
+    except Exception as e:  # noqa: BLE001
         logger.warning("Failed to create issue: %s", e)
         return False
 


### PR DESCRIPTION
## Summary

Simplifies redundant exception handling patterns in `ci_monitor.py`.

## Changes

- Replaced `except (subprocess.TimeoutExpired, FileNotFoundError, Exception)` with `except Exception` (with `# noqa: BLE001` for ruff compliance)
- Since `Exception` is the base class for all exceptions, listing specific exception types before it was redundant
- This makes the code cleaner and more idiomatic

## Testing

- All 954 unit tests pass
- Ruff linting passes
- No functional changes - behavior remains identical

## Checklist

- [x] `make test` passes (954 tests)
- [x] `make lint` passes
- [x] Single concern PR (\<200 lines)