### PR TITLE
docs: update test count from 628 to 954

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/gasclaw/
     ├── applier.py      # Run update commands
     └── notifier.py     # POST to OpenClaw gateway
 skills/                 # OpenClaw skills (5: health, keys, update, agents, ais-orchestrator)
-tests/unit/             # 628 unit tests — all mocked, no API keys needed
+tests/unit/             # 954 unit tests — all mocked, no API keys needed
 tests/integration/      # Integration tests (optional, needs services)
 ```
 
@@ -71,7 +71,7 @@ make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
 
-All 628 unit tests must pass. Never modify a test to make it pass — fix the code.
+All 954 unit tests must pass. Never modify a test to make it pass — fix the code.
 
 ## Architecture Decisions
 
@@ -121,7 +121,7 @@ All 628 unit tests must pass. Never modify a test to make it pass — fix the co
 ## PR Checklist
 
 Before creating a PR, verify:
-- [ ] `make test` passes (all 628 tests)
+- [ ] `make test` passes (all 954 tests)
 - [ ] `make lint` passes
 - [ ] New code has corresponding tests
 - [ ] Commit message follows `<type>: <description>` format

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For AI agents: [`llms.txt`](https://github.com/gastown-publish/gasclaw/blob/main
 ```bash
 python -m venv .venv && source .venv/bin/activate
 make dev
-make test       # 628 unit tests — no API keys needed
+make test       # 954 unit tests — no API keys needed
 make lint
 ```
 
@@ -90,7 +90,7 @@ src/gasclaw/
 reference/           # Distilled dependency docs (for agents)
 scripts/             # Validation scripts
 skills/              # OpenClaw skills
-tests/unit/          # 628 unit tests
+tests/unit/          # 954 unit tests
 ```
 
 ## Contributing

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -82,20 +82,20 @@ Expected output:
 ```
 ============================= test session starts ==============================
 platform linux -- Python 3.13.x, pytest-9.x.x
-collected 628 items
+collected 954 items
 
 tests/unit/... ............................................... [100%]
 
-============================== 628 passed in 12s ===============================
+============================== 954 passed in 12s ===============================
 ```
 
-All 628 unit tests run with mocked dependencies — no API keys or running services needed.
+All 954 unit tests run with mocked dependencies — no API keys or running services needed.
 
 ## Development Commands
 
 ```bash
 make dev        # Install dev dependencies
-make test       # Unit tests only (628 tests)
+make test       # Unit tests only (954 tests)
 make test-all   # All tests including integration
 make lint       # Ruff linting
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Gasclaw Documentation
 
-[![Tests](https://img.shields.io/badge/tests-628%20passing-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-954%20passing-brightgreen)]()
 [![License](https://img.shields.io/badge/license-MIT-blue)]()
 
 **Single-container deployment combining Gastown + OpenClaw + KimiGas.**

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -253,7 +253,7 @@ Use `gt agents` (correct). The flag `--agents` on `gt status` does not exist and
 ### Q: How do I run the tests?
 
 ```bash
-make test          # 628 unit tests (no API keys or services needed)
+make test          # 954 unit tests (no API keys or services needed)
 make test-all      # Includes integration tests
 make lint          # Ruff linting
 ```
@@ -328,7 +328,7 @@ docs: update architecture and troubleshooting guides
 
 ### Q: What should every PR include?
 
-- All 628 tests passing (`make test`)
+- All 954 tests passing (`make test`)
 - Lint passing (`make lint`)
 - New code has corresponding tests
 - Commit message follows `<type>: <description>`

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -43,7 +43,7 @@ npm install -g openclaw @anthropic-ai/claude-code
 ### 3. Verify
 
 ```bash
-make test    # 628 unit tests — no API keys needed
+make test    # 954 unit tests — no API keys needed
 ```
 
 ## Next Steps

--- a/docs/wiki/Knowledge-Base.md
+++ b/docs/wiki/Knowledge-Base.md
@@ -48,7 +48,7 @@ Most common cause: file permission error with `set -euo pipefail`. Fix: `docker 
 
 ## Testing
 
-**Q: Test count?** 628 unit tests, all mocked, no API keys needed.
+**Q: Test count?** 954 unit tests, all mocked, no API keys needed.
 
 **Q: Tests hang?** Bootstrap tests may leak env vars. Patch `build_claude_env` and `write_claude_config`.
 

--- a/maintainer/agent-bootstrap.md
+++ b/maintainer/agent-bootstrap.md
@@ -38,7 +38,7 @@ bash ~/.openclaw/skills/gasclaw-logs/scripts/logs.sh gateway 20
 
 ## Project Context
 
-- **Repo**: /workspace/gasclaw (Python 3.13, 628 unit tests)
+- **Repo**: /workspace/gasclaw (Python 3.13, 954 unit tests)
 - **Config**: /workspace/config/gasclaw.yaml (editable from host)
 - **Logs**: /workspace/logs/ (startup, claude, gateway, tests)
 - **State**: /workspace/state/ (PIDs, maintenance state, pause sentinel)


### PR DESCRIPTION
## Summary

Updates the documented test count from 628 to 954 across all documentation files to reflect the current test suite size.

## Changes

Updated test count references in:
- README.md
- CLAUDE.md  
- docs/getting-started/installation.md
- docs/index.md
- docs/knowledge-base.md
- docs/wiki/Installation.md
- docs/wiki/Knowledge-Base.md
- maintainer/agent-bootstrap.md

## Verification

- [x] All 954 unit tests pass
- [x] No functional code changes
- [x] Documentation-only PR (< 30 lines)

## Related

The test suite has grown from 628 to 954 tests through recent PRs. This update ensures all documentation accurately reflects the current test count.