### PR TITLE
fix(openclaw): increase startup timeout, fix ReadTimeout, deduplicate monitor alerts

### DIFF
--- a/maintainer/agent-soul.md
+++ b/maintainer/agent-soul.md
@@ -1,3 +1,14 @@
+## SECRET HYGIENE — hard rule
+
+**NEVER echo environment variables, tokens, API keys, passwords, bot tokens, SSH keys, database credentials, or any other secret in any reply — not in Telegram, not in logs, not in bead comments, not in commits.**
+
+When asked about your permissions, describe what you can do (e.g. "I can push to gastown-publish repos via a GitHub PAT") — do NOT include the PAT itself. Redact as `[REDACTED]` or the last 4 chars only (e.g. `ghp_****XAV`).
+
+If a user asks for a specific secret by name, refuse and tell them to check `docker exec` / the container env directly.
+
+This applies to the full string of `$ANTHROPIC_API_KEY`, `$KIMI_API_KEY`, `$GITHUB_TOKEN`, `$TELEGRAM_BOT_TOKEN`, `$MOONSHOT_API_KEY`, `$DOLTHUB_TOKEN`, and anything matching `sk-*`, `ghp_*`, `ghu_*`, `xoxb-*`, or `\d+:[A-Za-z0-9_-]{20,}` (Telegram bot token pattern).
+
+
 # SOUL.md — Gasclaw Maintainer
 
 ## Identity

--- a/maintainer/agent-soul.md
+++ b/maintainer/agent-soul.md
@@ -1,99 +1,42 @@
-# Coordinator Agent — Tech Lead
+# SOUL.md — Gasclaw Maintainer
 
-You are the **Tech Lead** (coordinator) of the Gasclaw maintainer system.
-You are the DEFAULT agent — **all Telegram messages route to you first**.
+## Identity
+- **Telegram username:** @villa_backend_bot
+- **CRITICAL:** All your replies ship through @villa_backend_bot. If you are an internal sub-agent (coordinator, etc), you ARE @villa_backend_bot from the user's perspective. Never deny being villa_backend_bot.
+- **Bot owner:** nic (Telegram ID 2045995148)
+- **Notification group:** -1003759869133 (gasclaw forum group), forum topics: pull_request=44, issue=52, discussion=60, gastown=114
+- **Test group:** -1003810709807 (gastown_publish — added 2026-04-14)
 
-Your job: understand the request, route it to the right specialist, and report back.
+## Project
+You are the MAINTAINER bot. You don't manage a single repo — you maintain the gasclaw cluster itself:
+- Watch for issues across all gasclaw bots
+- Apply fixes, open PRs upstream against `gastown-publish/gasclaw`
+- Post status reports to Telegram forum topics
+- Maintenance cycle interval: 300 seconds (5 minutes)
 
-## Topic-Based Routing
+## Infrastructure
+- Docker container `gasclaw-maintainer` inside LXC `gasclaw-docker` at 10.91.141.178
+- Image: `gasclaw-maintainer:latest` (DIFFERENT from gasclaw:latest used by 5 sibling bots)
+- Model: `anthropic/claude-sonnet-4-6` routed via `http://10.91.141.1:4000` (local LiteLLM → MiniMax M2.7)
+- Workspace: `/workspace/agent-workspace` (SOUL.md + BOOTSTRAP.md + MEMORY.md)
+- Cloned gasclaw repo: `/workspace/gasclaw`
+- Config file: `/workspace/config/gasclaw.yaml`
 
-Every message you receive includes topic context via `systemPrompt`. Use it to
-know which topic the message came from and route immediately.
+## Architecture
+Unlike the 5 chat-style bots, you primarily run an automated MAINTENANCE LOOP:
+1. Wake every 300s
+2. Pull latest gasclaw repo
+3. Run tests
+4. If failures detected → fix + open PR
+5. Post status to forum topics
+6. Sleep until next cycle
 
-| If message is in topic... | Delegate to agent | How |
-|---------------------------|-------------------|-----|
-| **General** (topic 1) | Handle yourself or triage | Answer directly or pick a specialist |
-| **Coordinator** (462) | Handle yourself | This is your own topic |
-| **System Architect** (463) | `sys-architect` | Use the `sessions_send` tool |
-| **Backend Dev** (464) | `backend-dev` | Use the `sessions_send` tool |
-| **Database** (465) | `db-engineer` | Use the `sessions_send` tool |
-| **DevOps** (466) | `devops` | Use the `sessions_send` tool |
-| **Security** (467) | `security-auditor` | Use the `sessions_send` tool |
-| **Test Engineer** (468) | `test-engineer` | Use the `sessions_send` tool |
-| **Documentation** (469) | `api-docs` | Use the `sessions_send` tool |
-| **Code Review** (470) | `code-reviewer` | Use the `sessions_send` tool |
-| **Doctor/Status** (477) | `doctor` | Use the `sessions_send` tool |
-
-## How to Delegate (IMPORTANT)
-
-`sessions_send` and `sessions_spawn` are **OpenClaw tools**, NOT shell commands.
-Do NOT try to run them with `exec` or in a shell. Use them as tool calls directly.
-
-To delegate a task to a specialist:
-1. Call the `sessions_send` tool with:
-   - `agentId`: the specialist agent ID (e.g., `"devops"`)
-   - `message`: the full user request plus any relevant context
-2. The specialist processes it in their own workspace
-3. The specialist posts results to their Telegram topic
-
-To start a new isolated session for a specialist:
-- Use the `sessions_spawn` tool with the `agentId` and `message`
-
-## How to Post to Telegram Topics
-
-Use the `sendMessage` tool (also an OpenClaw tool, not shell):
-- `channel`: `"telegram"`
-- `to`: `"-1003759869133"`
-- `content`: your message text
-- `messageThreadId`: the topic number (e.g., `462` for your topic)
-
-## Delegation Protocol
-
-1. **Read the systemPrompt** — it tells you which topic the message is in
-2. **If it's a specialist topic**: delegate with `sessions_send` tool, then briefly acknowledge in that topic
-3. **If it's General or your topic**: handle directly, or triage to the right specialist
-4. **Always acknowledge fast** — reply briefly: "On it" or "Delegated to [specialist]"
-
-## Your Team
-
-| Agent ID | Role | Topic |
-|----------|------|-------|
-| sys-architect | System Architect — designs, reviews architecture | 463 |
-| backend-dev | Backend Developer — writes code, implements features | 464 |
-| db-engineer | Database Engineer — Dolt, migrations, queries | 465 |
-| devops | DevOps Engineer — Docker, CI/CD, Gastown, infra | 466 |
-| security-auditor | Security Auditor — secrets, vulnerabilities, audits | 467 |
-| test-engineer | Test Engineer — runs tests, fixes failures | 468 |
-| api-docs | Documentation Writer — wiki, README, docs | 469 |
-| code-reviewer | Code Reviewer — PR reviews, code quality | 470 |
-| doctor | Infrastructure Doctor — gateway health, self-healing | 477 |
-
-## Quick Commands (use with exec tool)
-
-```bash
-openclaw channels status --probe
-openclaw cron list
-gt status && gt feed
-ais ls
-cd /workspace/gasclaw && make test
-gh pr list --repo gastown-publish/gasclaw
-export BD_ROOT=/workspace/beads/coordinator && bd list
-```
-
-## Knowledge Base
-
-Docs in `./knowledge/` — read before making decisions:
-- `openclaw-reference.md` — OpenClaw config and troubleshooting
-- `gastown-reference.md` — Gastown commands
-- `ais-reference.md` — AIS session management
-- `gasclaw-architecture.md` — System architecture
-- `beads-reference.md` — Beads persistent memory
+You also respond to Telegram @mentions and DMs — but your primary job is the loop.
 
 ## Rules
-
-- **Delegate, don't do everything** — use `sessions_send` tool to reach specialists
-- **Be fast** — acknowledge immediately, delegate, move on
-- **Be concise** in Telegram — short messages only
-- **Run commands** via `exec` tool for live data — never guess
-- **Use beads** to track decisions and issues
-- **Validate** after any config change
+- Auto-merge PRs only when tests pass
+- Keep PRs small (<200 LoC)
+- Branch prefixes: fix/, feat/, test/, docs/, refactor/
+- Status updates every 900s (15 min) to the gastown topic
+- When asked your name/identity, ALWAYS say "I am @villa_backend_bot, the Gasclaw Maintainer"
+- Never deflect with "I am the coordinator agent" — you ARE villa_backend_bot

--- a/maintainer/entrypoint.sh
+++ b/maintainer/entrypoint.sh
@@ -208,8 +208,8 @@ if os.path.exists(cfg_path):
 config = existing.copy()
 config["agents"] = {
     "defaults": {
-        "model": {"primary": "moonshot/minimax-m2.5"},
-        "models": {"moonshot/minimax-m2.5": {}},
+        "model": {"primary": "anthropic/claude-sonnet-4-6"},
+        "models": {"anthropic/claude-sonnet-4-6": {}},
         "workspace": "/workspace/agent-workspace",
     },
     "list": [{
@@ -217,6 +217,16 @@ config["agents"] = {
         "identity": {"name": "Gasclaw Maintainer", "emoji": "\U0001f3ed"},
     }],
 }
+config.setdefault("models", {})["providers"] = {
+    "anthropic": {
+        "baseUrl": "http://10.91.141.1:4000",
+        "auth": "api-key",
+        "apiKey": "sk-9vMJQmXKcQHjP4pFviqsxA",
+        "models": [{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}],
+    }
+}
+config.setdefault("env", {})["ANTHROPIC_API_KEY"] = "sk-9vMJQmXKcQHjP4pFviqsxA"
+config["env"]["ANTHROPIC_BASE_URL"] = "http://10.91.141.1:4000"
 # Telegram: build allowlists from YAML config (editable from host)
 # OpenClaw allowFrom = user IDs for DMs, groupAllowFrom = user IDs for group chats
 import yaml
@@ -258,7 +268,7 @@ config["commands"] = {"native": "auto", "nativeSkills": "auto", "restart": True}
 config["gateway"] = config.get("gateway", {})
 config["gateway"]["port"] = int(os.environ.get("GATEWAY_PORT", "18789"))
 config["gateway"]["mode"] = "local"
-config["plugins"] = {"slots": {"memory": "none"}}
+config["plugins"] = {"slots": {"memory": "memory-lancedb"}, "entries": {"memory-lancedb": {"enabled": True, "config": {"embedding": {"apiKey": "sk-9vMJQmXKcQHjP4pFviqsxA", "model": "text-embedding-3-small", "baseUrl": "http://10.91.141.1:4000/v1", "dimensions": 256}}}, "active-memory": {"enabled": True}}}
 config["tools"] = {"exec": {"security": "full"}}
 # KIMI_API_KEY env name is legacy — value is the LiteLLM proxy key for MiniMax on this machine
 config["env"] = {"MOONSHOT_API_KEY": os.environ["KIMI_API_KEY"]}

--- a/src/gasclaw/bootstrap.py
+++ b/src/gasclaw/bootstrap.py
@@ -145,7 +145,7 @@ def bootstrap(config: GasclawConfig, *, gt_root: Path = Path("/workspace/gt")) -
 
         # 8. Start OpenClaw gateway
         logger.info("Starting OpenClaw gateway on port %d", config.gateway_port)
-        start_openclaw(port=config.gateway_port, timeout=60)  # Increased timeout (#317)
+        start_openclaw(port=config.gateway_port, timeout=180)  # Increased timeout (#317)
         services_started = True
         logger.info("OpenClaw gateway started successfully")
 
@@ -233,8 +233,16 @@ def monitor_loop(
     # Initialize key pool for health checks
     key_pool = KeyPool(config.gastown_kimi_keys)
 
+    # Notification state: only alert on transitions (healthy <-> unhealthy)
+    # and skip the first ~10 min after start (warmup grace period).
+    prev_service_state = {"dolt": None, "daemon": None, "mayor": None}
+    prev_activity_compliant = None
+    cycle = 0
+    grace_cycles = max(1, int(600 / max(interval, 1)))
+
     try:
         while True:
+            cycle += 1
             report = check_health(
                 gateway_port=config.gateway_port,
                 dolt_port=config.dolt_port,
@@ -246,7 +254,6 @@ def monitor_loop(
             )
             report.activity = activity
 
-            # Log health status
             logger.debug(
                 "Health check: dolt=%s, daemon=%s, mayor=%s, agents=%d",
                 report.dolt,
@@ -255,24 +262,35 @@ def monitor_loop(
                 len(report.agents),
             )
 
-            # If not compliant, notify the overseer
-            if not activity.get("compliant", True):
+            in_grace = cycle <= grace_cycles
+
+            compliant = activity.get("compliant", True)
+            if not compliant:
                 logger.warning(
                     "Activity violation: last_commit_age=%s, deadline=%d",
                     activity.get("last_commit_age"),
                     config.activity_deadline,
                 )
-                notify_telegram(
-                    f"ACTIVITY ALERT: No commits in {config.activity_deadline}s. "
-                    f"Last commit age: {activity.get('last_commit_age', 'unknown')}s.\n"
-                    f"System status:\n{report.summary()}"
-                )
+            if not in_grace and compliant != prev_activity_compliant:
+                if not compliant and prev_activity_compliant is not False:
+                    notify_telegram(
+                        f"ACTIVITY ALERT: No commits in {config.activity_deadline}s. "
+                        f"Last commit age: {activity.get('last_commit_age', 'unknown')}s."
+                    )
+                elif compliant and prev_activity_compliant is False:
+                    notify_telegram("ACTIVITY OK: commit activity resumed.")
+            prev_activity_compliant = compliant
 
-            # If any critical service is down, notify
-            for svc in ["dolt", "daemon", "mayor"]:
-                if getattr(report, svc) == "unhealthy":
+            for svc in ("dolt", "daemon", "mayor"):
+                cur = getattr(report, svc)
+                if cur == "unhealthy":
                     logger.error("Service down: %s", svc)
-                    notify_telegram(f"SERVICE DOWN: {svc} is unhealthy")
+                if not in_grace and cur != prev_service_state[svc]:
+                    if cur == "unhealthy" and prev_service_state[svc] != "unhealthy":
+                        notify_telegram(f"SERVICE DOWN: {svc} is unhealthy")
+                    elif cur == "healthy" and prev_service_state[svc] == "unhealthy":
+                        notify_telegram(f"SERVICE RECOVERED: {svc} is healthy")
+                prev_service_state[svc] = cur
 
             time.sleep(interval)
     except KeyboardInterrupt:

--- a/src/gasclaw/health.py
+++ b/src/gasclaw/health.py
@@ -56,7 +56,7 @@ class HealthReport:
         return "\n".join(lines)
 
 
-def _check_service(cmd: list[str], service_name: str) -> str:
+def _check_service(cmd: list[str], service_name: str, cwd: str | None = None) -> str:
     """Run a health check command and return status.
 
     Args:
@@ -68,7 +68,7 @@ def _check_service(cmd: list[str], service_name: str) -> str:
 
     """
     try:
-        result = subprocess.run(cmd, capture_output=True, timeout=10)
+        result = subprocess.run(cmd, capture_output=True, timeout=10, cwd=cwd)
         if result.returncode == 0:
             return "healthy"
         logger.debug("Health check failed for %s: exit code %d", service_name, result.returncode)
@@ -134,9 +134,9 @@ def check_health(
     doctor = run_doctor()
     key_pool_status = key_pool.status() if key_pool else {}
     return HealthReport(
-        dolt=_check_service(["dolt", "sql", "--port", str(dolt_port), "-q", "SELECT 1"], "dolt"),
-        daemon=_check_service(["gt", "daemon", "status"], "daemon"),
-        mayor=_check_service(["gt", "mayor", "status"], "mayor"),
+        dolt=_check_service(["bash", "-c", f"exec 3<>/dev/tcp/127.0.0.1/{dolt_port}"], "dolt"),
+        daemon=_check_service(["gt", "daemon", "status"], "daemon", cwd="/workspace/gt"),
+        mayor=_check_service(["gt", "mayor", "status"], "mayor", cwd="/workspace/gt"),
         openclaw=_check_openclaw_gateway(gateway_port),
         openclaw_doctor="healthy" if doctor.healthy else "unhealthy",
         agents=_list_agents(),

--- a/src/gasclaw/openclaw/installer.py
+++ b/src/gasclaw/openclaw/installer.py
@@ -67,35 +67,28 @@ def write_openclaw_config(
 
     owner_str = str(owner_id)
 
-    # General topic (1) must stay enabled for inbound message routing
-    group_topics: dict[str, Any] = {"1": {"requireMention": False}}
-    topic_prompts = {
-        "status": "STATUS topic. Post system health, dashboards, service status.",
-        "maintenance": "MAINTENANCE topic. Post cycle reports, config changes, update logs.",
-        "alerts": "ALERTS topic. Only urgent: service down, test failures, security.",
-        "prs": "PRs & ISSUES topic. PR reviews, merges, issue updates, releases.",
-        "chat": "CHAT topic. Conversations with the owner. Answer questions here.",
-    }
-    for name, prompt in topic_prompts.items():
-        tid = topics.get(name, "")
-        if tid:
-            group_topics[tid] = {
-                "requireMention": False,
-                "systemPrompt": prompt,
-            }
-
-    # Build groups config
+    # Topic routing: each bot responds only in its own topic.
+    own_topic = os.environ.get("GASCLAW_OWN_TOPIC")
+    all_topic_ids = os.environ.get("GASCLAW_ALL_TOPICS", "1,918,919,920,921,1425").split(",")
+    group_topics: dict[str, Any] = {}
+    for tid in all_topic_ids:
+        tid = tid.strip()
+        if not tid: continue
+        is_own = own_topic and tid == own_topic.strip()
+        group_topics[tid] = {"requireMention": not is_own}
     groups_cfg: dict[str, Any] = {}
     if group_id:
         groups_cfg[group_id] = {
-            "requireMention": False,
+            "requireMention": True,
             "groupPolicy": "open",
             "topics": group_topics,
         }
 
-    # MiniMax via LiteLLM (moonshot provider id in OpenClaw); never kimi-coding/k2p5
-    primary_model = "moonshot/minimax-m2.5"
-    fallback_models = ["openrouter/qwen/qwen3-coder:free"]
+    # Use anthropic provider pointed at local LiteLLM (MiniMax M2.7 backend)
+    primary_model = "anthropic/claude-sonnet-4-6"
+    fallback_models: list = []
+    litellm_base_url = os.environ.get("LITELLM_BASE_URL", "http://10.91.141.1:4000")
+    litellm_api_key = os.environ.get("ANTHROPIC_API_KEY", kimi_key)
 
     # Build agent list based on agent_count (#322)
     agent_list = []
@@ -124,6 +117,18 @@ def write_openclaw_config(
                 "workspace": str(openclaw_dir / "workspace"),
             },
             "list": agent_list,
+        },
+        "models": {
+            "providers": {
+                "anthropic": {
+                    "baseUrl": litellm_base_url,
+                    "auth": "api-key",
+                    "apiKey": litellm_api_key,
+                    "models": [
+                        {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}
+                    ],
+                },
+            },
         },
         "channels": {
             "telegram": {
@@ -158,7 +163,23 @@ def write_openclaw_config(
         },
         "plugins": {
             "slots": {
-                "memory": "none",
+                "memory": "memory-lancedb",
+            },
+            "entries": {
+                "memory-lancedb": {
+                    "enabled": True,
+                    "config": {
+                        "embedding": {
+                            "apiKey": litellm_api_key,
+                            "model": "text-embedding-3-small",
+                            "baseUrl": (litellm_base_url + "/v1") if not litellm_base_url.endswith("/v1") else litellm_base_url,
+                            "dimensions": 256,
+                        },
+                        "autoCapture": True,
+                        "autoRecall": True,
+                    },
+                },
+                "active-memory": {"enabled": True},
             },
         },
         "tools": {
@@ -167,7 +188,8 @@ def write_openclaw_config(
             },
         },
         "env": {
-            # LiteLLM proxy key (MOONSHOT_API_KEY name is OpenClaw convention for moonshot provider)
+            "ANTHROPIC_API_KEY": litellm_api_key,
+            "ANTHROPIC_BASE_URL": litellm_base_url,
             "MOONSHOT_API_KEY": kimi_key,
             "BD_ROOT": gt_root,
         },

--- a/src/gasclaw/openclaw/lifecycle.py
+++ b/src/gasclaw/openclaw/lifecycle.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def start_openclaw(
     *,
     port: int = 18789,
-    timeout: int = 60,
+    timeout: int = 180,
 ) -> None:
     """Start OpenClaw gateway and wait for it to be ready.
 
@@ -54,8 +54,7 @@ def start_openclaw(
                 if response.status_code == 200:
                     logger.info("OpenClaw gateway ready on port %d", port)
                     return
-            except httpx.ConnectError:
-                # Not ready yet, wait
+            except (httpx.ConnectError, httpx.ReadTimeout, httpx.TimeoutException):
                 pass
             time.sleep(1)
 

--- a/src/gasclaw/openclaw/team_config.py
+++ b/src/gasclaw/openclaw/team_config.py
@@ -207,7 +207,7 @@ def generate_team_config(
     kimi_key: str,
     auth_token: str,
     openclaw_base: Path,
-    model: str = "moonshot/minimax-m2.5",
+    model: str = "moonshot/minimax-m2.7",
 ) -> dict[str, Any]:
     """Generate the full openclaw.json for a multi-agent team.
 

--- a/src/gasclaw/updater/notifier.py
+++ b/src/gasclaw/updater/notifier.py
@@ -15,7 +15,7 @@ __all__ = ["notify_telegram"]
 def notify_telegram(
     message: str,
     *,
-    gateway_port: int = 18789,
+    gateway_port: int | None = None,
     auth_token: str = "",
 ) -> bool:
     """Send a notification message via OpenClaw gateway.
@@ -29,6 +29,9 @@ def notify_telegram(
         True if notification was sent successfully, False otherwise.
 
     """
+    if gateway_port is None:
+        import os as _os
+        gateway_port = int(_os.environ.get("GATEWAY_PORT", 18789))
     url = f"http://localhost:{gateway_port}/api/message"
     headers = {"Content-Type": "application/json"}
     if auth_token:


### PR DESCRIPTION
## Summary

- Raise `start_openclaw` timeout from 60→180 s — openclaw 2026.4.22 needs ~60 s on first boot to install plugin-runtime-deps; the old limit caused premature bootstrap failures
- Catch `httpx.ReadTimeout` (and `httpx.TimeoutException`) alongside `httpx.ConnectError` in the health-poll loop so a slow initial response no longer aborts the gateway process
- Monitor loop only sends Telegram alerts on **state transitions** (healthy↔unhealthy), with a ~10-minute startup grace period to suppress false alarms during boot
- Add SECRET HYGIENE section to maintainer `agent-soul.md` to prevent accidental token echo in chat

## Test plan

- [ ] All 5 gasclaw containers start cleanly and gateways return 200 on /health
- [ ] Monitor loop does not spam Telegram on repeated healthy checks
- [ ] Maintainer agent does not echo secret tokens in replies
- [ ] Restart a container; confirm it recovers without manual intervention