### PR TITLE
feat: populate key_pool in health check reports

### DIFF
--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -193,9 +193,17 @@ def monitor_loop(
         interval = config.monitor_interval
 
     logger.info("Starting monitor loop with interval=%d seconds", interval)
+
+    # Initialize key pool for health checks
+    key_pool = KeyPool(config.gastown_kimi_keys)
+
     try:
         while True:
-            report = check_health()
+            report = check_health(
+                gateway_port=config.gateway_port,
+                dolt_port=config.dolt_port,
+                key_pool=key_pool,
+            )
             activity = check_agent_activity(
                 project_dir=config.project_dir,
                 deadline_seconds=config.activity_deadline,

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import httpx
 
+from gasclaw.kimigas.key_pool import KeyPool
 from gasclaw.openclaw.doctor import run_doctor
 
 logger = logging.getLogger(__name__)
@@ -116,15 +117,22 @@ def _list_agents() -> list[str]:
     return []
 
 
-def check_health(*, gateway_port: int = 18789, dolt_port: int = 3307) -> HealthReport:
+def check_health(
+    *,
+    gateway_port: int = 18789,
+    dolt_port: int = 3307,
+    key_pool: KeyPool | None = None,
+) -> HealthReport:
     """Run all health checks and return a complete report.
 
     Args:
         gateway_port: OpenClaw gateway port for connectivity check.
         dolt_port: Dolt SQL server port for health check.
+        key_pool: Optional KeyPool to include key status in the report.
 
     """
     doctor = run_doctor()
+    key_pool_status = key_pool.status() if key_pool else {}
     return HealthReport(
         dolt=_check_service(["dolt", "sql", "--port", str(dolt_port), "-q", "SELECT 1"], "dolt"),
         daemon=_check_service(["gt", "daemon", "status"], "daemon"),
@@ -132,6 +140,7 @@ def check_health(*, gateway_port: int = 18789, dolt_port: int = 3307) -> HealthR
         openclaw=_check_openclaw_gateway(gateway_port),
         openclaw_doctor="healthy" if doctor.healthy else "unhealthy",
         agents=_list_agents(),
+        key_pool=key_pool_status,
     )
 
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -9,6 +9,7 @@ import httpx
 import respx
 
 from gasclaw.health import HealthReport, check_agent_activity, check_health
+from gasclaw.kimigas.key_pool import KeyPool
 
 
 class TestCheckHealth:
@@ -971,3 +972,68 @@ class TestCheckAgentActivityClockSkew:
         assert report.dolt == "unhealthy"
         assert report.daemon == "unhealthy"
         assert report.mayor == "unhealthy"
+
+
+class TestCheckHealthKeyPool:
+    """Tests for check_health() with KeyPool parameter."""
+
+    def test_key_pool_status_populated(self, tmp_path, monkeypatch, respx_mock: respx.MockRouter):
+        """check_health populates key_pool field when KeyPool is provided."""
+        respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
+        )
+        pool = KeyPool(["sk-test1", "sk-test2", "sk-test3"], state_dir=tmp_path)
+        report = check_health(gateway_port=18789, key_pool=pool)
+
+        assert "total" in report.key_pool
+        assert "available" in report.key_pool
+        assert report.key_pool["total"] == 3
+        assert report.key_pool["available"] == 3
+
+    def test_key_pool_empty_without_pool(self, monkeypatch, respx_mock: respx.MockRouter):
+        """check_health returns empty key_pool when no KeyPool provided."""
+        respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
+        )
+        report = check_health(gateway_port=18789)
+
+        assert report.key_pool == {}
+
+    def test_key_pool_with_rate_limited_keys(
+        self, tmp_path, monkeypatch, respx_mock: respx.MockRouter
+    ):
+        """check_health shows rate-limited keys in key_pool status."""
+        respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
+        )
+        pool = KeyPool(["sk-test1", "sk-test2"], state_dir=tmp_path)
+        pool.mark_rate_limited("sk-test1")
+
+        report = check_health(gateway_port=18789, key_pool=pool)
+
+        assert report.key_pool["total"] == 2
+        assert report.key_pool["available"] == 1
+        assert report.key_pool["rate_limited"] == 1
+
+    def test_key_pool_passed_to_summary(self, tmp_path, monkeypatch, respx_mock: respx.MockRouter):
+        """HealthReport.summary() uses key_pool data when populated."""
+        respx_mock.get("http://localhost:18789/health").mock(return_value=httpx.Response(200))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(a[0], 0, stdout=b"ok"),
+        )
+        pool = KeyPool(["sk-test1", "sk-test2"], state_dir=tmp_path)
+        report = check_health(gateway_port=18789, key_pool=pool)
+
+        summary = report.summary()
+        assert "2/2" in summary or "Keys:" in summary


### PR DESCRIPTION
## Summary

The `HealthReport` dataclass has a `key_pool` field, but `check_health()` never populated it. This PR adds the missing functionality.

## Changes

- Added optional `key_pool` parameter to `check_health()`
- Populates `key_pool` status when `KeyPool` is provided
- Updated `monitor_loop()` to pass `KeyPool` to health checks
- Added 4 tests for key_pool status reporting

## Why

This allows the overseer (OpenClaw) to monitor key availability and rate-limiting status in health reports.

## Test Plan

- `make test` passes (958 tests)
- `make lint` passes
- New tests verify key_pool population and rate-limit tracking