### PR TITLE
Add __all__ declarations to module __init__.py files

### DIFF
--- a/src/gasclaw/gastown/__init__.py
+++ b/src/gasclaw/gastown/__init__.py
@@ -3,3 +3,19 @@
 Provides installation, configuration, and lifecycle management
 for Gastown agents and services.
 """
+
+from __future__ import annotations
+
+from gasclaw.gastown.agent_config import configure_agent
+from gasclaw.gastown.installer import gastown_install, setup_kimi_accounts
+from gasclaw.gastown.lifecycle import start_daemon, start_dolt, start_mayor, stop_all
+
+__all__ = [
+    "configure_agent",
+    "gastown_install",
+    "setup_kimi_accounts",
+    "start_daemon",
+    "start_dolt",
+    "start_mayor",
+    "stop_all",
+]

--- a/src/gasclaw/openclaw/__init__.py
+++ b/src/gasclaw/openclaw/__init__.py
@@ -3,3 +3,21 @@
 Provides installation, configuration, and lifecycle management
 for the OpenClaw overseer service.
 """
+
+from __future__ import annotations
+
+from gasclaw.openclaw.auth import get_gateway_auth_token
+from gasclaw.openclaw.doctor import DoctorResult, run_doctor
+from gasclaw.openclaw.installer import write_openclaw_config
+from gasclaw.openclaw.lifecycle import start_openclaw, stop_openclaw
+from gasclaw.openclaw.skill_manager import install_skills
+
+__all__ = [
+    "get_gateway_auth_token",
+    "DoctorResult",
+    "run_doctor",
+    "write_openclaw_config",
+    "start_openclaw",
+    "stop_openclaw",
+    "install_skills",
+]

--- a/src/gasclaw/openclaw/doctor.py
+++ b/src/gasclaw/openclaw/doctor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 
+__all__ = ["DoctorResult", "run_doctor"]
+
 
 @dataclass
 class DoctorResult:

--- a/src/gasclaw/updater/__init__.py
+++ b/src/gasclaw/updater/__init__.py
@@ -3,3 +3,15 @@
 Provides version checking, update application, and notification
 for gt, claude, openclaw, and dolt components.
 """
+
+from __future__ import annotations
+
+from gasclaw.updater.applier import apply_updates
+from gasclaw.updater.checker import check_versions
+from gasclaw.updater.notifier import notify_telegram
+
+__all__ = [
+    "apply_updates",
+    "check_versions",
+    "notify_telegram",
+]


### PR DESCRIPTION
Add explicit public API exports to improve IDE autocomplete support, clean wildcard imports, and document module interfaces.

Changes:
- openclaw/__init__.py: Export auth, doctor, installer, lifecycle, skill_manager functions
- gastown/__init__.py: Export agent_config, installer, lifecycle functions  
- updater/__init__.py: Export applier, checker, notifier functions
- openclaw/doctor.py: Add missing __all__ declaration

Testing: All 954 tests pass. 48 lines changed.