### PR TITLE
feat: add __all__ declarations to module __init__.py files

### DIFF
--- a/src/gasclaw/gastown/__init__.py
+++ b/src/gasclaw/gastown/__init__.py
@@ -3,3 +3,37 @@
 Provides installation, configuration, and lifecycle management
 for Gastown agents and services.
 """
+
+from __future__ import annotations
+
+from gasclaw.gastown.agent_config import configure_agent
+from gasclaw.gastown.gt_feed import (
+    ActivityEvent,
+    GastownFeed,
+    format_feed_for_telegram,
+    get_recent_activity,
+)
+from gasclaw.gastown.installer import (
+    gastown_install,
+    setup_kimi_accounts,
+)
+from gasclaw.gastown.lifecycle import (
+    start_daemon,
+    start_dolt,
+    start_mayor,
+    stop_all,
+)
+
+__all__ = [
+    "ActivityEvent",
+    "GastownFeed",
+    "configure_agent",
+    "format_feed_for_telegram",
+    "gastown_install",
+    "get_recent_activity",
+    "setup_kimi_accounts",
+    "start_daemon",
+    "start_dolt",
+    "start_mayor",
+    "stop_all",
+]

--- a/src/gasclaw/openclaw/__init__.py
+++ b/src/gasclaw/openclaw/__init__.py
@@ -3,3 +3,31 @@
 Provides installation, configuration, and lifecycle management
 for the OpenClaw overseer service.
 """
+
+from __future__ import annotations
+
+from gasclaw.openclaw.auth import get_gateway_auth_token
+from gasclaw.openclaw.doctor import DoctorResult, run_doctor
+from gasclaw.openclaw.forum_manager import (
+    ForumTopicError,
+    ForumTopicManager,
+    GroupForumState,
+    TopicConfig,
+)
+from gasclaw.openclaw.installer import write_openclaw_config
+from gasclaw.openclaw.lifecycle import start_openclaw, stop_openclaw
+from gasclaw.openclaw.skill_manager import install_skills
+
+__all__ = [
+    "DoctorResult",
+    "ForumTopicError",
+    "ForumTopicManager",
+    "GroupForumState",
+    "TopicConfig",
+    "get_gateway_auth_token",
+    "install_skills",
+    "run_doctor",
+    "start_openclaw",
+    "stop_openclaw",
+    "write_openclaw_config",
+]

--- a/src/gasclaw/updater/__init__.py
+++ b/src/gasclaw/updater/__init__.py
@@ -3,3 +3,15 @@
 Provides version checking, update application, and notification
 for gt, claude, openclaw, and dolt components.
 """
+
+from __future__ import annotations
+
+from gasclaw.updater.applier import apply_updates
+from gasclaw.updater.checker import check_versions
+from gasclaw.updater.notifier import notify_telegram
+
+__all__ = [
+    "apply_updates",
+    "check_versions",
+    "notify_telegram",
+]


### PR DESCRIPTION
This PR adds explicit `__all__` declarations to the openclaw, gastown, and updater module `__init__.py` files.

## Changes

- `openclaw/__init__.py`: Export 10 public symbols (DoctorResult, ForumTopicError, ForumTopicManager, GroupForumState, TopicConfig, get_gateway_auth_token, install_skills, run_doctor, start_openclaw, stop_openclaw, write_openclaw_config)
- `gastown/__init__.py`: Export 10 public symbols (ActivityEvent, GastownFeed, configure_agent, format_feed_for_telegram, gastown_install, get_recent_activity, setup_kimi_accounts, start_daemon, start_dolt, start_mayor, stop_all)
- `updater/__init__.py`: Export 3 public symbols (apply_updates, check_versions, notify_telegram)

## Why

Explicit `__all__` declarations make the public API clear to users and follow Python best practices. This helps:
1. IDE autocompletion shows only public symbols
2. `from module import *` only imports public symbols
3. Clearer documentation of intended public API

## Testing

- All 954 unit tests pass
- Ruff linting passes
- No functional changes, only module exports