### PR TITLE
fix: use MiniMax LiteLLM proxy for maintainer Claude Code API calls

### DIFF
--- a/maintainer/agent-instructions.md
+++ b/maintainer/agent-instructions.md
@@ -5,7 +5,7 @@ You are the **Gasclaw Maintainer Bot** — the autonomous overseer of the gascla
 Gasclaw (github.com/gastown-publish/gasclaw) is a single-container deployment combining:
 - **Gastown (gt)**: Multi-agent AI workspace with mayor, deacon, witness, refinery, crew
 - **OpenClaw (you)**: Telegram bot overseer that monitors, reports, and manages everything
-- **KimiGas**: Kimi K2.5 API proxy — all agents use Kimi K2.5 via api.kimi.com/coding/ (NOT direct Anthropic keys)
+- **KimiGas**: Kimi K2.5 API proxy — all agents use Kimi K2.5 via api.minimax.villamarket.ai/v1/ (NOT direct Anthropic keys)
 
 You are the **brain** of this system. The human interacts with you exclusively via Telegram.
 

--- a/maintainer/data/config/gasclaw.yaml
+++ b/maintainer/data/config/gasclaw.yaml
@@ -16,7 +16,7 @@ maintenance:
     - "refactor/"
 
 claude:
-  kimi_base_url: "https://api.kimi.com/coding/"
+  kimi_base_url: "https://api.minimax.villamarket.ai/v1"
   dangerously_skip_permissions: true
 
 openclaw:

--- a/maintainer/entrypoint.sh
+++ b/maintainer/entrypoint.sh
@@ -21,7 +21,7 @@ maintenance:
   working_dir: "/workspace/gasclaw"
   branch_prefixes: ["fix/", "feat/", "test/", "docs/", "refactor/"]
 claude:
-  kimi_base_url: "https://api.kimi.com/coding/"
+  kimi_base_url: "https://api.minimax.villamarket.ai/v1"
   bypass_permissions_via_config: true
 openclaw:
   gateway_port: 18789
@@ -37,7 +37,7 @@ fi
 echo "Loading config..."
 MAINTENANCE_INTERVAL=$(python3 /opt/scripts/config-loader.py --get maintenance.loop_interval 2>/dev/null || echo "300")
 MAINTENANCE_REPO=$(python3 /opt/scripts/config-loader.py --get maintenance.repo 2>/dev/null || echo "gastown-publish/gasclaw")
-KIMI_BASE_URL=$(python3 /opt/scripts/config-loader.py --get claude.kimi_base_url 2>/dev/null || echo "https://api.kimi.com/coding/")
+KIMI_BASE_URL=$(python3 /opt/scripts/config-loader.py --get claude.kimi_base_url 2>/dev/null || echo "https://api.minimax.villamarket.ai/v1")
 GATEWAY_PORT=$(python3 /opt/scripts/config-loader.py --get openclaw.gateway_port 2>/dev/null || echo "18789")
 echo "  maintenance_interval=${MAINTENANCE_INTERVAL}s repo=${MAINTENANCE_REPO}"
 

--- a/maintainer/scripts/config-loader.py
+++ b/maintainer/scripts/config-loader.py
@@ -23,7 +23,7 @@ DEFAULTS = {
         "branch_prefixes": ["fix/", "feat/", "test/", "docs/", "refactor/"],
     },
     "claude": {
-        "kimi_base_url": "https://api.kimi.com/coding/",
+        "kimi_base_url": "https://api.minimax.villamarket.ai/v1",
         "dangerously_skip_permissions": True,
     },
     "openclaw": {

--- a/maintainer/skills/gasclaw-config/SKILL.md
+++ b/maintainer/skills/gasclaw-config/SKILL.md
@@ -46,6 +46,6 @@ Located at `/workspace/config/gasclaw.yaml` — also editable from the host.
 | maintenance.max_pr_size | 200 | Max lines per PR |
 | maintenance.auto_merge | true | Auto-merge passing PRs |
 | maintenance.repo | gastown-publish/gasclaw | GitHub repo |
-| claude.kimi_base_url | https://api.kimi.com/coding/ | Kimi API endpoint |
+| claude.kimi_base_url | https://api.minimax.villamarket.ai/v1 | Kimi API endpoint |
 | openclaw.gateway_port | 18789 | OpenClaw gateway port |
 | logging.level | INFO | Log verbosity |


### PR DESCRIPTION
## Summary
The maintainer loop's Claude Code subprocess was failing with 401 authentication errors because it was calling `https://api.kimi.com/coding/` with an invalid/expired API key. This explains why the maintainer ran 2015 cycles with 0 PRs merged — it could never successfully call the AI API.

**Root cause:** `ANTHROPIC_BASE_URL` was set to `https://api.kimi.com/coding/` (expired Kimi endpoint) instead of the MiniMax LiteLLM proxy that works.

**Fix:** Changed `kimi_base_url` from `https://api.kimi.com/coding/` to `https://api.minimax.villamarket.ai/v1` in all maintainer config files. The `KIMI_API_KEY` works with the MiniMax LiteLLM proxy (verified with API test).

## Files changed
- `maintainer/entrypoint.sh` — default config + fallback echo URL
- `maintainer/scripts/config-loader.py` — default `kimi_base_url` value
- `maintainer/data/config/gasclaw.yaml` — default gasclaw config
- `maintainer/agent-instructions.md` — documentation
- `maintainer/skills/gasclaw-config/SKILL.md` — skill documentation

## Verification
- API test: `KIMI_API_KEY` returns 200 OK against `https://api.minimax.villamarket.ai/v1/models` ✅
- All 1020 unit tests pass ✅

## Test plan
1. Verify maintainer loop can now authenticate to AI API (no more 401 errors in `claude-code.log`)
2. Verify maintainer starts creating/merging PRs for open issues
3. Confirm issue #334 (and other open issues) get addressed